### PR TITLE
Add non-3XX redirects

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -113,6 +113,11 @@ class SessionRedirectMixin(object):
             if is_py3:
                 location = location.encode('latin1')
             return to_native_string(location, 'utf8')
+        # if resp.is_meta_redirect:
+        #    location = parse_meta_tag(resp.text)
+        #    if is_py3:
+        #        location = location.encode('latin1')
+        #    return to_native_string(location, 'utf8')
         return None
 
     def should_strip_auth(self, old_url, new_url):


### PR DESCRIPTION
Looking for early feedback.

`requests` should have a native solution to dealing with non-3XX redirects i.e. https://stackoverflow.com/questions/56366175/how-to-handle-redirects-that-do-not-use-3xx-status-codes. But should such a new feature be tied to a preexisting flag `allow_redirects`, or should there be a new flag such as `allow_meta_redirects`? I understand the use case between not allowing redirects and allowing redirects, but I am not sure if there is a use case where you want to handle 2XX redirects but do not want to handle 3XX redirects or vice versa.