### PR TITLE
Add project URLs with links to source code and docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,4 +106,8 @@ setup(
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
     },
+    project_urls={
+        'Documentation': 'http://docs.python-requests.org',
+        'Source': 'https://github.com/kennethreitz/requests',
+    },
 )


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests. For example, see Django's [setup.py](https://github.com/django/django/blob/master/setup.py) and [PyPI listing](https://pypi.org/project/Django/).