### PR TITLE
http://pipenv.org > https://github.com/pypa/pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ PyPy.
 Installation
 ------------
 
-To install Requests, simply use [pipenv](http://pipenv.org/) (or pip, of
+To install Requests, simply use [pipenv](https://github.com/pypa/pipenv) (or pip, of
 course):
 
 ``` {.sourceCode .bash}


### PR DESCRIPTION
It looks like a few of the resources on https://docs.pipenv.org/en/latest/ are broken, like the gif under "A short animation of pipenv at work" and the installation instructions are a bit behind what's on the GitHub repo. Maybe we should link to the repo directly? 

First time contributing, feel free to reject this!