### PR TITLE
Allow semicolon in the href of Link header

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -826,9 +826,9 @@ def parse_header_links(value):
 
     links = []
 
-    replace_chars = ' \'";'
+    strip_chars = ' \'";'
 
-    value = value.strip(replace_chars)
+    value = value.strip(strip_chars)
     if not value:
         return links
 
@@ -837,13 +837,13 @@ def parse_header_links(value):
 
         link = {'url': url.strip('<> \'"')}
 
-        for param in params.strip(replace_chars).split(';'):
+        for param in params.strip(strip_chars).split(';'):
             try:
                 key, value = param.split('=')
             except ValueError:
                 break
 
-            link[key.strip(replace_chars)] = value.strip(replace_chars)
+            link[key.strip(strip_chars)] = value.strip(strip_chars)
 
         links.append(link)
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -826,21 +826,18 @@ def parse_header_links(value):
 
     links = []
 
-    replace_chars = ' \'"'
+    replace_chars = ' \'";'
 
     value = value.strip(replace_chars)
     if not value:
         return links
 
     for val in re.split(', *<', value):
-        try:
-            url, params = val.split(';', 1)
-        except ValueError:
-            url, params = val, ''
+        url, _, params = val.partition('>')
 
         link = {'url': url.strip('<> \'"')}
 
-        for param in params.split(';'):
+        for param in params.strip(replace_chars).split(';'):
             try:
                 key, value = param.split('=')
             except ValueError:


### PR DESCRIPTION
Semicolons are valid characters in URIs, splitting them while parsing the `Link` header results in unexpected token and wrong `url` attribute (notice `;oldid=934259284` portion the below example).

```
<https://en.wikipedia.org/w/index.php?title=COVID-19_pandemic&amp;oldid=934259284>; rel="original", <https://web.archive.org/web/timemap/link/https://en.wikipedia.org/w/index.php?title=COVID-19_pandemic&amp;oldid=934259284>; rel="timemap"; type="application/link-format"
```

This PR attempts to fix current parsing issue and also renames a variable to better reflect the purpose of it.

I would note here that this parser still is far from perfect and can be better implemented using state machine.