### PR TITLE
Fix typo in api.requests() docstring formatting

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -16,7 +16,7 @@ from . import sessions
 def request(method, url, **kwargs):
     """Constructs and sends a :class:`Request <Request>`.
 
-    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS`, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
         in the query string for the :class:`Request`.


### PR DESCRIPTION
Fix a formatting typo which caused the documentation for `api.request()`'s `method` arg to be corrupted when rendered:

![2019-07-28-090608_764x154_scrot](https://user-images.githubusercontent.com/4450708/62008995-f2a7f080-b116-11e9-9531-50f2b2c0e87a.png)
