### PR TITLE
Port of PR #4173 from v3 to v2 to fix issue #4391

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -260,9 +260,12 @@ class HTTPAdapter(BaseAdapter):
         return manager
 
     def cert_verify(self, conn, url, verify, cert):
-        """Verify a SSL certificate. This method should not be called from user
-        code, and is only exposed for use when subclassing the
+        """This call has been deprecated but kept for API compatibility.
+
+        This method should not be called from user code, and is only
+        exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
+
         :param conn: The urllib3 connection object associated with the cert.
         :param url: The requested URL.
         :param verify: Either a boolean, in which case it controls whether we verify
@@ -270,45 +273,7 @@ class HTTPAdapter(BaseAdapter):
             to a CA bundle to use
         :param cert: The SSL certificate to verify.
         """
-        if url.lower().startswith('https') and verify:
-
-            cert_loc = None
-
-            # Allow self-specified cert location.
-            if verify is not True:
-                cert_loc = verify
-
-            if not cert_loc:
-                cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
-
-            if not cert_loc or not os.path.exists(cert_loc):
-                raise IOError("Could not find a suitable TLS CA certificate bundle, "
-                              "invalid path: {}".format(cert_loc))
-
-            conn.cert_reqs = 'CERT_REQUIRED'
-
-            if not os.path.isdir(cert_loc):
-                conn.ca_certs = cert_loc
-            else:
-                conn.ca_cert_dir = cert_loc
-        else:
-            conn.cert_reqs = 'CERT_NONE'
-            conn.ca_certs = None
-            conn.ca_cert_dir = None
-
-        if cert:
-            if not isinstance(cert, basestring):
-                conn.cert_file = cert[0]
-                conn.key_file = cert[1]
-            else:
-                conn.cert_file = cert
-                conn.key_file = None
-            if conn.cert_file and not os.path.exists(conn.cert_file):
-                raise IOError("Could not find the TLS certificate file, "
-                              "invalid path: {}".format(conn.cert_file))
-            if conn.key_file and not os.path.exists(conn.key_file):
-                raise IOError("Could not find the TLS key file, "
-                              "invalid path: {}".format(conn.key_file))
+        pass
 
     def build_response(self, req, resp):
         """Builds a :class:`Response <requests.Response>` object from a urllib3

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -260,9 +260,12 @@ class HTTPAdapter(BaseAdapter):
         return manager
 
     def cert_verify(self, conn, url, verify, cert):
-        """Verify a SSL certificate. This method should not be called from user
-        code, and is only exposed for use when subclassing the
+        """Verify a SSL certificate [DEPRECATED].
+
+        This method should not be called from user code, and is only
+        exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
+
         :param conn: The urllib3 connection object associated with the cert.
         :param url: The requested URL.
         :param verify: Either a boolean, in which case it controls whether we verify

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -260,12 +260,9 @@ class HTTPAdapter(BaseAdapter):
         return manager
 
     def cert_verify(self, conn, url, verify, cert):
-        """This call has been deprecated but kept for API compatibility.
-
-        This method should not be called from user code, and is only
-        exposed for use when subclassing the
+        """Verify a SSL certificate. This method should not be called from user
+        code, and is only exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
-
         :param conn: The urllib3 connection object associated with the cert.
         :param url: The requested URL.
         :param verify: Either a boolean, in which case it controls whether we verify
@@ -273,7 +270,45 @@ class HTTPAdapter(BaseAdapter):
             to a CA bundle to use
         :param cert: The SSL certificate to verify.
         """
-        pass
+        if url.lower().startswith('https') and verify:
+
+            cert_loc = None
+
+            # Allow self-specified cert location.
+            if verify is not True:
+                cert_loc = verify
+
+            if not cert_loc:
+                cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
+
+            if not cert_loc or not os.path.exists(cert_loc):
+                raise IOError("Could not find a suitable TLS CA certificate bundle, "
+                              "invalid path: {}".format(cert_loc))
+
+            conn.cert_reqs = 'CERT_REQUIRED'
+
+            if not os.path.isdir(cert_loc):
+                conn.ca_certs = cert_loc
+            else:
+                conn.ca_cert_dir = cert_loc
+        else:
+            conn.cert_reqs = 'CERT_NONE'
+            conn.ca_certs = None
+            conn.ca_cert_dir = None
+
+        if cert:
+            if not isinstance(cert, basestring):
+                conn.cert_file = cert[0]
+                conn.key_file = cert[1]
+            else:
+                conn.cert_file = cert
+                conn.key_file = None
+            if conn.cert_file and not os.path.exists(conn.cert_file):
+                raise IOError("Could not find the TLS certificate file, "
+                              "invalid path: {}".format(conn.cert_file))
+            if conn.key_file and not os.path.exists(conn.key_file):
+                raise IOError("Could not find the TLS key file, "
+                              "invalid path: {}".format(conn.key_file))
 
     def build_response(self, req, resp):
         """Builds a :class:`Response <requests.Response>` object from a urllib3

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -31,6 +31,7 @@ from requests.sessions import SessionRedirectMixin
 from requests.models import urlencode
 from requests.hooks import default_hooks
 from requests.compat import MutableMapping
+from requests.utils import DEFAULT_CA_BUNDLE_PATH
 
 from .compat import StringIO, u
 from .utils import override_environ
@@ -2421,12 +2422,12 @@ class TestPreparingURLs(object):
     def test_preparing_url(self, url, expected):
 
         def normalize_percent_encode(x):
