### PR TITLE
Update kens github

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,7 +8,7 @@ Keepers of the Crystals
 
 Previous Keepers of Crystals
 ````````````````````````````
-- Kenneth Reitz <me@kennethreitz.org> `@kennethreitz <https://github.com/kennethreitz>`_, reluctant Keeper of the Master Crystal.
+- Kenneth Reitz <me@kennethreitz.org> `@ken-reitz <https://github.com/ken-reitz>`_, reluctant Keeper of the Master Crystal.
 - Cory Benfield <cory@lukasa.co.uk> `@lukasa <https://github.com/lukasa>`_
 - Ian Cordasco <graffatcolmingov@gmail.com> `@sigmavirus24 <https://github.com/sigmavirus24>`_.
 


### PR DESCRIPTION
His website points to https://github.com/ken-reitz, kennethreitz seems to be trolling account (there is Islamophobic profile picture )


![image](https://user-images.githubusercontent.com/193832/92941329-8722fe80-f450-11ea-9ee6-86e55957b21d.png)
