### PR TITLE
Change link for pip installation instructions

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -18,7 +18,7 @@ To install Requests, simply run this simple command in your terminal of choice::
     $ pipenv install requests
 
 If you don't have `pipenv <http://pipenv.org/>`_ installed (tisk tisk!), head over to the Pipenv website for installation instructions. Or, if you prefer to just use pip and don't have it installed,
-`this Python installation guide <https://requests.readthedocs.io/en/master/user/install/>`_
+`this Python installation guide <https://docs.python-guide.org/starting/installation/>`_
 can guide you through the process.
 
 Get the Source Code


### PR DESCRIPTION
After #5236, the [Installation of Requests](https://requests.readthedocs.io/en/master/user/install/) documentation page links to itself for instructions on how to install pip.

This restores the previous link to https://docs.python-guide.org/starting/installation/.