-            # Helper function that normalizes equivalent 
+            # Helper function that normalizes equivalent
             # percent-encoded bytes before comparisons
             for c in re.findall(r'%[a-fA-F0-9]{2}', x):
                 x = x.replace(c, c.upper())
             return x
-        
+
         r = requests.Request('GET', url=url)
         p = r.prepare()
         assert normalize_percent_encode(p.url) == expected
@@ -2525,3 +2526,225 @@ class TestPreparingURLs(object):
         r = requests.Request('GET', url=input, params=params)
         p = r.prepare()
         assert p.url == expected
+
+
+class TestGetConnection(object):
+    """
+    Tests for the :meth:`requests.adapters.HTTPAdapter.get_connection` that assert
+    the connections are correctly configured.
+    """
+    @pytest.mark.parametrize(
+        'proxies, verify, cert, expected',
+        (
+            (
+                {},
+                True,
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                False,
+                None,
+                {
+                    'cert_reqs': 'CERT_NONE',
+                    'ca_certs': None,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                __file__,
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': __file__,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                os.path.dirname(__file__),
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': None,
+                    'ca_cert_dir': os.path.dirname(__file__),
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                True,
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                True,
+                __file__,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': __file__,
+                    'key_file': None,
+                },
+            ),
+            (
+                {},
+                True,
+                (__file__, __file__),
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': __file__,
+                    'key_file': __file__,
+                },
+            ),
+            (
+                {},
+                True,
+                (__file__, __file__),
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': __file__,
+                    'key_file': __file__,
+                },
+            ),
+            (
+                {'http': 'http://proxy.example.com', 'https': 'http://proxy.example.com'},
+                True,
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {'http': 'http://proxy.example.com', 'https': 'http://proxy.example.com'},
+                os.path.dirname(__file__),
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': None,
+                    'ca_cert_dir': os.path.dirname(__file__),
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {'http': 'http://proxy.example.com', 'https': 'http://proxy.example.com'},
+                __file__,
+                None,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': __file__,
+                    'ca_cert_dir': None,
+                    'cert_file': None,
+                    'key_file': None,
+                },
+            ),
+            (
+                {'http': 'http://proxy.example.com', 'https': 'http://proxy.example.com'},
+                True,
+                __file__,
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': __file__,
+                    'key_file': None,
+                },
+            ),
+            (
+                {'http': 'http://proxy.example.com', 'https': 'http://proxy.example.com'},
+                True,
+                (__file__, __file__),
+                {
+                    'cert_reqs': 'CERT_REQUIRED',
+                    'ca_certs': DEFAULT_CA_BUNDLE_PATH,
+                    'ca_cert_dir': None,
+                    'cert_file': __file__,
+                    'key_file': __file__,
+                },
+            ),
+        )
+    )
+    def test_get_https_connection(self, proxies, verify, cert, expected):
+        """Assert connections are configured correctly."""
+        adapter = requests.adapters.HTTPAdapter()
+        connection = adapter.get_connection(
+            'https://example.com', proxies=proxies, verify=verify, cert=cert)
+        actual_config = {}
+        for key, value in connection.__dict__.items():
+            if key in expected:
+                actual_config[key] = value
+        assert actual_config == expected
+
+    @pytest.mark.parametrize(
+        'verify, cert',
+        (
+            ('a/path/that/does/not/exist', None),
+            (True, 'a/path/that/does/not/exist'),
+            (True, (__file__, 'a/path/that/does/not/exist')),
+            (True, ('a/path/that/does/not/exist', __file__)),
+        )
+    )
+    def test_cert_files_missing(self, verify, cert):
+        """
+        Assert an IOError is raised when one of the certificate files or
+        directories can't be found.
+        """
+        adapter = requests.adapters.HTTPAdapter()
+        with pytest.raises(IOError) as excinfo:
+            adapter.get_connection('https://example.com', verify=verify, cert=cert)
+        excinfo.match('invalid path: a/path/that/does/not/exist')
+
+    def test_session_verify_not_stateful(self):
+        insecure_url = "https://expired.badssl.com/"
+        s = requests.Session()
+        assert s.verify is True
+
+        with pytest.raises(Exception):
+            s.get(insecure_url, verify=True)
+
+        s.get(insecure_url, verify=False)
+        assert s.verify is True
+
+        with pytest.raises(Exception):
+            s.get(insecure_url, verify=True)
+
+    def test_verify_not_stateful(self):
+        insecure_url = "https://expired.badssl.com/"
+
+        with pytest.raises(Exception):
+            requests.get(insecure_url, verify=True)
+
+        requests.get(insecure_url, verify=False)
+
+        with pytest.raises(Exception):
+            requests.get(insecure_url, verify=True)


### PR DESCRIPTION
Fixes #4391

# Problem
This code was failing to verify the SSL:
```python
    def test_session_verify_not_stateful(self):
        insecure_url = "https://expired.badssl.com/"
        s = requests.Session()
        assert s.verify is True

        with pytest.raises(Exception):
            s.get(insecure_url, verify=True)

        s.get(insecure_url, verify=False)
        assert s.verify is True

        with pytest.raises(Exception):
            s.get(insecure_url, verify=True)  # <- This line was not raising bc we got a cached unverfied connection
```
The problem was that we were modifying the connection object returned to us by the poolmanager, which is illegal, causing us to get unverified connections when requesting verified ones.

# Approach
I had come up with the same solution as PR #4173 independently, not having found the issue before trying to fix it, but my unit-tests were not as thurough, so I added those from PR #4173

The issue was closed in 2018 because it was fixed in v3 (which is still not released), and presumably because it was not fixable in v2, but perhaps this fix works for v2 (new urllib3 perhaps that allows it?)