### PR TITLE
Update translation links from http -> https

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -66,13 +66,13 @@
 
 <ul>
   <li><a href="http://docs.python-requests.org/">English</a></li>
-  <li><a href="http://fr.python-requests.org/">French</a></li>
-  <li><a href="http://de.python-requests.org/">German</a></li>
-  <li><a href="http://jp.python-requests.org/">Japanese</a></li>
-  <li><a href="http://cn.python-requests.org/">Chinese</a></li>
-  <li><a href="http://pt.python-requests.org/">Portuguese</a></li>
-  <li><a href="http://it.python-requests.org/">Italian</a></li>
-  <li><a href="http://es.python-requests.org/">Spanish</a></li>
+  <li><a href="https://fr.python-requests.org/">French</a></li>
+  <li><a href="https://de.python-requests.org/">German</a></li>
+  <li><a href="https://jp.python-requests.org/">Japanese</a></li>
+  <li><a href="https://cn.python-requests.org/">Chinese</a></li>
+  <li><a href="https://pt.python-requests.org/">Portuguese</a></li>
+  <li><a href="https://it.python-requests.org/">Italian</a></li>
+  <li><a href="https://es.python-requests.org/">Spanish</a></li>
 </ul>
 
 <div id="native-ribbon">

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -55,11 +55,11 @@
 
   <ul>
     <li><a href="http://docs.python-requests.org/">English</a></li>
-    <li><a href="http://fr.python-requests.org/">French</a></li>
-    <li><a href="http://de.python-requests.org/">German</a></li>
-    <li><a href="http://jp.python-requests.org/">Japanese</a></li>
-    <li><a href="http://cn.python-requests.org/">Chinese</a></li>
-    <li><a href="http://pt.python-requests.org/">Portuguese</a></li>
-    <li><a href="http://it.python-requests.org/">Italian</a></li>
-    <li><a href="http://es.python-requests.org/">Spanish</a></li>
+    <li><a href="https://fr.python-requests.org/">French</a></li>
+    <li><a href="https://de.python-requests.org/">German</a></li>
+    <li><a href="https://jp.python-requests.org/">Japanese</a></li>
+    <li><a href="https://cn.python-requests.org/">Chinese</a></li>
+    <li><a href="https://pt.python-requests.org/">Portuguese</a></li>
+    <li><a href="https://it.python-requests.org/">Italian</a></li>
+    <li><a href="https://es.python-requests.org/">Spanish</a></li>
   </ul>


### PR DESCRIPTION
This modifies links to translations of the `requests` documentation for non-English languages to https instead of http