### PR TITLE
Strip whitespace for proxy urls, test for same. #4613

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -300,7 +300,7 @@ class HTTPAdapter(BaseAdapter):
         proxy = select_proxy(url, proxies)
 
         if proxy:
-            proxy = prepend_scheme_if_needed(proxy, 'http')
+            proxy = prepend_scheme_if_needed(proxy, 'http').strip()
             proxy_url = parse_url(proxy)
             if not proxy_url.host:
                 raise InvalidProxyURL("Please check proxy URL. It is malformed"

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -549,10 +549,16 @@ class TestRequests:
         with pytest.raises(InvalidProxyURL):
             requests.get(httpbin(), proxies={'http': 'http:///example.com:8080'})
 
-    def test_proxy_strip_spaces(self):
+    @pytest.mark.parametrize('proxies', (
+        {'http': 'localhost:1234'},
+        {'http': ' http://localhost:1234'},
+        None,
+        {'http': 'http://localhost:1234 '}
+    ))
+    def test_proxy_strip_spaces(self, proxies):
         # Don't yet have testing proxies sorted out.
         with pytest.raises(ProxyError):
-            requests.get('http://localhost:1', proxies={'http': 'http://localhost:1234 '})
+            requests.get('http://localhost:1', proxies)
 
     def test_basicauth_with_netrc(self, httpbin):
         auth = ('user', 'pass')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -547,6 +547,11 @@ class TestRequests:
         with pytest.raises(InvalidProxyURL):
             requests.get(httpbin(), proxies={'http': 'http:///example.com:8080'})
 
+    def test_proxy_strip_spaces(self):
+        # Don't yet have testing proxies sorted out.
+        with pytest.raises(ProxyError):
+            requests.get('http://localhost:1', proxies={'http': 'http://localhost:1234 '})
+
     def test_basicauth_with_netrc(self, httpbin):
         auth = ('user', 'pass')
         wrong_auth = ('wronguser', 'wrongpass')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -550,15 +550,16 @@ class TestRequests:
             requests.get(httpbin(), proxies={'http': 'http:///example.com:8080'})
 
     @pytest.mark.parametrize('proxies', (
-        {'http': 'localhost:1234'},
-        {'http': ' http://localhost:1234'},
-        None,
-        {'http': 'http://localhost:1234 '}
+        {'http': 'localhost:3128'},
+        {'http': ' http://localhost:3128'},
+        {'http': None},
+        {'http': 'http://localhost:3128'},
+        {'http': 'http://localhost:3128 '}
     ))
     def test_proxy_strip_spaces(self, proxies):
         # Don't yet have testing proxies sorted out.
         with pytest.raises(ProxyError):
-            requests.get('http://localhost:1', proxies)
+            requests.get('http://www.google.com', proxies=proxies)
 
     def test_basicauth_with_netrc(self, httpbin):
         auth = ('user', 'pass')


### PR DESCRIPTION
I'm not sure this is the right place to do this operation, but it does solve the problem. Or at least it passes the test that I wrote for it.

Quite likely I'm not reading them correctly, but as far as I can tell the other test methods related to proxies don't test something like a `requests.get()` call with the expectation of a successful result.

I found a ton of tests for error cases, though, and modeled the test for this situation on those, but it seems like there would be a better way.