### PR TITLE
Make chardet encoding auto-detect run once

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -617,6 +617,7 @@ class Response(object):
 
         #: Encoding to decode with when accessing r.text.
         self.encoding = None
+        self.tried_auto_detect_encoding = False
 
         #: A list of :class:`Response <Response>` objects from
         #: the history of the Request. Any redirect responses will end
@@ -854,8 +855,9 @@ class Response(object):
             return str('')
 
         # Fallback to auto-detected encoding.
-        if self.encoding is None:
+        if self.encoding is None and not self.tried_auto_detect_encoding:
             encoding = self.apparent_encoding
+            self.tried_auto_detect_encoding = True
 
         # Decode unicode from given encoding.
         try:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2379,6 +2379,13 @@ def test_urllib3_pool_connection_closed(httpbin):
         assert u"Pool is closed." in str(e)
 
 
+def test_chardet_encoding_auto_detect_accessed_once(mocker):
+    chardet_mock = mocker.patch('requests.compat.chardet.detect')
+    r = requests.request('GET', url='https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf')
+    _ = r.text
+    _ = r.text
+    chardet_mock.assert_called_once()
+
 class TestPreparingURLs(object):
     @pytest.mark.parametrize(
         'url,expected',

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2384,7 +2384,7 @@ def test_chardet_encoding_auto_detect_accessed_once(mocker):
     r = requests.request('GET', url='https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf')
     _ = r.text
     _ = r.text
-    chardet_mock.assert_called_once()
+    assert chardet_mock.call_count == 1
 
 class TestPreparingURLs(object):
     @pytest.mark.parametrize(


### PR DESCRIPTION
When you are using reuqest.request to get large non-text files and you are trying to call r.text, it tries to auto-detect using chardet because there is no header defining the charset.

When chardet is running on large EXE/PDF files (and maybe other file types) it takes quite some time to get the answer, which is None.

Once None returns, self.encoding receives the None value. Therefore the next time you call r.text on the same content, it will try to auto-detect again as if you never tried to auto-detect it.

I know it doesn't make much sense to use r.text when requesting PDF/EXE files but sometimes websites do return EXE/PDF content and not HTML as you would expect.

I think it can also improve performance when doing multiple calls to r.text on text content that needs to be auto-detected as well.