### PR TITLE
Change requests.ConnectionError to inherit standard ConnectionError

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -72,3 +72,5 @@ elif is_py3:
     basestring = (str, bytes)
     numeric_types = (int, float)
     integer_types = (int,)
+
+    ConnectionError = ConnectionError

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -54,6 +54,8 @@ if is_py2:
     numeric_types = (int, long, float)
     integer_types = (int, long)
 
+    class ConnectionError(OSError): pass
+
 elif is_py3:
     from urllib.parse import urlparse, urlunparse, urljoin, urlsplit, urlencode, quote, unquote, quote_plus, unquote_plus, urldefrag
     from urllib.request import parse_http_list, getproxies, proxy_bypass, proxy_bypass_environment, getproxies_environment

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -29,7 +29,7 @@ class HTTPError(RequestException):
     """An HTTP error occurred."""
 
 
-class ConnectionError(RequestException):
+class ConnectionError(RequestException, ConnectionError):
     """A Connection error occurred."""
 
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -7,6 +7,7 @@ requests.exceptions
 This module contains the set of Requests' exceptions.
 """
 from urllib3.exceptions import HTTPError as BaseHTTPError
+from .compat import ConnectionError as BaseConnectionError
 
 
 class RequestException(IOError):
@@ -29,7 +30,7 @@ class HTTPError(RequestException):
     """An HTTP error occurred."""
 
 
-class ConnectionError(RequestException, ConnectionError):
+class ConnectionError(RequestException, BaseConnectionError):
     """A Connection error occurred."""
 
 


### PR DESCRIPTION
This PR changes the requests version of `ConnectionError` to also inherit from the built-in `ConnectionError`, see #5162 