### PR TITLE
Re-add newline to docstring for proper rendering

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -4,6 +4,7 @@ r"""
 The ``codes`` object defines a mapping from common names for HTTP statuses
 to their numerical codes, accessible either as attributes or as dictionary
 items.
+
 >>> import requests
 >>> requests.codes['temporary_redirect']
 307


### PR DESCRIPTION
#4987 had [removed the existence of a blank line before a doctest block](https://github.com/psf/requests/pull/4987/files#diff-35c843f55d3e3abf0fca8d08b73bc26cL7), which results in [the documentation for `requests.codes`](https://2.python-requests.org/en/master/api/#status-code-lookup) being improperly rendered:
![Screen Shot 2019-08-30 at 1 04 03 PM](https://user-images.githubusercontent.com/7754936/64048738-70e91f80-cb27-11e9-9d66-251ad9cce653.png)

This PR re-introduces the blank line, which appears to be? suggested by [reST spec](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks) and worked for NumPy as well [at some point](https://github.com/numpy/numpy/pull/14085).