### PR TITLE
Remove the deprecated security extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=test_requirements,
     extras_require={
-        'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
     },


### PR DESCRIPTION
> The requests[security] extra is officially deprecated and will be removed in Requests v2.26.0.

https://requests.readthedocs.io/en/latest/community/updates/