### PR TITLE
Add response context to errors raised by iter_content

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -756,13 +756,13 @@ class Response(object):
                         yield chunk
 
                 except ProtocolError as e:
-                    self._error = ChunkedEncodingError(e, response=self)
+                    self._error = ChunkedEncodingError(e, request=self.request)
 
                 except DecodeError as e:
-                    self._error = ContentDecodingError(e, response=self)
+                    self._error = ContentDecodingError(e, request=self.request)
 
                 except ReadTimeoutError as e:
-                    self._error = ConnectionError(e, response=self)
+                    self._error = ConnectionError(e, request=self.request)
 
                 finally:
                     # if we had an error - throw the saved error

--- a/requests/models.py
+++ b/requests/models.py
@@ -756,13 +756,13 @@ class Response(object):
                         yield chunk
 
                 except ProtocolError as e:
-                    self._error = ChunkedEncodingError(e)
+                    self._error = ChunkedEncodingError(e, response=self)
 
                 except DecodeError as e:
-                    self._error = ContentDecodingError(e)
+                    self._error = ContentDecodingError(e, response=self)
 
                 except ReadTimeoutError as e:
-                    self._error = ConnectionError(e)
+                    self._error = ConnectionError(e, response=self)
 
                 finally:
                     # if we had an error - throw the saved error
@@ -780,7 +780,7 @@ class Response(object):
             self._content_consumed = True
 
         if self._content_consumed and isinstance(self._content, bool):
-            raise StreamConsumedError()
+            raise StreamConsumedError(response=self)
         elif chunk_size is not None and not isinstance(chunk_size, int):
             raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
         # simulate reading small chunks of the content

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -336,7 +336,7 @@ def test_response_content_retains_error():
         r = requests.post(url, stream=True)
         with pytest.raises(ChunkedEncodingError) as exc:
             r.content
-        assert exc.value.response is r
+        assert exc.value.request is r.request
 
     # Access the bad response data again, I would expect the same
     # error again.
@@ -370,7 +370,6 @@ def test_response_content_decoding_error():
             resp = requests.post(url, stream=True)
             with pytest.raises(ContentDecodingError) as exc:
                 resp.content
-            err = exc.value
-            assert exc.value.response is resp
+            assert exc.value.request is resp.request
     finally:
         close_server.set()


### PR DESCRIPTION
Errors raised by `Response.iter_content` did not have request/response context.

I couldn't figure out how to simulate `StreamConsumedError` or `ConnectionError` as raised from that context, and I could not find any other tests that simulate those errors either. However, the additions are so trivial and other tests _were_ updated to test the very same thing, so I'm confident in the changes.

Except for `StreamConsumedError` ~this introduces a circular reference between the `Response` and error objects because of `<Response>._error`. One way I thought of solving that issue is to break the cycle with a weakref, but that seems annoying since it would likely involve changing the implementation of `RequestException` in a way that may make it lose references.~ Another option would be to pass `request=self.request` instead of `response=self`. I added https://github.com/psf/requests/pull/5323/commits/8bb881fe425da8e2b5043da73462e6128d728506 to do that instead since that seems like a reasonable idea.