### PR TITLE
Fix formatting of status code example

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -4,13 +4,16 @@ r"""
 The ``codes`` object defines a mapping from common names for HTTP statuses
 to their numerical codes, accessible either as attributes or as dictionary
 items.
->>> import requests
->>> requests.codes['temporary_redirect']
-307
->>> requests.codes.teapot
-418
->>> requests.codes['\o/']
-200
+
+Example::
+
+    >>> import requests
+    >>> requests.codes['temporary_redirect']
+    307
+    >>> requests.codes.teapot
+    418
+    >>> requests.codes['\o/']
+    200
 
 Some codes have multiple names, and both upper- and lower-case versions of
 the names are allowed. For example, ``codes.ok``, ``codes.OK``, and


### PR DESCRIPTION
Currently the [website][1] looks like this:
![image](https://user-images.githubusercontent.com/15225902/65042108-5ebe0c80-d982-11e9-9555-a97c89866b6b.png)

[1]: https://2.python-requests.org/en/master/api/#status-code-lookup