### PR TITLE
Added a warning when stripping authentication from requests on a redirect

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -10,6 +10,7 @@ requests (cookies, auth, proxies).
 import os
 import sys
 import time
+import warnings
 from datetime import timedelta
 from collections import OrderedDict
 
@@ -22,7 +23,9 @@ from .hooks import default_hooks, dispatch_hook
 from ._internal_utils import to_native_string
 from .utils import to_key_val_list, default_headers, DEFAULT_PORTS
 from .exceptions import (
-    TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError)
+    TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError,
+    RequestsWarning
+)
 
 from .structures import CaseInsensitiveDict
 from .adapters import HTTPAdapter
@@ -263,6 +266,11 @@ class SessionRedirectMixin(object):
             # If we get redirected to a new host, we should strip out any
             # authentication headers.
             del headers['Authorization']
+            warnings.warn(
+                "The request has been redirected, requests has stripped authentication "
+                "to avoid leaking credentials. Credentials from .netrc might be used instead.",
+                category=RequestsWarning
+            )
 
         # .netrc might have more auth for us on our new host.
         new_auth = get_netrc_auth(url) if self.trust_env else None


### PR DESCRIPTION
Hello!
After seeing this [question](https://stackoverflow.com/questions/60358216/python-requests-post-request-dropping-authorization-header), I thought a warning should be added when authentication is stripped from redirected requests, in order to save users a significant amount of debugging time.
Apparently the matter has already been discussed in [this issue](https://github.com/psf/requests/issues/2949), and it has been agreed upon that *some* message should be passed to the user, like a debug log or a warning. But requests still does not use logs, and it seems people are still confused by this.
Maybe it is time to add a warning?