### PR TITLE
Delegate chunked encoding handling to urllib

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -435,64 +435,19 @@ class HTTPAdapter(BaseAdapter):
             timeout = TimeoutSauce(connect=timeout, read=timeout)
 
         try:
-            if not chunked:
-                resp = conn.urlopen(
-                    method=request.method,
-                    url=url,
-                    body=request.body,
-                    headers=request.headers,
-                    redirect=False,
-                    assert_same_host=False,
-                    preload_content=False,
-                    decode_content=False,
-                    retries=self.max_retries,
-                    timeout=timeout
-                )
-
-            # Send the request.
-            else:
-                if hasattr(conn, 'proxy_pool'):
-                    conn = conn.proxy_pool
-
-                low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
-
-                try:
-                    low_conn.putrequest(request.method,
-                                        url,
-                                        skip_accept_encoding=True)
-
-                    for header, value in request.headers.items():
-                        low_conn.putheader(header, value)
-
-                    low_conn.endheaders()
-
-                    for i in request.body:
-                        low_conn.send(hex(len(i))[2:].encode('utf-8'))
-                        low_conn.send(b'\r\n')
-                        low_conn.send(i)
-                        low_conn.send(b'\r\n')
-                    low_conn.send(b'0\r\n\r\n')
-
-                    # Receive the response from the server
-                    try:
-                        # For Python 2.7, use buffering of HTTP responses
-                        r = low_conn.getresponse(buffering=True)
-                    except TypeError:
-                        # For compatibility with Python 3.3+
-                        r = low_conn.getresponse()
-
-                    resp = HTTPResponse.from_httplib(
-                        r,
-                        pool=conn,
-                        connection=low_conn,
-                        preload_content=False,
-                        decode_content=False
-                    )
-                except:
-                    # If we hit any problems here, clean up the connection.
-                    # Then, reraise so that we can handle the actual exception.
-                    low_conn.close()
-                    raise
+            resp = conn.urlopen(
+                method=request.method,
+                url=url,
+                body=request.body,
+                headers=request.headers,
+                redirect=False,
+                assert_same_host=False,
+                preload_content=False,
+                decode_content=False,
+                retries=self.max_retries,
+                timeout=timeout,
+                chunked=chunked
+            )
 
         except (ProtocolError, socket.error) as err:
             raise ConnectionError(err, request=request)


### PR DESCRIPTION
This MR removes the custom handling of sending chunked HTTP requests from requests to delegate to the equivalent logic in urllib3 (https://github.com/urllib3/urllib3/blob/4325867d1ae0d139a11c8689c2d2a5ba2c666c83/src/urllib3/connectionpool.py#L351).

As far as I can tell this has a couple of advantages:
* Remove code that is duplicated between the two libraries
* Allow fixes for outstanding issues in this area to be made in urllib3 so that users of both libraries benefit (I noticed #4445 when having a quick trawl of the issues but I guess there are more)
* All requests are now logged by the urllib3 debug logger (which was the issue I was originally trying to diagnose)