### PR TITLE
Remove an obsolete attribute from Session.__attrs__

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -355,7 +355,7 @@ class Session(SessionRedirectMixin):
 
     __attrs__ = [
         'headers', 'cookies', 'auth', 'proxies', 'hooks', 'params', 'verify',
-        'cert', 'prefetch', 'adapters', 'stream', 'trust_env',
+        'cert', 'adapters', 'stream', 'trust_env',
         'max_redirects',
     ]
 


### PR DESCRIPTION
The extra attribute in `Session.__attrs__` makes an unpickled session have one more attribute than the original.  Removing it makes the original and the unpickled be identical.