### PR TITLE
WIP: Allow use of system CA certs

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -212,7 +212,10 @@ class HTTPAdapter(BaseAdapter):
             to a CA bundle to use
         :param cert: The SSL certificate to verify.
         """
-        if url.lower().startswith('https') and verify:
+        if url.lower().startswith('https') and verify == 'SYSTEM':
+          conn.cert_reqs = 'CERT_REQUIRED'
+
+        elif url.lower().startswith('https') and verify:
 
             cert_loc = None
 


### PR DESCRIPTION
This allows setting `REQUESTS_CA_BUNDLE=SYSTEM` to make Requests behaves like the base python standard library with respect to CA cert trust.