### PR TITLE
Fix: safe proxies reading

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -671,9 +671,10 @@ class Session(SessionRedirectMixin):
         :rtype: dict
         """
         # Gather clues from the surrounding environment.
+        proxies = proxies or {}
         if self.trust_env:
             # Set environment's proxies.
-            no_proxy = proxies.get('no_proxy') if proxies is not None else None
+            no_proxy = proxies.get('no_proxy')
             env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
             for (k, v) in env_proxies.items():
                 proxies.setdefault(k, v)


### PR DESCRIPTION
Set up `proxies` safely for the `.setdefault()` call a few lines below by coercing it into a dict if passed in as `None`, and adjust the one line that was potentially expecting a `None`.