### PR TITLE
Fix no_proxy being too greedy.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-pytest = ">=2.8.0"
+pytest = ">=3.1.0"
 codecov = "*"
 pytest-httpbin = ">=0.0.7"
 pytest-mock = "*"

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -727,12 +727,16 @@ def should_bypass_proxies(url, no_proxy):
                     # matches the IP of the index
                     return True
         else:
-            host_with_port = parsed.hostname
+            host_without_port = '.' + parsed.hostname
+            host_with_port = host_without_port
             if parsed.port:
                 host_with_port += ':{0}'.format(parsed.port)
 
             for host in no_proxy:
-                if parsed.hostname.endswith(host) or host_with_port.endswith(host):
+                if not host.startswith('.'):
+                    host = '.' + host
+
+                if host_without_port.endswith(host) or host_with_port.endswith(host):
                     # The URL does match something in no_proxy, so we don't want
                     # to apply the proxies on this URL.
                     return True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import filecmp
 from io import BytesIO
 import zipfile
 from collections import deque
+import sys
 
 import pytest
 from requests import compat
@@ -182,6 +183,7 @@ class TestGetEnvironProxies:
             'http://192.168.1.1:5000/',
             'http://192.168.1.1/',
             'http://www.requests.com/',
+            'http://requests.com/',
         ))
     def test_bypass_no_proxy_keyword(self, url):
         no_proxy = '192.168.1.1,requests.com'
@@ -194,6 +196,13 @@ class TestGetEnvironProxies:
             'http://172.16.1.1/',
             'http://172.16.1.1:5000/',
             'http://localhost.localdomain:5000/v1.0/',
+            pytest.param(
+                'http://somerequests.com',
+                marks=pytest.mark.skipif(
+                    (sys.version_info[0], sys.version_info[1]) == (3, 4),
+                    reason='Python 3.4 implementation of no_proxy is greedy',
+                ),
+            ),
         ))
     def test_not_bypass_no_proxy_keyword(self, url, monkeypatch):
         # This is testing that the 'no_proxy' argument overrides the
@@ -619,6 +628,7 @@ def test_urldefragauth(url, expected):
             ('http://172.16.1.1:5000/', True),
             ('http://localhost.localdomain:5000/v1.0/', True),
             ('http://google.com:6000/', True),
+            ('http://zgoogle.com:6000/', False),
             ('http://172.16.1.12/', False),
             ('http://172.16.1.12:5000/', False),
             ('http://google.com:5000/v1.0/', False),


### PR DESCRIPTION
**Summary:** Setting `no_proxy` on `requests.com` used to enable it on `somerequests.com` also, which was unexpected and potentially dangerous. (see #4795)

Note that this delegates to urllib more often, as stated [here](https://github.com/requests/requests/issues/4795#issuecomment-425886286). I don't have the history behind `should_bypass_proxies` implementation, therefore my change is the tiniest possible (minimum thing to fix the greedy behavior). I don't know exactly why requests tries some things first and then delegates to urllib though.

Fixes #4795 