### PR TITLE
Prefer Transfer-Encoding=chunked even if both Transfer-Encoding and Content-Length are set

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -417,7 +417,7 @@ class HTTPAdapter(BaseAdapter):
         url = self.request_url(request, proxies)
         self.add_headers(request, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
 
-        chunked = not (request.body is None or 'Content-Length' in request.headers)
+        chunked = request.body is not None and request.headers.get('Transfer-Encoding') == 'chunked'
 
         if isinstance(timeout, tuple):
             try:


### PR DESCRIPTION
RFC 7230 says (see section [3.3.3 Message Body Length](https://tools.ietf.org/html/rfc7230#page-32)):

> If a message is received with both a `Transfer-Encoding` and a `Content-Length` header field, the `Transfer-Encoding` overrides the `Content-Length`.

Since HTTP servers MUST ignore `Content-Length` if `Transfer-Encoding` is sent, **python-requests** MUST follow the same logic and send payload using `chunked` approach if both are detected in among request headers.

Normally, `Content-Length` MUST NOT be sent in the same request with `Trasnfer-Encoding`, however, it may happened both intentionally (e.g. malicious intent) and accidentally (e.g. proxying a request downstream).