### PR TITLE
Drop monkeypatching with pyopenssl

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -124,7 +124,7 @@ Patches and Suggestions
 - Bryce Boe <bbzbryce@gmail.com> (`@bboe <https://github.com/bboe>`_)
 - Colin Dunklau <colin.dunklau@gmail.com> (`@cdunklau <https://github.com/cdunklau>`_)
 - Bob Carroll <bob.carroll@alum.rit.edu> (`@rcarz <https://github.com/rcarz>`_)
-- Hugo Osvaldo Barrera <hugo@barrera.io> (`@hobarrera <https://github.com/hobarrera>`_)
+- Hugo Osvaldo Barrera <hugo@barrera.io> (`@WhyNotHugo <https://github.com/WhyNotHugo>`_)
 - Łukasz Langa <lukasz@langa.pl>
 - Dave Shawley <daveshawley@gmail.com>
 - James Clarke (`@jam <https://github.com/jam>`_)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,14 +4,10 @@ Release History
 dev
 ---
 
-**Improvements**
+**Deprecations**
 
-- pyOpenSSL TLS implementation is now only used if Python
-  either doesn't have an `ssl` module or doesn't support
-  SNI. Previously pyOpenSSL was unconditionally used if available.
-  This applies even if pyOpenSSL is installed via the
-  `requests[security]` extra (#5443)
-
+- pyOpenSSL TLS is no longer patched to add extra SNI support. Python 2.7.9 or
+  later is now required for SNI support.
 
 2.23.0 (2020-02-19)
 -------------------

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -71,17 +71,6 @@ def check_compatibility(urllib3_version, chardet_version):
     assert patch >= 2
 
 
-def _check_cryptography(cryptography_version):
-    # cryptography < 1.3.4
-    try:
-        cryptography_version = list(map(int, cryptography_version.split('.')))
-    except ValueError:
-        return
-
-    if cryptography_version < [1, 3, 4]:
-        warning = 'Old version of cryptography ({}) may cause slowdown.'.format(cryptography_version)
-        warnings.warn(warning, RequestsDependencyWarning)
-
 # Check imported dependencies for compatibility.
 try:
     check_compatibility(urllib3.__version__, chardet.__version__)
@@ -89,25 +78,6 @@ except (AssertionError, ValueError):
     warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
                   "version!".format(urllib3.__version__, chardet.__version__),
                   RequestsDependencyWarning)
-
-# Attempt to enable urllib3's fallback for SNI support
-# if the standard library doesn't support SNI or the
-# 'ssl' library isn't available.
-try:
-    try:
-        import ssl
-    except ImportError:
-        ssl = None
-
-    if not getattr(ssl, "HAS_SNI", False):
-        from urllib3.contrib import pyopenssl
-        pyopenssl.inject_into_urllib3()
-
-        # Check cryptography version
-        from cryptography import __version__ as cryptography_version
-        _check_cryptography(cryptography_version)
-except ImportError:
-    pass
 
 # urllib3's DependencyWarnings should be silenced.
 from urllib3.exceptions import DependencyWarning

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=test_requirements,
     extras_require={
-        'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
     },


### PR DESCRIPTION
Monkey patching url3 with pyopenssl 3 is no longer a good idea nor even necessary, and actually has security drawbacks, as described in #5267.

This also undoes the changes I initially made in #1347, so I guess it means my previous contribution has completed its life cycle.