### PR TITLE
[IMPROVEMENT] Update monthly download count

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ HTTP connection pooling are 100% automatic, thanks to
 [urllib3](https://github.com/shazow/urllib3).
 
 Besides, all the cool kids are doing it. Requests is one of the most
-downloaded Python packages of all time, pulling in over 11,000,000
+downloaded Python packages of all time, pulling in over 50,000,000
 downloads every month. You don't want to be left out!
 
 Feature Support


### PR DESCRIPTION
Requests pulls over 50+ million downloads per month while the old figure is at 11.

https://pepy.tech/project/requests