### PR TITLE
V2.24.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ Release History
 dev
 ---
 
+-   \[Short description of non-trivial change.\]
+
+2.24.0 (2020-06-17)
+-------------------
+
 **Improvements**
 
 - pyOpenSSL TLS implementation is now only used if Python
@@ -12,6 +17,11 @@ dev
   This applies even if pyOpenSSL is installed via the
   `requests[security]` extra (#5443)
 
+- Redirect resolution should now only occur when
+  `allow_redirects` is True. (#5492)
+
+- No longer perform unnecessary Content-Length calculation for
+  requests that won't use it. (#5496)
 
 2.23.0 (2020-02-19)
 -------------------

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ by <a href="https://kennethreitz.org/">Kenneth Reitz</a> & is protected by The <
 
 <p>&nbsp;</p>
 
-```pycon
+```python
 >>> import requests
 >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
 >>> r.status_code
@@ -52,7 +52,7 @@ by <a href="https://kennethreitz.org/">Kenneth Reitz</a> & is protected by The <
 Requests allows you to send HTTP/1.1 requests extremely easily. There’s no need to manually add query strings to your URLs, or to form-encode your `PUT` & `POST` data — but nowadays, just use the `json` method!
 
 
-Requests is **the most downloaded Python package today**, pulling in around `14M downloads / week`— according to GitHub, Requests is currently [depended upon](https://github.com/psf/requests/network/dependents?package_id=UGFja2FnZS01NzA4OTExNg%3D%3D) by `500,000+` repositories. You may certainly put your trust in this code.
+Requests is one of the most downloaded Python package today, pulling in around `14M downloads / week`— according to GitHub, Requests is currently [depended upon](https://github.com/psf/requests/network/dependents?package_id=UGFja2FnZS01NzA4OTExNg%3D%3D) by `500,000+` repositories. You may certainly put your trust in this code.
 
 
 <p>&nbsp;</p>

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.23.0'
-__build__ = 0x022300
+__version__ = '2.24.0'
+__build__ = 0x022400
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
2.24.0 (2020-06-17)
-------------------

**Improvements**

- pyOpenSSL TLS implementation is now only used if Python either doesn't have an `ssl` module or doesn't support SNI. Previously pyOpenSSL was unconditionally used if available. This applies even if pyOpenSSL is installed via the `requests[security]` extra (#5443)

- Redirect resolution should now only occur when `allow_redirects` is True. (#5492)

- No longer perform unnecessary Content-Length calculation for requests that won't use it. (#5496)