### PR TITLE
Add more details in error reponse of "Bad Request"

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -932,7 +932,7 @@ class Response(object):
             reason = self.reason
 
         if 400 <= self.status_code < 500:
-            http_error_msg = u'%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
+            http_error_msg = u'%s Client Error: %s for url: %s, Server Response: %s' % (self.status_code, reason, self.url, self.content)
 
         elif 500 <= self.status_code < 600:
             http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)


### PR DESCRIPTION
When there is an exception raised on a 400 "Bad Request" from the server. The information provided on the exception is not enough to debug problems. Adding "content" attribute from the response to understand the error from the server's perspective.