### PR TITLE
Remove shebang from nonexecutable script

### DIFF
--- a/requests/certs.py
+++ b/requests/certs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
When packaging requests and pip (which bundles it) in Fedora, we have realised
that there is a nonexecutable file with a shebang line.

It seems that the primary purpose of this file is to be imported from Python
code and hence the shebang appears to be unnecessary.

Shebangs are hard to handle when doing downstream packaging, because it makes
sense for upstream to use `#!/usr/bin/env python` while in the RPM package, we
need to avoid that and use a more specific interpreter. Since the shebang was
unused, I propose to remove it to avoid the problems.