### PR TITLE
fix cookie management bug

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -420,7 +420,7 @@ class Session(SessionRedirectMixin):
 
         # Merge with session cookies
         merged_cookies = merge_cookies(
-            merge_cookies(RequestsCookieJar(), self.cookies), cookies)
+            merge_cookies(self.cookies.__class__(), self.cookies), cookies)
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth


### PR DESCRIPTION
Even I used custom cookie jar class to manage cookie values, redirecting link only used default `RequestCookieJar` class and it seemed there was not work around.