### PR TITLE
Strip double-quotes on proxy environment variables and add test (issue #4613)

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -613,6 +613,19 @@ def requote_uri(uri):
         return quote(uri, safe=safe_without_percent)
 
 
+def strip_double_quotes_from_url(url):
+    """Remove the double quotes around url if any are presents.
+
+    '"http://www.myproxy.com"' -> 'http://www.myproxy.com'
+    'http://www.otherproxy.com' -> 'http://www.otherproxy.com'
+
+    :param url:
+    :rtype: str
+    """
+    if url and len(url) >= 2 and url[0] == '"' and url[-1] =='"':
+        url = url[1:-1]
+    return url
+
 def address_in_network(ip, net):
     """This function allows you to check if an IP belongs to a network subnet
 
@@ -766,7 +779,10 @@ def get_environ_proxies(url, no_proxy=None):
     if should_bypass_proxies(url, no_proxy=no_proxy):
         return {}
     else:
-        return getproxies()
+        # strip the double-quotes for overquoted proxies (see end of issue #4613)
+        # Typical case on Windows is created by: set http_proxy="http://www.myproxy.com"
+        # -> proxy value is set to '"http://www.myproxy.com"'
+        return { var: strip_double_quotes_from_url(url) for (var,url) in getproxies().items() }
 
 
 def select_proxy(url, proxies):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2286,6 +2286,25 @@ def test_requests_are_updated_each_time(httpbin):
 
 
 @pytest.mark.parametrize("var,url,proxy", [
+    ('http_proxy', 'http://example.com', '"https://proxy.com:9876"'),
+    ('https_proxy', 'https://example.com', '"http://proxy.com:9876"'),
+    ('all_proxy', 'http://example.com', '"https://proxy.com:9876"'),
+])
+def test_proxy_url_strips_quotes(var, url, proxy):
+    session = requests.Session()
+    prep = PreparedRequest()
+    prep.prepare(method='GET', url=url)
+
+    kwargs = {
+        var: proxy
+    }
+    scheme = urlparse(url).scheme
+    with override_environ(**kwargs):
+        proxies = session.rebuild_proxies(prep, {})
+        assert scheme in proxies
+        assert proxies[scheme] == proxy[1:-1]   # with quotes stripped
+
+@pytest.mark.parametrize("var,url,proxy", [
     ('http_proxy', 'http://example.com', 'socks5://proxy.com:9876'),
     ('https_proxy', 'https://example.com', 'socks5://proxy.com:9876'),
     ('all_proxy', 'http://example.com', 'socks5://proxy.com:9876'),


### PR DESCRIPTION
Issue #4613 details two problems :
* proxy may contain white-space accidentally
* proxy may be contain extra double-quotes on Windows

A fix already exists for the white-space problem, this addresses the second problem.