### PR TITLE
Remove unneeded setdefault calls

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -542,7 +542,6 @@ class Session(SessionRedirectMixin):
         :rtype: requests.Response
         """
 
-        kwargs.setdefault('allow_redirects', True)
         return self.request('GET', url, **kwargs)
 
     def options(self, url, **kwargs):
@@ -553,7 +552,6 @@ class Session(SessionRedirectMixin):
         :rtype: requests.Response
         """
 
-        kwargs.setdefault('allow_redirects', True)
         return self.request('OPTIONS', url, **kwargs)
 
     def head(self, url, **kwargs):


### PR DESCRIPTION
Remove unneeded `kwargs.setdefault('allow_redirects', True)` calls from 
`Session.get` and `Session.options`. The `allow_redirects` argument of 
`Session.request`already has a default value of `True`.