### PR TITLE
Fix broken URLS in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <span align="center">
 
 <pre>
-    <a href="https://2.python-requests.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/requests-logo.png" align="center" /></a>
+    <a href="https://requests.readthedocs.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/requests-logo.png" align="center" /></a>
     
     <div align="left">
     <p></p>
@@ -106,7 +106,7 @@ Requests officially supports Python 2.7 & 3.4–3.8.
 ## P.S. — Documentation is Available at [`//requests.readthedocs.io`](https://requests.readthedocs.io/en/master/).
 
 <p align="center">
-        <a href="https://2.python-requests.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/ss.png" align="center" /></a>
+        <a href="https://requests.readthedocs.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/ss.png" align="center" /></a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <span align="center">
 
 <pre>
-    <a href="https://requests.readthedocs.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/requests-logo.png" align="center" /></a>
+    <a href="https://requests.readthedocs.io/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/requests-logo.png" align="center" /></a>
     
     <div align="left">
     <p></p>
@@ -106,7 +106,7 @@ Requests officially supports Python 2.7 & 3.4–3.8.
 ## P.S. — Documentation is Available at [`//requests.readthedocs.io`](https://requests.readthedocs.io/en/master/).
 
 <p align="center">
-        <a href="https://requests.readthedocs.org/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/ss.png" align="center" /></a>
+        <a href="https://requests.readthedocs.io/"><img src="https://raw.githubusercontent.com/psf/requests/master/ext/ss.png" align="center" /></a>
 </p>
 
 


### PR DESCRIPTION
[This commit](https://github.com/psf/requests/commit/74b72ce4265583db0430080ab67d3d5e0c4b44b2) removed several references to the URL 2.python-requests.org but left several behind. This PR cleans those up and replaces with requests.readthedocs.io