### PR TITLE
Reuse session SSLContexts for same TLS settings

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -15,6 +15,7 @@ from urllib3.poolmanager import PoolManager, proxy_from_url
 from urllib3.response import HTTPResponse
 from urllib3.util import Timeout as TimeoutSauce
 from urllib3.util.retry import Retry
+from urllib3.util.ssl_ import create_urllib3_context
 from urllib3.exceptions import ClosedPoolError
 from urllib3.exceptions import ConnectTimeoutError
 from urllib3.exceptions import HTTPError as _HTTPError
@@ -177,6 +178,7 @@ class HTTPAdapter(BaseAdapter):
             self.max_retries = Retry.from_int(max_retries)
         self.config = {}
         self.proxy_manager = {}
+        self.ssl_contexts = {}
 
         super(HTTPAdapter, self).__init__()
 
@@ -194,6 +196,7 @@ class HTTPAdapter(BaseAdapter):
         # self.poolmanager uses a lambda function, which isn't pickleable.
         self.proxy_manager = {}
         self.config = {}
+        self.ssl_contexts = {}
 
         for attr, value in state.items():
             setattr(self, attr, value)
@@ -295,6 +298,15 @@ class HTTPAdapter(BaseAdapter):
 
         return response
 
+    def get_ssl_context(self, pool_kwargs):
+        """Returns correct SSLContext for settings in pool_kwargs"""
+        paths = (pool_kwargs.get(p, None) for p in ('ca_cert_dir', 'ca_certs', 'cert_file', 'key_file'))
+        # use real paths to avoid creating extra SSLContexts for same files
+        key = tuple(None if p is None else os.path.realpath(p) for p in paths)
+        if key not in self.ssl_contexts:
+            self.ssl_contexts[key] = create_urllib3_context()
+        return self.ssl_contexts[key]
+
     def get_connection(self, url, proxies=None, verify=None, cert=None):
         """Returns a urllib3 connection for the given URL. This should not be
         called from user code, and is only exposed for use when subclassing the
@@ -305,6 +317,9 @@ class HTTPAdapter(BaseAdapter):
         :rtype: urllib3.ConnectionPool
         """
         pool_kwargs = _pool_kwargs(verify, cert)
+        if url.lower().startswith('https'):
+            pool_kwargs['ssl_context'] = self.get_ssl_context(pool_kwargs)
+
         proxy = select_proxy(url, proxies)
 
         if proxy:

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -110,6 +110,11 @@ def _pool_kwargs(verify, cert):
                           "invalid path: {0}".format(key_file))
     return pool_kwargs
 
+def _consistent_path(path):
+    """Get cosistent path for cert files"""
+    if not path:
+        return None
+    return os.path.normcase(os.path.realpath(path))
 
 class BaseAdapter(object):
     """The Base Transport Adapter"""
@@ -300,9 +305,8 @@ class HTTPAdapter(BaseAdapter):
 
     def get_ssl_context(self, pool_kwargs):
         """Returns correct SSLContext for settings in pool_kwargs"""
-        paths = (pool_kwargs.get(p, None) for p in ('ca_cert_dir', 'ca_certs', 'cert_file', 'key_file'))
-        # use real paths to avoid creating extra SSLContexts for same files
-        key = tuple(None if p is None else os.path.realpath(p) for p in paths)
+        fields = ('ca_cert_dir', 'ca_certs', 'cert_file', 'key_file')
+        key = tuple(_consistent_path(pool_kwargs.get(f, None)) for f in fields)
         if key not in self.ssl_contexts:
             self.ssl_contexts[key] = create_urllib3_context()
         return self.ssl_contexts[key]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2982,3 +2982,53 @@ class TestGetConnection(object):
         with pytest.raises(IOError) as excinfo:
             adapter.get_connection('https://example.com', verify=verify, cert=cert)
         excinfo.match('invalid path: a/path/that/does/not/exist')
+
+def test_no_ssl_context_http():
+    """Assert adapter does not create SSLContext for HTTP request"""
+    adapter = requests.adapters.HTTPAdapter()
+    conn = adapter.get_connection('http://example.com')
+    assert 'ssl_context' not in conn.conn_kw
+
+def get_connection_context(adapter, verify=None, cert=None):
+    """Easily get SSLContext for new connection pool"""
+    return adapter.get_connection('https://example.com', verify=verify, cert=cert).conn_kw['ssl_context']
+
+def test_ssl_context_reused():
+    """Assert adapter reuses SSLContext for same verify and cert"""
+    adapter = requests.adapters.HTTPAdapter()
+    ctx1 = get_connection_context(adapter, True)
+    ctx2 = get_connection_context(adapter, True)
+    assert ctx1 is ctx2
+
+def test_ssl_context_unique_by_settings():
+    """Assert adapter creates new SSLContext for different verify or cert"""
+    adapter = requests.adapters.HTTPAdapter()
+    ctx1 = get_connection_context(adapter, True)
+
+    ca_file = pytest_httpbin.certs.where()
+    ctx2 = get_connection_context(adapter, ca_file)
+    assert ctx1 is not ctx2
+    
+    cert = os.path.join(os.path.dirname(ca_file), 'cert.pem')
+    key = os.path.join(os.path.dirname(ca_file), 'key.pem')
+    ctx3 = get_connection_context(adapter, True, (cert, key))
+    assert ctx1 is not ctx2
+
+def test_ssl_context_unique_by_absolute_paths():
+    """Assert adapter reuses SSLContext when verify and cert parameters result in
+    connection using same cert files"""
+    adapter = requests.adapters.HTTPAdapter()
+    ctx1 = get_connection_context(adapter, True)
+    ctx2 = get_connection_context(adapter, DEFAULT_CA_BUNDLE_PATH)
+    # different verify values leading to same ca_cert_dir value
+    assert ctx1 is ctx2
+    
+    ca_dir = os.path.dirname(pytest_httpbin.certs.where())
+    cert = os.path.join(ca_dir, 'cert.pem')
+    key = os.path.join(ca_dir, 'key.pem')
+    rel_cert = os.path.relpath(cert)
+    rel_key = os.path.relpath(key)
+    ctx3 = get_connection_context(adapter, True, (cert, key))
+    ctx4 = get_connection_context(adapter, True, (rel_cert, rel_key))
+    # relative path and absolute path to same files
+    assert ctx3 is ctx4


### PR DESCRIPTION
Creates SSLContext objects in HTTPAdapter and uses a single SSLContext for connections with the same TLS settings (ca_cert_dir, ca_certs, cert_file, and key_file).

This is another try for https://github.com/requests/requests/issues/4322 