### PR TITLE
docs: make danger of verify=False clearer

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -247,7 +247,8 @@ Requests can also ignore verifying the SSL certificate if you set ``verify`` to 
 Note that when ``verify`` is set to ``False``, requests will accept any TLS
 certificate presented by the server, and will ignore hostname mismatches
 and/or expired certificates, which will make your application vulnerable to
-man-in-the-middle (MitM) attacks. Only set this to ``False`` for testing.
+man-in-the-middle (MitM) attacks. Setting verify to ``False`` may be useful
+during local development or testing.
 
 By default, ``verify`` is set to True. Option ``verify`` only applies to host certs.
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -244,6 +244,11 @@ Requests can also ignore verifying the SSL certificate if you set ``verify`` to 
     >>> requests.get('https://kennethreitz.org', verify=False)
     <Response [200]>
 
+Note that when ``verify`` is set to ``False``, requests will accept any TLS
+certificate presented by the server, and will ignore hostname mismatches
+and/or expired certificates, which will make your application vulnerable to
+man-in-the-middle (MitM) attacks. Only set this to ``False`` for testing.
+
 By default, ``verify`` is set to True. Option ``verify`` only applies to host certs.
 
 Client Side Certificates

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -387,6 +387,13 @@ class Session(SessionRedirectMixin):
         self.stream = False
 
         #: SSL Verification default.
+        #: Defaults to `True`, requiring requests to verify the TLS certificate at the
+        #: remote end.
+        #: If verify is set to `False`, requests will accept any TLS certificate
+        #: presented by the server, and will ignore hostname mismatches and/or
+        #: expired certificates, which will make your application vulnerable to
+        #: man-in-the-middle (MitM) attacks.
+        #: Only set this to `False` for testing.
         self.verify = True
 
         #: SSL client certificate default, if String, path to ssl client
@@ -495,7 +502,12 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``.
+            to a CA bundle to use. Defaults to ``True``. When set to
+            ``False``, requests will accept any TLS certificate presented by
+            the server, and will ignore hostname mismatches and/or expired
+            certificates, which will make your application vulnerable to
+            man-in-the-middle (MitM) attacks. Only set this to ``False`` for
+            testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -506,8 +506,8 @@ class Session(SessionRedirectMixin):
             ``False``, requests will accept any TLS certificate presented by
             the server, and will ignore hostname mismatches and/or expired
             certificates, which will make your application vulnerable to
-            man-in-the-middle (MitM) attacks. Only set this to ``False`` for
-            testing.
+            man-in-the-middle (MitM) attacks. Setting verify to ``False`` 
+            may be useful during local development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response


### PR DESCRIPTION
This PR makes the danger of setting `verify=False` clearer to users of requests. In many cases, users may set this to `False` when running into problems locally with self-signed certificates, but not realize the risk they are opening themselves up to.

As an example of how the dangers of not verifying TLS (SSL) certificates is communicated, see Go's `InsecureSkipVerify` docs: https://golang.org/pkg/crypto/tls/

```
    // InsecureSkipVerify controls whether a client verifies the
    // server's certificate chain and host name.
    // If InsecureSkipVerify is true, TLS accepts any certificate
    // presented by the server and any host name in that certificate.
    // In this mode, TLS is susceptible to man-in-the-middle attacks.
    // This should be used only for testing.
```

Happy to take feedback on the wording / doc-style - this is my first PR to requests but I care a lot about 'safe defaults' in OSS!