### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,18 @@
+specfile_path: python-requests.spec
+upstream_package_name: requests
+downstream_package_name: python-requests
+actions:
+  post-upstream-clone:
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/python-requests.spec
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/patch-requests-certs.py-to-use-the-system-CA-bundle.patch
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/Remove-tests-that-use-the-tarpit.patch
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/requests-2.12.4-tests_nonet.patch
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/Don-t-inject-pyopenssl-into-urllib3.patch
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/requests-2.20.0-no-py2-httpbin.patch
+    - wget -N https://src.fedoraproject.org/rpms/python-requests/raw/master/f/support-pytest-4.patch
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-stable
+  trigger: pull_request


### PR DESCRIPTION
Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact [@packit-service/the-packit-team](https://github.com/orgs/packit-service/teams/the-packit-team)