### PR TITLE
Remove unnecessary compat shim for bytes

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -47,7 +47,6 @@ if is_py2:
 
 
     builtin_str = str
-    bytes = str
     str = unicode
     basestring = basestring
     numeric_types = (int, long, float)
@@ -64,7 +63,6 @@ elif is_py3:
 
     builtin_str = str
     str = str
-    bytes = bytes
     basestring = (str, bytes)
     numeric_types = (int, float)
     integer_types = (int,)

--- a/requests/models.py
+++ b/requests/models.py
@@ -37,7 +37,7 @@ from .utils import (
     iter_slices, guess_json_utf, super_len, check_header_validity)
 from .compat import (
     Callable, Mapping,
-    cookielib, urlunparse, urlsplit, urlencode, str, bytes,
+    cookielib, urlunparse, urlsplit, urlencode, str,
     is_py2, chardet, builtin_str, basestring)
 from .compat import json as complexjson
 from .status_codes import codes

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -26,7 +26,7 @@ from . import certs
 from ._internal_utils import to_native_string
 from .compat import parse_http_list as _parse_list_header
 from .compat import (
-    quote, urlparse, bytes, str, OrderedDict, unquote, getproxies,
+    quote, urlparse, str, OrderedDict, unquote, getproxies,
     proxy_bypass, urlunparse, basestring, integer_types, is_py3,
     proxy_bypass_environment, getproxies_environment, Mapping)
 from .cookies import cookiejar_from_dict

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,7 +249,7 @@ class TestGuessFilename:
 
     @pytest.mark.parametrize(
         'value, expected_type', (
-            (b'value', compat.bytes),
+            (b'value', bytes),
             (b'value'.decode('utf-8'), compat.str)
         ))
     def test_guess_filename_valid(self, value, expected_type):


### PR DESCRIPTION
Both Python 2.7 & Python 3 have the type `bytes`. On Python 2.7, it is an alias of `str`, same as what was defined in `compat.py`.