### PR TITLE
Pin GHA to Ubuntu 18.04

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy3 on Mac OS currently fails trying to compile
           # brotlipy. Moving pypy3 to only test linux.


### PR DESCRIPTION
Fixes https://github.com/psf/requests/issues/5662. 

`ubuntu-latest` points to 18.04 and will soon flip to 20.04.

However tests currently fail on 20.04, so let's explicitly pin to 18.04 for now.