### PR TITLE
Add support for HTTPS proxies.

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -38,6 +38,7 @@ def request(method, url, **kwargs):
     :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
+    :param proxies_kwargs: (optional) Dictionary with additional proxy kwargs.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use. Defaults to ``True``.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -470,7 +470,8 @@ class Session(SessionRedirectMixin):
     def request(self, method, url,
             params=None, data=None, headers=None, cookies=None, files=None,
             auth=None, timeout=None, allow_redirects=True, proxies=None,
-            hooks=None, stream=None, verify=None, cert=None, json=None):
+                proxies_kwargs=None, hooks=None, stream=None, verify=None,
+                cert=None, json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it.
         Returns :class:`Response <Response>` object.
 
@@ -498,6 +499,7 @@ class Session(SessionRedirectMixin):
         :type allow_redirects: bool
         :param proxies: (optional) Dictionary mapping protocol or protocol and
             hostname to the URL of the proxy.
+        :param proxies_kwargs: (optional) Dictionary with additional proxy kwargs.
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
@@ -537,6 +539,7 @@ class Session(SessionRedirectMixin):
         send_kwargs = {
             'timeout': timeout,
             'allow_redirects': allow_redirects,
+            'proxies_kwargs': proxies_kwargs,
         }
         send_kwargs.update(settings)
         resp = self.send(prep, **send_kwargs)


### PR DESCRIPTION
Starting with 1.26 urllib3 now supports HTTPS proxies. To enable the support two changes are needed:

* An additional proxy_kwargs argument that can be passed from client config. This dictionary will be used to pass any arguments needed to the underlying httpsession.
* The use_forwarding_for_https mode requires us to send the absolute URI when enabled.

The resulting API is very similar except it takes an additional parameter when needed. An example:

```
    session = requests.Session()
    proxies = {"http": "https://proxy.example", "https": "https://proxy.example"}

    proxies_kwargs = {
        "proxy_ssl_context": proxy_ssl_context(),
    }

    response = session.get(
       "https://www.google.com", proxies=proxies, proxies_kwargs=proxies_kwargs
    )
```
