### PR TITLE
Update supported python version in doc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.4–3.8, and runs great on PyPy.
 
 
 The User Guide


### PR DESCRIPTION
I think python 3.8 is supported now after I checked some other places in this rep.