### PR TITLE
RFC8288 support for link relations

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -821,6 +821,8 @@ def parse_header_links(value):
 
     i.e. Link: <http:/.../front.jpeg>; rel=front; type="image/jpeg",<http://.../back.jpeg>; rel=back;type="image/jpeg"
 
+    See also RFC8288: https://tools.ietf.org/html/rfc8288
+
     :rtype: list
     """
 
@@ -839,6 +841,7 @@ def parse_header_links(value):
             url, params = val, ''
 
         link = {'url': url.strip('<> \'"')}
+        rels = []
 
         for param in params.split(';'):
             try:
@@ -846,9 +849,22 @@ def parse_header_links(value):
             except ValueError:
                 break
 
-            link[key.strip(replace_chars)] = value.strip(replace_chars)
+            key = key.strip(replace_chars)
+            value = value.strip(replace_chars)
+            if key == 'rel':
+                if rels:
+                    # only use first occurrence of "rel", drop others
+                    continue
+                for v in value.split():
+                    rels.append(v)
+            else:
+                link[key] = value
 
-        links.append(link)
+        if rels:
+            for rel in rels:
+                links.append(dict(link, rel=rel))
+        else:
+            links.append(link)
 
     return links
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -573,6 +573,17 @@ def test_iter_slices(value, length):
             ]
         ),
         (
+            '</foo?page=2>; rel=next; rel=prev',
+            [{'url': '/foo?page=2', 'rel': 'next'}]
+        ),
+        (
+            '<http:/.../front.jpeg>; rel="front http://example.net/foo"',
+            [
+                {'url': 'http:/.../front.jpeg', 'rel': 'front'},
+                {'url': 'http:/.../front.jpeg', 'rel': 'http://example.net/foo'}
+            ]
+        ),
+        (
             '',
             []
         ),


### PR DESCRIPTION
Comply to RFC8288 for relation type (section 3.3)
https://tools.ietf.org/html/rfc8288#section-3.3

Changes:
- Only parse first "rel" parameter
- Allow multiple link relation types, i.e.
  rel="start http://example.net/relation/other"