### PR TITLE
Fix duplicated idna requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=test_requirements,
     extras_require={
-        'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
+        'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
     },


### PR DESCRIPTION
Hello everyone,

The `idna` is in the `install_requires` already, so it makes sense to remove it from extra requirements.

Also, `poetry` has been confused by this duplicated requirement.
https://github.com/sdispater/poetry/issues/1449

Best regards!