### PR TITLE
Update to return correct value for multiple_domains().

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -73,5 +73,8 @@
 
 - ``Response.raise_for_status()`` now returns the response object for good responses
 
+- ``RequestCookieJar.multiple_domains()`` will return the correct boolean value
+  when exectued. See `#4557`_.
+
 .. _#2002: https://github.com/kennethreitz/requests/issues/2002
 .. _#2631: https://github.com/kennethreitz/requests/issues/2631

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -183,3 +183,4 @@ Patches and Suggestions
 - Matt Liu <liumatt@gmail.com> (`@mlcrazy <https://github.com/mlcrazy>`_)
 - Taylor Hoff <primdevs@protonmail.com> (`@PrimordialHelios <https://github.com/PrimordialHelios>`_)
 - Hugo van Kemenade (`@hugovk <https://github.com/hugovk>`_)
+- Xander Harris (`@gahancorpcfo <https://github.com/gahancorpcfo>`_)

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -290,11 +290,13 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
 
         :rtype: bool
         """
-        domains = []
+        domains = set()
         for cookie in iter(self):
-            if cookie.domain is not None and cookie.domain in domains:
+            if cookie.domain:
+                domains.add(cookie.domain)
+
+            if len(domains) > 1:
                 return True
-            domains.append(cookie.domain)
         return False  # there is only one domain in jar
 
     def get_dict(self, domain=None, path=None):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -452,6 +452,24 @@ class TestRequests:
         # Make sure the cookie was sent
         assert r.json()['cookies']['foo'] == 'bar'
 
+    def test_cookies_multiple_domains_returns_correct_value(self, httpbin):
+        """Tests that multiple_domains() returns the correct value. 
+
+        See GH #4557
+        """
+        s = requests.session()
+        r = s.get(httpbin('cookies'))
+
+        r.cookies.set('foo', 'bar', domain='.google.com')
+        assert r.cookies.multiple_domains() == False
+
+        r.cookies.set('baz', 'foo')
+        assert r.cookies.multiple_domains() == False
+
+        r.cookies.set('baz', 'foo', domain='.google.com')
+        r.cookies.set('zin', 'foo', domain='.github.com')
+        assert r.cookies.multiple_domains() == True
+
     def test_cookielib_cookiejar_on_redirect(self, httpbin):
         """Tests resolve_redirect doesn't fail when merging cookies
         with non-RequestsCookieJar cookiejar.


### PR DESCRIPTION
requests/cookies.py

Adjust flow to add domains to list as the first operation in the loop, then convert to a set and check the length of that set is greater than 1.

Add tests to pass for a single domain, two cookies with the same domain, and multiple domains.

Perhaps not the most efficient method, but it works. 