### PR TITLE
Fix broken link to Kenneth Rietz page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Requests"
-copyright = u'MMXVIX. A <a href="http://kennethreitz.com/pages/open-projects.html">Kenneth Reitz</a> Project'
+copyright = u'MMXVIX. A <a href="https://kenreitz.org/projects">Kenneth Reitz</a> Project'
 author = u"Kenneth Reitz"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
The link to Kenneth Reitz page seems to be broken now.
Fix it by using a currently active link.