### PR TITLE
Allow further configuration of HTTPAdapter's PoolManager by passing pool_kwargs dict

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -99,6 +99,7 @@ class HTTPAdapter(BaseAdapter):
         which we retry a request, import urllib3's ``Retry`` class and pass
         that instead.
     :param pool_block: Whether the connection pool should block for connections.
+    :param pool_kwargs: Extra keyword arguments used to initialize the urllib3 Pool Manager.
 
     Usage::
 
@@ -112,7 +113,7 @@ class HTTPAdapter(BaseAdapter):
 
     def __init__(self, pool_connections=DEFAULT_POOLSIZE,
                  pool_maxsize=DEFAULT_POOLSIZE, max_retries=DEFAULT_RETRIES,
-                 pool_block=DEFAULT_POOLBLOCK):
+                 pool_block=DEFAULT_POOLBLOCK, **pool_kwargs):
         if max_retries == DEFAULT_RETRIES:
             self.max_retries = Retry(0, read=False)
         else:
@@ -126,7 +127,7 @@ class HTTPAdapter(BaseAdapter):
         self._pool_maxsize = pool_maxsize
         self._pool_block = pool_block
 
-        self.init_poolmanager(pool_connections, pool_maxsize, block=pool_block)
+        self.init_poolmanager(pool_connections, pool_maxsize, block=pool_block, **pool_kwargs)
 
     def __getstate__(self):
         return {attr: getattr(self, attr, None) for attr in self.__attrs__}


### PR DESCRIPTION
There are various useful configurations of underlying urllib3 PoolManager not supported by the existing  HTTPAdapter, such as a global timeout, source_address, and many more https://github.com/urllib3/urllib3/blob/29b214a129883301f91ae4a74fd7ef2958cbf7b0/src/urllib3/poolmanager.py#L49-L75

It is trivial to support them directly. The construction of the HTTPAdapter's poolmanager at `HTTPAdapter.init_poolmanager(..., **pool_kwargs)` already contains this provision as the arbitrary `pool_kwargs` dict that is passed to the PoolManager constructor. All it takes is to also add this to the HTTPAdapter constructor, and pass it.

It also appears that this was the original intention that was somehow forgotten; this `**pool_kwargs` argument is not being passed by any caller of `init_poolmanager()`.