### PR TITLE
Update documentation for response.json()

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -892,7 +892,7 @@ class Response(object):
         return content
 
     def json(self, **kwargs):
-        r"""Returns the json-encoded content of a response, if any.
+        r"""Decodes and returns the JSON response body, if any.
 
         :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
         :raises ValueError: If the response body does not contain valid json.


### PR DESCRIPTION
The current documentation says that the function is encoding - actually, it is decoding!

I'm also wondering if it might be worth putting in some type annotations at some point