### PR TITLE
Fixed a decode problem when missing `charset`

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -494,9 +494,6 @@ def get_encoding_from_headers(headers):
     if 'charset' in params:
         return params['charset'].strip("'\"")
 
-    if 'text' in content_type:
-        return 'ISO-8859-1'
-
 
 def stream_decode_response_unicode(iterator, r):
     """Stream decodes a iterator."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -526,7 +526,7 @@ def test__parse_content_type_header(value, expected):
         ),
         (
             CaseInsensitiveDict({'content-type': 'text/plain'}),
-            'ISO-8859-1'
+            None
         ),
     ))
 def test_get_encoding_from_headers(value, expected):


### PR DESCRIPTION
When the `charset` is not declared in `Content-type`, the `get_encoding_from_headers` function returns `ISO-8859-1` as the response encoding by default, but the encoding is a single-byte encoding system, so if the response contains other multi-byte encoding languages like Chinese, `Response.text` will return garbage characters.

So I think it's better to leave it to `Response.apparent_encoding` to determine the encoding.

for example, if the response is like this
```python
r.headers['Content-Type'] == 'text/html'
r.content == b'<title>\xe4\xb8\xad\xe6\x96\x87</title>'
r.encoding == 'ISO-8859-1'
r.text == '<title>ä¸\xadæ\x96\x87</title>' # garbage characters
# but if we leave it to `Response.apparent_encoding`
r.encoding == 'utf-8'
r.text == '<title>中文</title>'
```