### PR TITLE
Safely handle, when uri contains IPv6 link local with %zone index 

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -573,7 +573,15 @@ def unquote_unreserved(uri):
 
     :rtype: str
     """
-    parts = uri.split('%')
+    delim = len(uri)
+    start = uri.find("//")+2
+    for c in '/?#':
+        wdelim = uri.find(c, start)
+        if wdelim >= 0:
+            delim = min(delim, wdelim)
+    # IPv6 link local may have %zone_index. Safely ignore it.
+    # Ex: http://[fe80::726f:8a26:222a:2bf3%eth0]:8080/a%20b/index.html
+    parts = uri[delim:].split('%')
     for i in range(1, len(parts)):
         h = parts[i][0:2]
         if len(h) == 2 and h.isalnum():
@@ -588,7 +596,7 @@ def unquote_unreserved(uri):
                 parts[i] = '%' + parts[i]
         else:
             parts[i] = '%' + parts[i]
-    return ''.join(parts)
+    return uri[:delim] + ''.join(parts)
 
 
 def requote_uri(uri):


### PR DESCRIPTION
## Issue:
When URI contains IPv6 link local with zone index (Ex: fe80::726f:8a26:222a:2bf3%eth0), requote_uri encodes all % to %25. Because of it, requests.get was requesting different resource.

Screenshot: 
![image](https://user-images.githubusercontent.com/1691611/68458332-8b76fd80-0228-11ea-9c6f-8e439f257180.png)

I'm proposing to ignore domain part in utils.unquote_unreserved.

## Actual Result
<pre>
>>> requests.utils.requote_uri('http://[fe80::726f:8a26:222a:2bf3%eth0]:8080/a%20b/index.html')
'http://[fe80::726f:8a26:222a:2bf3%25eth0]:8080/a%2520b/index.html'
</pre>

## Expected Result
<pre>
>>> requests.utils.requote_uri('http://[fe80::726f:8a26:222a:2bf3%eth0]:8080/a%20b/index.html')
'http://[fe80::726f:8a26:222a:2bf3%eth0]:8080/a%20b/index.html'
</pre>

## System Information
<pre>
# python3 -m requests.help
{
  "chardet": {
    "version": "3.0.4"
  },
  "cryptography": {
    "version": "2.2.2"
  },
  "idna": {
    "version": "2.8"
  },
  "implementation": {
    "name": "CPython",
    "version": "3.5.2"
  },
  "platform": {
    "release": "4.4.71-UNRELEASED-v4-00050-g76f27ecf9a52",
    "system": "Linux"
  },
  "pyOpenSSL": {
    "openssl_version": "1000207f",
    "version": "18.0.0"
  },
  "requests": {
    "version": "2.22.0"
  },
  "system_ssl": {
    "version": "1000207f"
  },
  "urllib3": {
    "version": "1.24.1"
  },
  "using_pyopenssl": true
}
</pre>