### PR TITLE
Possible fix for #4945?

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -608,7 +608,7 @@ class Response(object):
 
         #: File-like object representation of response (for advanced usage).
         #: Use of ``raw`` requires that ``stream=True`` be set on the request.
-        # This requirement does not apply for use internally to Requests.
+        #: This requirement does not apply for use internally to Requests.
         self.raw = None
 
         #: Final URL location of Response.


### PR DESCRIPTION
Could the missing colon on line 612 in models.py be the reason for the missing reference in the docs as described in issue #4945?