### PR TITLE
Update pipenv links in README and installation guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Requests is ready for the demands of building robust and reliable HTTP–speak a
 Requests Module Installation
 ----------------------------
 
-The recommended way to intall the `requests` module is to simply use [`pipenv`](http://pipenv.org/) (or `pip`, of
+The recommended way to intall the `requests` module is to simply use [`pipenv`](https://pipenv.kennethreitz.org) (or `pip`, of
 course):
 
 ```console

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -17,7 +17,7 @@ To install Requests, simply run this simple command in your terminal of choice::
 
     $ pipenv install requests
 
-If you don't have `pipenv <http://pipenv.org/>`_ installed (tisk tisk!), head over to the Pipenv website for installation instructions. Or, if you prefer to just use pip and don't have it installed,
+If you don't have `pipenv <https://pipenv.kennethreitz.org>`_ installed (tisk tisk!), head over to the Pipenv website for installation instructions. Or, if you prefer to just use pip and don't have it installed,
 `this Python installation guide <https://docs.python-guide.org/starting/installation/>`_
 can guide you through the process.
 


### PR DESCRIPTION
http://pipenv.org is unavailable, so I changed all of the links to https://pipenv.kennethreitz.org.