### PR TITLE
Raise InvalidUrl if host starts with '.' character.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -403,7 +403,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 host = self._get_idna_encoded_host(host)
             except UnicodeError:
                 raise InvalidURL('URL has an invalid label.')
-        elif host.startswith(u'*'):
+        elif host.startswith((u'*', u'.')):
             raise InvalidURL('URL has an invalid label.')
 
         # Carefully reconstruct the network location

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -81,6 +81,8 @@ class TestRequests:
             (InvalidSchema, 'localhost.localdomain:3128/'),
             (InvalidSchema, '10.122.1.1:3128/'),
             (InvalidURL, 'http://'),
+            (InvalidURL, 'http://*example.com'),
+            (InvalidURL, 'http://.example.com'),
         ))
     def test_invalid_url(self, exception, url):
         with pytest.raises(exception):


### PR DESCRIPTION
Closes #5367

Attempting to get `http://.example.com` results in a `UnicodeError` but should be raise `InvalidUrl` as attempting to get `http://*example.com`.

I've added `InvalidUrl` tests for `http://.example.com` and `http://*example.com`.