### PR TITLE
Replace deprecated `setup.py test` with tox entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,31 +7,9 @@ import sys
 from codecs import open
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass into py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        try:
-            from multiprocessing import cpu_count
-            self.pytest_args = ['-n', str(cpu_count()), '--boxed']
-        except (ImportError, NotImplementedError):
-            self.pytest_args = ['-n', '1', '--boxed']
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 # 'setup.py publish' shortcut.
 if sys.argv[-1] == 'publish':
@@ -47,14 +25,6 @@ requires = [
     'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
     'certifi>=2017.4.17'
 
-]
-test_requirements = [
-    'pytest-httpbin==0.0.7',
-    'pytest-cov',
-    'pytest-mock',
-    'pytest-xdist',
-    'PySocks>=1.5.6, !=1.5.7',
-    'pytest>=3'
 ]
 
 about = {}
@@ -99,8 +69,6 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
-    cmdclass={'test': PyTest},
-    tests_require=test_requirements,
     extras_require={
         'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,12 @@
 envlist = py27,py35,py36,py37,py38
 
 [testenv]
-
+deps =
+    pytest-httpbin==0.0.7
+    pytest-cov
+    pytest-mock
+    pytest-xdist
+    PySocks>=1.5.6, !=1.5.7
+    pytest>=3
 commands =
-    python setup.py test
+    pytest -n auto --boxed {posargs}


### PR DESCRIPTION
The seuptools test command has been formally deprecated since version
41.5.0 (27 Oct 2019). The project recommends replacing its use with tox
as a project level testing entrypoint.

Fixes the warning when running tests:

> WARNING: Testing via this command is deprecated and will be removed in
> a future version. Users looking for a generic test entry point
> independent of test runner are encouraged to use tox.

For more details, see the setuptools history:
https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0

And the command's documentation:
https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite