### PR TITLE
Fix chunked encoding with SSL via proxy

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -447,6 +447,10 @@ class HTTPAdapter(BaseAdapter):
 
                 low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
 
+                if hasattr(conn, 'proxy'):
+                    if conn.proxy is not None and not getattr(low_conn, 'sock', None):
+                        conn._prepare_proxy(low_conn)
+
                 try:
                     low_conn.putrequest(request.method,
                                         url,


### PR DESCRIPTION
This is a patch applying @bpitman's proposed fix for #3844.

Assuming a proxy is running on port 8875 (`docker run --rm --name='tinyproxy' -p 8875:8888 dannydirect/tinyproxy:latest ANY` works for me), the issue can be reproduced with

```
requests.put('https://www.google.com', data=iter('Hello World'), proxies={'https': 'http://localhost:8875'})
```