### PR TITLE
Fix Reitz's GitHub handle in docs

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -45,7 +45,7 @@
 <h3>Stay Informed</h3>
 <p>Receive updates on new releases and upcoming projects.</p>
 
-<p><iframe src="https://ghbtns.com/github-btn.html?user=kennethreitz&type=follow&count=false" allowtransparency="true"
+<p><iframe src="https://ghbtns.com/github-btn.html?user=ken-reitz&type=follow&count=false" allowtransparency="true"
     frameborder="0" scrolling="0" width="200" height="20"></iframe></p>
 
 <h3>Useful Links</h3>


### PR DESCRIPTION
Currently it links to some account created in April 21 2020, so I'm taking a wild guess that it isn't intentional.