### PR TITLE
Fix link to requests-threads in community/recommended doc

### DIFF
--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -40,7 +40,7 @@ requested by users within the community.
 Requests-Threads
 ----------------
 
-`Requests-Threads` is a Requests session that returns the amazing Twisted's awaitable Deferreds instead of Response objects. This allows the use of ``async``/``await`` keyword usage on Python 3, or Twisted's style of programming, if desired.
+`Requests-Threads`_ is a Requests session that returns the amazing Twisted's awaitable Deferreds instead of Response objects. This allows the use of ``async``/``await`` keyword usage on Python 3, or Twisted's style of programming, if desired.
 
 .. _Requests-Threads: https://github.com/requests/requests-threads
 


### PR DESCRIPTION
The link for `Requests-Threads` was missing a trailing `_` causing it to be italicized instead of being a proper link.