### PR TITLE
Add text_with_headers to Response model

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -870,6 +870,15 @@ class Response(object):
             content = str(self.content, errors='replace')
 
         return content
+    
+    @property
+    def text_with_headers(self):
+        """Returns the raw HTTP response as a string."""
+        head = f'HTTP/1.1 {self.status_code} {self.raw.reason}\r\n'
+        for header_name, header_value in self.headers.items():
+            head += f'{header_name}: {header_value}\r\n'
+        return head + '\r\n' + self.text
+
 
     def json(self, **kwargs):
         r"""Returns the json-encoded content of a response, if any.


### PR DESCRIPTION
This property will return the entire HTTP response including the headers. There doesn't seem to be a `test_models.py` file in the tests folder so I'm not sure if I should make a test for this, but if so where would I make it?