### PR TITLE
Improve the Session.request() documentation

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -498,8 +498,9 @@ class Session(SessionRedirectMixin):
         :type allow_redirects: bool
         :param proxies: (optional) Dictionary mapping protocol or protocol and
             hostname to the URL of the proxy.
-        :param stream: (optional) whether to immediately download the response
-            content. Defaults to ``False``.
+        :param stream: (optional) Whether to defer downloading the response
+            body until you access the :meth:`Response.content` attribute.
+            Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use. Defaults to ``True``. When set to


### PR DESCRIPTION
This PR improves the documentation of the `Session.request()` method. Its `stream` parameter's description used to have remnants of the old `prefetch` parameter (from PR #1283), which are now rephrased slightly.

The new sentence is the same as that in the [Body Content Worklflow](https://requests.readthedocs.io/en/latest/user/advanced/#body-content-workflow) section of the documentation.