### PR TITLE
Send only one Host header in chunked request

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -191,3 +191,4 @@ Patches and Suggestions
 - "Dull Bananas" <dull.bananas0@gmail.com> (`@dullbananas <https://github.com/dullbananas>`_)
 - Alessio Izzo (`@aless10 <https://github.com/aless10>`_)
 - Sylvain Marié (`@smarie <https://github.com/smarie>`_)
+- Hod Bin Noon (`@hodbn <https://github.com/hodbn>`_)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -458,10 +458,11 @@ class HTTPAdapter(BaseAdapter):
                 low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
 
                 try:
+                    skip_host = 'Host' in request.headers
                     low_conn.putrequest(request.method,
                                         url,
                                         skip_accept_encoding=True,
-                                        skip_host='Host' in request.headers)
+                                        skip_host=skip_host)
 
                     for header, value in request.headers.items():
                         low_conn.putheader(header, value)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -460,7 +460,8 @@ class HTTPAdapter(BaseAdapter):
                 try:
                     low_conn.putrequest(request.method,
                                         url,
-                                        skip_accept_encoding=True)
+                                        skip_accept_encoding=True,
+                                        skip_host='Host' in request.headers)
 
                     for header, value in request.headers.items():
                         low_conn.putheader(header, value)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -46,6 +46,33 @@ def test_chunked_encoding_error():
         close_server.set()  # release server block
 
 
+def test_chunked_upload_uses_only_specified_host_header():
+    """Ensure we use only the specified Host header for chunked requests."""
+    text_200 = (b'HTTP/1.1 200 OK\r\n'
+                b'Content-Length: 0\r\n\r\n')
+    wanted_host = 'sample-host'
+    expected_header = 'Host: {}'.format(wanted_host).encode('utf-8')
+    def single_host_resp_handler(sock):
+        request_content = consume_socket_content(sock, timeout=0.5)
+        assert expected_header in request_content
+        assert request_content.count(b'Host: ') == 1
+        sock.send(text_200)
+
+        return request_content
+
+    close_server = threading.Event()
+
+    server = Server(single_host_resp_handler, wait_to_close_event=close_server)
+    data = iter([b'a', b'b', b'c'])
+
+    with server as (host, port):
+        url = 'http://{}:{}/'.format(host, port)
+        r = requests.post(url, data=data, headers={'Host': wanted_host}, stream=True)
+        close_server.set()  # release server block
+
+    assert r.status_code == 200
+
+
 def test_conflicting_content_lengths():
     """Ensure we correctly throw an InvalidHeader error if multiple
     conflicting Content-Length headers are returned.


### PR DESCRIPTION
Send only one Host header when specifying a custom Host header in a chunked request.

Before this fix, the default Host header was sent along with the custom Host header.

Closes #5274 