### PR TITLE
v2.25.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,24 @@ dev
 
 -   \[Short description of non-trivial change.\]
 
+
+2.25.0 (2020-11-11)
+------------------
+
+**Improvements**
+
+- Added support for NETRC environment variable. (#5643)
+
+**Dependencies**
+
+- Requests now supports urllib3 v1.26.
+
+**Deprecations**
+
+- Requests v2.25.x will be the last release series with support for Python 3.5.
+- The `requests[security]` extra is officially deprecated and will be removed
+  in Requests v2.26.0.
+
 2.24.0 (2020-06-17)
 -------------------
 

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, <= 1.25
+    # urllib3 >= 1.21.1, <= 1.26
     assert major == 1
     assert minor >= 21
-    assert minor <= 25
+    assert minor <= 26
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.24.0'
-__build__ = 0x022400
+__version__ = '2.25.0'
+__build__ = 0x022500
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ packages = ['requests']
 requires = [
     'chardet>=3.0.2,<4',
     'idna>=2.5,<3',
-    'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
+    'urllib3>=1.21.1,<1.27',
     'certifi>=2017.4.17'
 
 ]
@@ -74,7 +74,7 @@ setup(
     author_email=about['__author_email__'],
     url=about['__url__'],
     packages=packages,
-    package_data={'': ['LICENSE', 'NOTICE'], 'requests': ['*.pem']},
+    package_data={'': ['LICENSE', 'NOTICE']},
     package_dir={'requests': 'requests'},
     include_package_data=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
@@ -94,6 +94,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
This is getting staged for a release this week to stay in sync with urllib3. This release should also resolve the outstanding doc issues with Requests on pypi (#5501).

2.25.0 (2020-11-11)
------------------

**Improvements**

- Added support for NETRC environment variable. (#5643)

**Dependencies**

- Requests now supports urllib3 v1.26.

**Deprecations**

- Requests v2.25.x will be the last release series with support for Python 3.5.
- The `requests[security]` extra is officially deprecated and will be removed
  in Requests v2.26.0.