### PR TITLE
Update index.rst to mention support Python 3.5+

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.7 & 3.4–3.7, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.5+, and runs great on PyPy.
 
 
 The User Guide


### PR DESCRIPTION
The [README](https://github.com/psf/requests/blob/master/README.md) and [FAQ](https://github.com/psf/requests/blob/master/docs/community/faq.rst) mentions that it supports Python 3.5+. But, the `docs/index.rst` still mentions that the support is only for Python 3.4–3.7 which is misleading and is not consistent with other docs.

This PR is for the update of misleading text about python support and make it consistent with README and FAQ.