### PR TITLE
#4965 Fix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -189,3 +189,4 @@ Patches and Suggestions
 - Darren Dormer (`@ddormer <https://github.com/ddormer>`_)
 - Rajiv Mayani (`@mayani <https://github.com/mayani>`_)
 - Antti Kaihola (`@akaihola <https://github.com/akaihola>`_)
+- Belavin Denis (`@luckydenis <https://github.com/luckydenis>`_)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -3,6 +3,7 @@
 import pytest
 import threading
 import requests
+from requests.exceptions import ChunkedEncodingError
 
 from tests.testserver.server import Server, consume_socket_content
 
@@ -307,3 +308,43 @@ def test_fragment_update_on_redirect():
         assert r.url == 'http://{}:{}/final-url/#relevant-section'.format(host, port)
 
         close_server.set()
+
+
+def test_response_content_retains_error():
+    """Verify that accessing response.content retains an error.
+
+    See https://github.com/kennethreitz/requests/issues/4965
+    """
+
+    data = "Some random stuff to read from remove server.\n"
+
+    def response_handler(sock):
+        req = consume_socket_content(sock, timeout=0.5)
+
+        # Send invalid chunked data (length mismatch)
+        sock.send(
+            b'HTTP/1.1 200 OK\r\n'
+            b'Transfer-Encoding: chunked\r\n'
+            b'\r\n2\r\n42\r\n8\r\n123\r\n'  # 5 bytes missing
+        )
+
+    close_server = threading.Event()
+    server = Server(response_handler, wait_to_close_event=close_server)
+
+    with server as (host, port):
+        url = 'http://{}:{}/path'.format(host, port)
+        r = requests.post(url, stream=True)
+        with pytest.raises(ChunkedEncodingError):
+            r.content
+
+    # Access the bad response data again, I would expect the same
+    # error again.
+
+    try:
+        content = r.content
+    except ChunkedEncodingError:
+        pass  # fine, same exception
+    else:
+        assert False, "error response has content: {0!r}".format(content)
+    close_server.set()
+


### PR DESCRIPTION
#4965 Issue: Accessing response.content twice removes forgets read error.

Added variable to save errors, and added a check that returns a re-error when accessed.