### PR TITLE
Revert PR 1440, do not modify cookie value

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -129,7 +129,6 @@ Patches and Suggestions
 - Dave Shawley <daveshawley@gmail.com>
 - James Clarke (`@jam <https://github.com/jam>`_)
 - Kevin Burke <kev@inburke.com>
-- Flavio Curella
 - David Pursehouse <david.pursehouse@gmail.com> (`@dpursehouse <https://github.com/dpursehouse>`_)
 - Jon Parise (`@jparise <https://github.com/jparise>`_)
 - Alexander Karpinsky (`@homm86 <https://twitter.com/homm86>`_)

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -340,11 +340,6 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
         """
         remove_cookie_by_name(self, name)
 
-    def set_cookie(self, cookie, *args, **kwargs):
-        if hasattr(cookie.value, 'startswith') and cookie.value.startswith('"') and cookie.value.endswith('"'):
-            cookie.value = cookie.value.replace('\\"', '')
-        return super(RequestsCookieJar, self).set_cookie(cookie, *args, **kwargs)
-
     def update(self, other):
         """Updates this jar with cookies from another CookieJar or dict-like"""
         if isinstance(other, cookielib.CookieJar):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -345,11 +345,6 @@ class TestRequests:
         )
         assert 'foo' not in s.cookies
 
-    def test_cookie_quote_wrapped(self, httpbin):
-        s = requests.session()
-        s.get(httpbin('cookies/set?foo="bar:baz"'))
-        assert s.cookies['foo'] == '"bar:baz"'
-
     def test_cookie_persists_via_api(self, httpbin):
         s = requests.session()
         r = s.get(httpbin('redirect/1'), cookies={'foo': 'bar'})


### PR DESCRIPTION
Revert PR  #1440 as discussed in issue #3759 
It does not make sense to modify the cookie value arbitrarily.