### PR TITLE
Fix encode data which has a dict value

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -97,6 +97,8 @@ class RequestEncodingMixin(object):
             for k, vs in to_key_val_list(data):
                 if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
                     vs = [vs]
+                elif isinstance(vs, Mapping):
+                    vs = [str(vs)]
                 for v in vs:
                     if v is not None:
                         result.append(


### PR DESCRIPTION
If data contains a dict in dict value like {'a': 'b', 'c': {'d': 'e'}}, it will be encoded as a=b&c=d which is obviously wrong.