### PR TITLE
Update supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Adding requests to Pipfile's [packages]…
 …
 ```
 
-Requests officially supports Python 2.7 & 3.4–3.8.
+Requests officially supports Python 2.7 & 3.5+.
 
 -------------------------------------
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -54,15 +54,7 @@ Chris Adams gave an excellent summary on
 Python 3 Support?
 -----------------
 
-Yes! Here's a list of Python platforms that are officially
-supported:
-
-* Python 2.7
-* Python 3.4
-* Python 3.5
-* Python 3.6
-* Python 3.7
-* PyPy
+Yes! Requests officially supports Python 2.7 & 3.5+ and PyPy.
 
 What are "hostname doesn't match" errors?
 -----------------------------------------


### PR DESCRIPTION
Supported versions are 2.7 and 3.5+ (currently to 3.8):

https://github.com/psf/requests/blob/eedd67462819f8dbf8c1c32e77f9070606605231/setup.py#L82-L100

3.4 was dropped in https://github.com/psf/requests/pull/5092.

Writing "3.5+" means the docs don't need updating when 3.9 is released, only when 3.5 is dropped.