### PR TITLE
Docstring explaining when HTTPError is/is not raised

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -538,6 +538,8 @@ to hang indefinitely::
     not time out.
 
 
+.. _errors-and-exceptions:
+
 Errors and Exceptions
 ---------------------
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -26,7 +26,14 @@ class RequestException(IOError):
 
 
 class HTTPError(RequestException):
-    """An HTTP error occurred."""
+    """An HTTP error (status code >= 400) occurred.
+
+    Keep in mind that, by default, you don't need to handle this exception when
+    performing a request, since it is raised only when you ask requests to do
+    so, via the
+    :meth:`Response.raise_for_status() <requests.Response.raise_for_status>`
+    method. See also :ref:`errors-and-exceptions`.
+    """
 
 
 class ConnectionError(RequestException):


### PR DESCRIPTION
This is mostly to tell the reader about when HTTP error must be handled, and to better link to the other places in the doc. where this is explained.