### PR TITLE
v2.23.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,22 @@ dev
 
 -   \[Short description of non-trivial change.\]
 
+2.23.0 (2020-02-19)
+-------------------
+
+**Improvements**
+
+- Remove defunct reference to `prefetch` in Session `__attrs__` (#5110)
+
+**Bugfixes**
+
+- Requests no longer outputs password in basic auth usage warning. (#5099)
+
+**Dependencies**
+
+- Pinning for `chardet` and `idna` now uses major version instead of minor.
+  This hopefully reduces the need for releases everytime a dependency is updated.
+
 2.22.0 (2019-05-15)
 -------------------
 

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,10 +5,10 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.22.0'
-__build__ = 0x022200
+__version__ = '2.23.0'
+__build__ = 0x022300
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2019 Kenneth Reitz'
+__copyright__ = 'Copyright 2020 Kenneth Reitz'
 __cake__ = u'\u2728 \U0001f370 \u2728'


### PR DESCRIPTION
2.23.0 (2020-02-19)
-------------------

**Improvements**

- Remove defunct reference to `prefetch` in Session `__attrs__` (#5110)

**Bugfixes**

- Requests no longer outputs password in basic auth usage warning. (#5099)

**Dependencies**

- Pinning for `chardet` and `idna` now uses major version instead of minor.
  This hopefully reduces the need for releases everytime a dependency is updated.