### PR TITLE
Warn user once about missing timeouts

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -10,6 +10,7 @@ requests (cookies, auth, proxies).
 import os
 import sys
 import time
+import warnings
 from datetime import timedelta
 from collections import OrderedDict
 
@@ -22,7 +23,8 @@ from .hooks import default_hooks, dispatch_hook
 from ._internal_utils import to_native_string
 from .utils import to_key_val_list, default_headers, DEFAULT_PORTS
 from .exceptions import (
-    TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError)
+    TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError,
+    RequestsWarning)
 
 from .structures import CaseInsensitiveDict
 from .adapters import HTTPAdapter
@@ -633,7 +635,8 @@ class Session(SessionRedirectMixin):
 
         if "timeout" not in kwargs:
             if not Session.__timeout_warned:
-                print("WARNING: timeout missing from requests call, can hang forever")
+                warnings.warn("Timeout missing from requests call, can hang forever", 
+                              RequestsWarning)
                 Session.__timeout_warned = True
                 
         # Set up variables needed for resolve_redirects and dispatching of hooks

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -358,6 +358,9 @@ class Session(SessionRedirectMixin):
         'cert', 'adapters', 'stream', 'trust_env',
         'max_redirects',
     ]
+    
+    # whether the user has been warned about making requests without packet timeouts
+    __timeout_warned = False
 
     def __init__(self):
 
@@ -413,7 +416,7 @@ class Session(SessionRedirectMixin):
         self.adapters = OrderedDict()
         self.mount('https://', HTTPAdapter())
         self.mount('http://', HTTPAdapter())
-
+        
     def __enter__(self):
         return self
 
@@ -628,6 +631,11 @@ class Session(SessionRedirectMixin):
         if isinstance(request, Request):
             raise ValueError('You can only send PreparedRequests.')
 
+        if "timeout" not in kwargs:
+            if not Session.__timeout_warned:
+                print("WARNING: timeout missing from requests call, can hang forever")
+                Session.__timeout_warned = True
+                
         # Set up variables needed for resolve_redirects and dispatching of hooks
         allow_redirects = kwargs.pop('allow_redirects', True)
         stream = kwargs.get('stream')


### PR DESCRIPTION
Not sure if this is the best way to do it, but some sort of warning that "hanging forever" is a possibility is probably important - given that this lib is for "humans".