### PR TITLE
Bump maximum version of idna

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ packages = ['requests']
 
 requires = [
     'chardet>=3.0.2,<3.1.0',
-    'idna>=2.5,<2.9',
+    'idna>=2.5,<2.10',
     'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
     'certifi>=2017.4.17'
 


### PR DESCRIPTION
Looks like `idna` 2.9 was released yesterday. Bumping maximum version.