### PR TITLE
Removing extra documentation parameter json when undefined

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -125,7 +125,6 @@ def put(url, data=None, **kwargs):
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
@@ -140,7 +139,6 @@ def patch(url, data=None, **kwargs):
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response


### PR DESCRIPTION
On the functions `put` and `patch` the parameter `json` is not defined as function parameter but it is on the docstring.
This commit is to remove the extra lines from the docstring. 
The json parameter can be passed on the kwargs but never as positional parameter as it would be following the current docstring.  