### PR TITLE
Handle space-separated values in NO_PROXY

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -721,7 +721,7 @@ def should_bypass_proxies(url, no_proxy):
         # We need to check whether we match here. We need to see if we match
         # the end of the hostname, both with and without the port.
         no_proxy = (
-            host for host in no_proxy.replace(' ', '').split(',') if host
+            host for host in re.split('[, ]', no_proxy) if host
         )
 
         if is_ipv4_address(parsed.hostname):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -697,7 +697,7 @@ def test_should_bypass_proxies_no_proxy(
     """Tests for function should_bypass_proxies to check if proxy
     can be bypassed or not using the 'no_proxy' argument
     """
-    no_proxy = '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1'
+    no_proxy = '192.168.0.0/24,127.0.0.1 localhost.localdomain 172.16.1.1'
     # Test 'no_proxy' argument
     assert should_bypass_proxies(url, no_proxy=no_proxy) == expected
 


### PR DESCRIPTION
Since there is no standard for the NO_PROXY environment variable allow values
to be comma- and space-separated values.