### PR TITLE
Update structures.py

### DIFF
--- a/requests/structures.py
+++ b/requests/structures.py
@@ -65,14 +65,14 @@ class CaseInsensitiveDict(MutableMapping):
     def lower_items(self):
         """Like iteritems(), but with all lowercase keys."""
         return (
-            (lowerkey, keyval[1])
-            for (lowerkey, keyval)
+            (lowerkey, value)
+            for (lowerkey, (original_key, value))
             in self._store.items()
         )
 
     def __eq__(self, other):
         if isinstance(other, Mapping):
-            other = CaseInsensitiveDict(other)
+            other = type(self)(other)
         else:
             return NotImplemented
         # Compare insensitively
@@ -80,7 +80,7 @@ class CaseInsensitiveDict(MutableMapping):
 
     # Copy is required
     def copy(self):
-        return CaseInsensitiveDict(self._store.values())
+        return type(self)(self._store.values())
 
     def __repr__(self):
         return str(dict(self.items()))


### PR DESCRIPTION
Changed lower_items() to use iterable unpacking to clarify the intent of the function. Changed copy() and __eq__() to retrieve the class via inspection using type() -- this way behavior will be preserved in classes that inherit from CaseInsensitiveDict.