### PR TITLE
use dumb reason decoding on Python 2

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -914,14 +914,17 @@ class Response(object):
 
         http_error_msg = ''
         if isinstance(self.reason, bytes):
-            # We attempt to decode utf-8 first because some servers
-            # choose to localize their reason strings. If the string
-            # isn't utf-8, we fall back to iso-8859-1 for all other
-            # encodings. (See PR #3538)
-            try:
-                reason = self.reason.decode('utf-8')
-            except UnicodeDecodeError:
-                reason = self.reason.decode('iso-8859-1')
+            if is_py2:
+                reason = self.reason.decode('utf-8', 'ignore')
+            else:
+                # We attempt to decode utf-8 first because some servers
+                # choose to localize their reason strings. If the string
+                # isn't utf-8, we fall back to iso-8859-1 for all other
+                # encodings. (See PR #3538)
+                try:
+                    reason = self.reason.decode('utf-8')
+                except UnicodeDecodeError:
+                    reason = self.reason.decode('iso-8859-1')
         else:
             reason = self.reason
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -17,7 +17,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 from requests.compat import (
     Morsel, cookielib, getproxies, str, urlparse,
-    builtin_str, OrderedDict)
+    builtin_str, OrderedDict, is_py2)
 from requests.cookies import (
     cookiejar_from_dict, morsel_to_cookie)
 from requests.exceptions import (
@@ -1212,7 +1212,10 @@ class TestRequests:
         r.encoding = None
         with pytest.raises(requests.exceptions.HTTPError) as e:
             r.raise_for_status()
-        assert reason in e.value.args[0]
+        if is_py2:
+            assert 'Komponenttia ei lydy' in str(e)
+        else:
+            assert reason in str(e)
 
     def test_response_chunk_size_type(self):
         """Ensure that chunk_size is passed as None or an integer, otherwise


### PR DESCRIPTION
Try to fix #4489 : Python 2.x IOError cannot handle unicode argument, and HTTPError is a IOError.