### PR TITLE
Use urllib for chunked requests (Resubmit)

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -456,6 +456,10 @@ class HTTPAdapter(BaseAdapter):
 
                 low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
 
+                if hasattr(conn, 'proxy'):
+                    if conn.proxy is not None and not getattr(low_conn, 'sock', None):
+                        conn._prepare_proxy(low_conn)
+
                 try:
                     low_conn.putrequest(request.method,
                                         url,

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -435,68 +435,19 @@ class HTTPAdapter(BaseAdapter):
             timeout = TimeoutSauce(connect=timeout, read=timeout)
 
         try:
-            if not chunked:
-                resp = conn.urlopen(
-                    method=request.method,
-                    url=url,
-                    body=request.body,
-                    headers=request.headers,
-                    redirect=False,
-                    assert_same_host=False,
-                    preload_content=False,
-                    decode_content=False,
-                    retries=self.max_retries,
-                    timeout=timeout
-                )
-
-            # Send the request.
-            else:
-                if hasattr(conn, 'proxy_pool'):
-                    conn = conn.proxy_pool
-
-                low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
-
-                if hasattr(conn, 'proxy'):
-                    if conn.proxy is not None and not getattr(low_conn, 'sock', None):
-                        conn._prepare_proxy(low_conn)
-
-                try:
-                    low_conn.putrequest(request.method,
-                                        url,
-                                        skip_accept_encoding=True)
-
-                    for header, value in request.headers.items():
-                        low_conn.putheader(header, value)
-
-                    low_conn.endheaders()
-
-                    for i in request.body:
-                        low_conn.send(hex(len(i))[2:].encode('utf-8'))
-                        low_conn.send(b'\r\n')
-                        low_conn.send(i)
-                        low_conn.send(b'\r\n')
-                    low_conn.send(b'0\r\n\r\n')
-
-                    # Receive the response from the server
-                    try:
-                        # For Python 2.7, use buffering of HTTP responses
-                        r = low_conn.getresponse(buffering=True)
-                    except TypeError:
-                        # For compatibility with Python 3.3+
-                        r = low_conn.getresponse()
-
-                    resp = HTTPResponse.from_httplib(
-                        r,
-                        pool=conn,
-                        connection=low_conn,
-                        preload_content=False,
-                        decode_content=False
-                    )
-                except:
-                    # If we hit any problems here, clean up the connection.
-                    # Then, reraise so that we can handle the actual exception.
-                    low_conn.close()
-                    raise
+            resp = conn.urlopen(
+                method=request.method,
+                url=url,
+                body=request.body,
+                headers=request.headers,
+                redirect=False,
+                assert_same_host=False,
+                preload_content=False,
+                decode_content=False,
+                retries=self.max_retries,
+                timeout=timeout,
+                chunked=chunked
+            )
 
         except (ProtocolError, socket.error) as err:
             raise ConnectionError(err, request=request)


### PR DESCRIPTION
This is a resubmit of Use urllib for chunked requests #5128 which was merged and then pulled without warning.

"Resubmit of #4958 with up to date merge. Also addresses #4179.

Specifically, in my use case, chunked requests when a proxy is in use results in failure to evaluate the proxy configuration and the request being sent direct. It appears that urllib3 supports chunking as an option so this fork to lower level urllib3 code seems to no longer be required."

[](https://github.com/psf/requests/pull/5128)
