### PR TITLE
Docs: list CURL_CA_BUNDLE as supported

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -237,7 +237,8 @@ or persistent::
 .. note:: If ``verify`` is set to a path to a directory, the directory must have been processed using
   the c_rehash utility supplied with OpenSSL.
 
-This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` or ``CURL_CA_BUNDLE`` environment variables.
+This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` environment variable.
+If ``REQUESTS_CA_BUNDLE`` is not set, ``CURL_CA_BUNDLE`` can be used as fallback.
 
 Requests can also ignore verifying the SSL certificate if you set ``verify`` to False::
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -237,7 +237,7 @@ or persistent::
 .. note:: If ``verify`` is set to a path to a directory, the directory must have been processed using
   the c_rehash utility supplied with OpenSSL.
 
-This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` environment variable.
+This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` or ``CURL_CA_BUNDLE`` environment variables.
 
 Requests can also ignore verifying the SSL certificate if you set ``verify`` to False::
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -236,7 +236,7 @@ or persistent::
   the c_rehash utility supplied with OpenSSL.
 
 This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` environment variable.
-If ``REQUESTS_CA_BUNDLE`` is not set, ``CURL_CA_BUNDLE`` can be used as fallback.
+If ``REQUESTS_CA_BUNDLE`` is not set, ``CURL_CA_BUNDLE`` will be used as fallback.
 
 Requests can also ignore verifying the SSL certificate if you set ``verify`` to False::
 


### PR DESCRIPTION
https://github.com/psf/requests/blob/2b3436e0e7831676044b57f6f2cc9eb7c188293e/requests/sessions.py#L707 supports `CURL_CA_BUNDLE` too so lets list it in docs.