### PR TITLE
Remove extraneous paramater from doctring for put() method

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -125,7 +125,6 @@ def put(url, data=None, **kwargs):
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response


### PR DESCRIPTION
There's an unused `json` parameter in the docstring from the put() method.