### PR TITLE
[models] Fix '_encode_params'/'_encode_files'

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -119,6 +119,9 @@ class RequestEncodingMixin:
         elif hasattr(data, "__iter__"):
             result = []
             for k, vs in to_key_val_list(data):
+                if isinstance(vs, Mapping):
+                    raise ValueError("Field type should not be '%s'" % type(vs).__name__)
+
                 if isinstance(vs, basestring) or not hasattr(vs, "__iter__"):
                     vs = [vs]
                 for v in vs:
@@ -153,6 +156,9 @@ class RequestEncodingMixin:
         files = to_key_val_list(files or {})
 
         for field, val in fields:
+            if isinstance(val, Mapping):
+                raise ValueError("Field type should not be '%s'" % type(val).__name__)
+
             if isinstance(val, basestring) or not hasattr(val, "__iter__"):
                 val = [val]
             for v in val:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1747,7 +1747,19 @@ class TestRequests:
         with pytest.raises(InvalidHeader):
             requests.get(httpbin("get"), headers=invalid_header)
 
-    @pytest.mark.parametrize("files", ("foo", b"foo", bytearray(b"foo")))
+    def test_cannot_send_dict_objects_in_data(self, httpbin):
+        payload = {"foo_dict": {"foo": 2}}
+
+        # Test without file
+        with pytest.raises(ValueError):
+            r = requests.get(httpbin("post"), data=payload)
+
+        # Test with files
+        with pytest.raises(ValueError):
+            f = io.BytesIO()
+            r = requests.get(httpbin("post"), data=payload, files={"f": f})
+
+    @pytest.mark.parametrize('files', ('foo', b'foo', bytearray(b'foo')))
     def test_can_send_objects_with_files(self, httpbin, files):
         data = {"a": "this is a string"}
         files = {"b": files}


### PR DESCRIPTION
Look at https://github.com/kennethreitz/requests/blob/master/requests/models.py#L100 or
https://github.com/kennethreitz/requests/blob/master/requests/models.py#L131
```
for v in vs:
    if v is not None:
        ...
```
When the type of `vs` is `dict`, `v` will be the field key, but not field value, the body of the request will be puzzling.
It would be better to prevent it.

Signed-off-by: weiyang <weiyang.ones@gmail.com>