### PR TITLE
improve error message for invalid timeouts

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -419,20 +419,21 @@ class HTTPAdapter(BaseAdapter):
 
         chunked = not (request.body is None or 'Content-Length' in request.headers)
 
-        if isinstance(timeout, tuple):
+        if isinstance(timeout, TimeoutSauce):
+            pass
+        else:
             try:
-                connect, read = timeout
-                timeout = TimeoutSauce(connect=connect, read=read)
+                if isinstance(timeout, tuple):
+                    connect, read = timeout
+                    timeout = TimeoutSauce(connect=connect, read=read)
+                else:
+                    timeout = TimeoutSauce(connect=timeout, read=timeout)
             except ValueError as e:
                 # this may raise a string formatting error.
                 err = ("Invalid timeout {}. Pass a (connect, read) "
                        "timeout tuple, or a single float to set "
                        "both timeouts to the same value".format(timeout))
                 raise ValueError(err)
-        elif isinstance(timeout, TimeoutSauce):
-            pass
-        else:
-            timeout = TimeoutSauce(connect=timeout, read=timeout)
 
         try:
             if not chunked:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2150,7 +2150,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         'timeout, error_text', (
             ((3, 4, 5), '(connect, read)'),
-            ('foo', 'must be an int, float or None'),
+            ('foo', 'Pass a (connect, read) timeout tuple, or a single float to set both timeouts to the same value'),
         ))
     def test_invalid_timeout(self, httpbin, timeout, error_text):
         with pytest.raises(ValueError) as e:


### PR DESCRIPTION
Rearrange a try/except so that these two programs give similar error
messages.

Program 1:

```
import requests
requests.get("https://random.org, timeout=(True, True))
```

Program 2:

```
import requests
requests.get("https://random.org, timeout=True)
```

Before this commit, _Program 2_ raised an error in `urllib3` asking for
an "int, float or None" timeout.