### PR TITLE
Update Travis syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ os: linux
 
 dist: xenial
 
-# command to install dependencies
-install: "make"
-# command to run tests
-script:
-  - make test-readme
-  - make ci
-cache: pip
 jobs:
   include:
     - stage: test
@@ -29,3 +22,13 @@ jobs:
     - stage: coverage
       python: '3.6'
       script: codecov
+
+# command to install dependencies
+install: "make"
+
+# command to run tests
+script:
+  - make test-readme
+  - make ci
+  
+cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ dist: xenial
 jobs:
   include:
     - stage: test
-      python: '2.7'
+      python: '2.7.18'
     - stage: test
-      python: '3.5'
+      python: '3.5.9'
     - stage: test
-      python: '3.6'
+      python: '3.6.10'
     - stage: test
-      python: '3.7' 
+      python: '3.7.7' 
     - stage: test
       python: 'pypy3'
       dist: xenial
     - stage: test
-      python: '3.8'
+      python: '3.8.2'
     - stage: coverage
-      python: '3.6'
+      python: '3.6.10'
       script: codecov
 
 # command to install dependencies
@@ -31,4 +31,6 @@ script:
   - make test-readme
   - make ci
   
-cache: pip
+cache: 
+  pip: true
+  apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+os: linux
+
+dist: xenial
+
 # command to install dependencies
 install: "make"
 # command to run tests


### PR DESCRIPTION
### This pull request  brings the following changes:

- Ordered the commands to follow Travis CI execution order: <https://docs.travis-ci.com/user/job-lifecycle/#the-job-lifecycle> 

- Adds explicit os and dist commands protecting from changes on Travis default distro

- Forces the build to use the latest minor version of each python release so build become fully reproducible