### PR TITLE
Fix intersphinx_mapping config for Python standard library

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -381,6 +381,6 @@ epub_exclude_files = ["search.html"]
 # epub_use_index = True
 
 intersphinx_mapping = {
-    "python": ("https://requests.readthedocs.io/en/master/", None),
+    "python": ("https://docs.python.org/3/", None),
     "urllib3": ("https://urllib3.readthedocs.io/en/latest", None),
 }


### PR DESCRIPTION
Currently, the [intersphinx_mapping](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping) for `python` is set to the Requests documentation. This prevents some references from being linked to the Python standard library documentation.

This PR reverts the configuration change made in #5236 and sets the URL for `python` back to https://docs.python.org/3/ as (shown in the example in the intersphinx_mapping documentation).

Some effects of this change can be seen on the Developer Interface page.

Before:

![image](https://user-images.githubusercontent.com/1156625/73128655-84969600-3fa0-11ea-9e43-ffb8e5c7886f.png)

After:

![image](https://user-images.githubusercontent.com/1156625/73128660-a6901880-3fa0-11ea-87a0-012b185b605f.png)
