### PR TITLE
Document the security extra for SNI support with legacy Python

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -269,6 +269,28 @@ If you specify a wrong path or an invalid cert, you'll get a SSLError::
 .. warning:: The private key to your local certificate *must* be unencrypted.
    Currently, Requests does not support using encrypted keys.
 
+.. _sni-support:
+
+SNI support with legacy Python
+------------------------------
+
+.. versionadded:: 2.4.1
+
+It's possible to enable `Server Name Indication (SNI)`_ via `urllib3's SNI support`_
+for legacy Python versions (older than 2.7.9) by installing a few optional dependencies
+using the ``security`` extra::
+
+    $ pipenv install requests[security]
+
+This will install PyOpenSSL and its dependencies and setup ``urllib3`` automatically
+when Requests is imported.
+
+However, it should not be required if you're using Python 3 and you could save a bit
+of time when importing Requests by not including it.
+
+.. _`Server Name Indication (SNI)`: https://en.wikipedia.org/wiki/Server_Name_Indication
+.. _`urllib3's SNI support`: https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2
+
 .. _ca-certificates:
 
 CA Certificates

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -271,25 +271,24 @@ If you specify a wrong path or an invalid cert, you'll get a SSLError::
 
 .. _sni-support:
 
-SNI support with legacy Python
-------------------------------
+SSL support with old Python versions
+------------------------------------
 
-.. versionadded:: 2.4.1
-
-It's possible to enable `Server Name Indication (SNI)`_ via `urllib3's SNI support`_
-for legacy Python versions (older than 2.7.9) by installing a few optional dependencies
+It's possible to enable OpenSSL support & `Server Name Indication (SNI)`_ for old Python
+versions (older than 2.7.9 & 3.4.3) by installing a few optional dependencies
 using the ``security`` extra::
 
     $ pipenv install requests[security]
 
-This will install PyOpenSSL and its dependencies and setup ``urllib3`` automatically
-when Requests is imported.
+This will install PyOpenSSL, its dependencies and setup `urllib3 certificate validation`_
+automatically when Requests is imported.
 
-However, it should not be required if you're using Python 3 and you could save a bit
-of time when importing Requests by not including it.
+However, it is not required if you're using a recent version of Python with `PEP 476`_.
+This is included from Python 2.7.9 and 3.4.3.
 
 .. _`Server Name Indication (SNI)`: https://en.wikipedia.org/wiki/Server_Name_Indication
-.. _`urllib3's SNI support`: https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2
+.. _`urllib3 certificate validation`: https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification-in-python-2
+.. _`PEP 476`: https://www.python.org/dev/peps/pep-0476/
 
 .. _ca-certificates:
 


### PR DESCRIPTION
This was added back in #2195.

This started as I was trying to understand why we had PyOpenSSL installed on the project I joined recently. After a bit of digging, it seems that it came from the time when we were using Python 2 and was for Requests/urllib3.

However, looking at Requests' documentation, I couldn't find a clear explanation about this feature, so this is my attempt at fixing this.

Disclaimer: I'm by no means an expert at SNI, so please correct me on anything wrong that follows.

Here are what I could find:

- The intend was to [document this feature](https://github.com/requests/requests/pull/2195#issuecomment-54524390) after merging it, so I assume this contribution is welcome.
- Looking at [the documentation from urllib3](https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2), it seems that the extra dependencies aren't needed in Python 3* and by the look of #4315 it can slow down importing Requests when we have PyOpenSSL.
- Another open pull request (#4591) is trying to change this, but @sigmavirus24 comment implies that there is more to SNI in Requests?

I'm not sure if this is the best place to document this, adding it to the "install" section feels overwhelming for beginners, and I felt like it belongs close to the SSL & certificates verification of the advanced section. Happy to move it somewhere else.

*Edit:*

(*) Actually, it seems it was implemented in [PEP 476](https://www.python.org/dev/peps/pep-0476/) which covers Python >=2.7.9 or >=[3.4.3](https://docs.python.org/3.4/whatsnew/changelog.html#python-3-4-3-final), so not any Python 3 versions.