### PR TITLE
docs - clarify json() error exception for Python 3

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -152,7 +152,7 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,
-attempting ``r.json()`` raises ``ValueError: No JSON object could be decoded``.
+attempting ``r.json()`` will raise ``simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)``, or ``ValueError: No JSON object could be decoded`` in Python 2.
 
 It should be noted that the success of the call to ``r.json()`` does **not**
 indicate the success of the response. Some servers may return a JSON object in a

--- a/requests/models.py
+++ b/requests/models.py
@@ -895,7 +895,7 @@ class Response(object):
         r"""Returns the json-encoded content of a response, if any.
 
         :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
-        :raises ValueError: If the response body does not contain valid json.
+        :raises JSONDecodeError or ValueError (Python 2): If the response body does not contain valid json.
         """
 
         if not self.encoding and self.content and len(self.content) > 3:


### PR DESCRIPTION
python 3 exception is `JSONDecodeError:  Expecting value: line 1 column 1 (char 0)`

https://github.com/psf/requests/issues/4908