### PR TITLE
Add link to user-agent documentation

### DIFF
--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -21,7 +21,8 @@ Custom User-Agents?
 -------------------
 
 Requests allows you to easily override User-Agent strings, along with
-any other HTTP Header.
+any other HTTP Header. See `documentation about headers <http://docs.python-requests.org/en/master/user/quickstart/#custom-headers>`_.
+
 
 
 Why not Httplib2?


### PR DESCRIPTION
So the user has a pointer to the documentation about the searched topic.