### PR TITLE
Fix no_proxy and no, not being respected. Merge self.proxies and proxies

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -713,7 +713,7 @@ class Session(SessionRedirectMixin):
         :rtype: dict
         """
         # Gather clues from the surrounding environment.
-        bypass_proxy = False
+        bypass_proxies = False
         if self.trust_env:
             # Set environment's proxies.
             no_proxy = proxies.get('no_proxy') if proxies is not None else None
@@ -727,7 +727,7 @@ class Session(SessionRedirectMixin):
             if any([no_proxy,no]):
                 no_proxy = ','.join(filter(None, (no_proxy, no)))
             if should_bypass_proxies(url, no_proxy):
-              bypass_proxy = True
+              bypass_proxies = True
 
             # Look for requests environment configuration and be compatible
             # with cURL.
@@ -736,7 +736,7 @@ class Session(SessionRedirectMixin):
                           os.environ.get('CURL_CA_BUNDLE'))
 
         # Merge all the kwargs.
-        if bypass_proxy:
+        if bypass_proxies:
             proxies = {}
         else:
             proxies = merge_setting(proxies, self.proxies)

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -721,19 +721,19 @@ class Session(SessionRedirectMixin):
             for (k, v) in env_proxies.items():
                 proxies.setdefault(k, v)
 
-            # Check for no_proxy and no since they could be loaded from environment
-            no_proxy = proxies.get('no_proxy') if proxies is not None else None
-            no = proxies.get('no') if proxies is not None else None
-            if any([no_proxy,no]):
-                no_proxy = ','.join(filter(None, (no_proxy, no)))
-            if should_bypass_proxies(url, no_proxy):
-              bypass_proxies = True
-
             # Look for requests environment configuration and be compatible
             # with cURL.
             if verify is True or verify is None:
                 verify = (os.environ.get('REQUESTS_CA_BUNDLE') or
                           os.environ.get('CURL_CA_BUNDLE'))
+
+        # Check for no_proxy and no since they could be loaded from environment
+        no_proxy = proxies.get('no_proxy') if proxies is not None else None
+        no = proxies.get('no') if proxies is not None else None
+        if any([no_proxy, no]):
+            no_proxy = ','.join(filter(None, (no_proxy, no)))
+        if should_bypass_proxies(url, no_proxy):
+            bypass_proxy = True
 
         # Merge all the kwargs.
         if bypass_proxies:


### PR DESCRIPTION
Since no_proxy is not working as intended, I tried fixing it with least intrsion into whole process.
It is contained to the `merge_environment_settings` and `request` function. In the `request` the proxy from request and proxy from session are merged. Having the request proxy overwrite the session proxy where needed.

The  `should_bypass_proxies` is applied outside `get_environ_proxies` in `merge_environment_settings`, since `no_proxy` is only applied to OS ENV and not the proxies set in `requests` or `Sessions`

Should close #4871, I hope.