### PR TITLE
Don't use pyOpenSSL unless no SNI is detected

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,9 +4,14 @@ Release History
 dev
 ---
 
-**Bugfixes**
+**Improvements**
 
--   \[Short description of non-trivial change.\]
+- pyOpenSSL TLS implementation is now only used if Python
+  either doesn't have an `ssl` module or doesn't support
+  SNI. Previously pyOpenSSL was unconditionally used if available.
+  This applies even if pyOpenSSL is installed via the
+  `requests[security]` extra (#5443)
+
 
 2.23.0 (2020-02-19)
 -------------------

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -90,14 +90,22 @@ except (AssertionError, ValueError):
                   "version!".format(urllib3.__version__, chardet.__version__),
                   RequestsDependencyWarning)
 
-# Attempt to enable urllib3's SNI support, if possible
+# Attempt to enable urllib3's fallback for SNI support
+# if the standard library doesn't support SNI or the
+# 'ssl' library isn't available.
 try:
-    from urllib3.contrib import pyopenssl
-    pyopenssl.inject_into_urllib3()
+    try:
+        import ssl
+    except ImportError:
+        ssl = None
 
-    # Check cryptography version
-    from cryptography import __version__ as cryptography_version
-    _check_cryptography(cryptography_version)
+    if not getattr(ssl, "HAS_SNI", False):
+        from urllib3.contrib import pyopenssl
+        pyopenssl.inject_into_urllib3()
+
+        # Check cryptography version
+        from cryptography import __version__ as cryptography_version
+        _check_cryptography(cryptography_version)
 except ImportError:
     pass
 


### PR DESCRIPTION
This is part 1 on removing `requests[security]` extra, for now we can still support SNI-less installations of Python but instead of unconditional monkey-patching we only patch if we detect either no `ssl` module or no `SNI` support.

Related: https://github.com/psf/requests/issues/5267
cc @tiran 

An additional thought I had was if we wanted to warn users about the complete removal of `requests[security]` I don't think there's a way to detect if you were installed via `requests pyopenssl` or `requests[security]` beyond registering a name on PyPI like `requests-security-extra`, trying to import it, and if we do then we know we were installed via `requests[security]` so throw a deprecation warning? Otherwise our "end-goal" could be to have `requests[security]` be empty?