### PR TITLE
updated `get_encoding_from_headers` to return utf-8 if the content type is set to application/json

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -503,6 +503,10 @@ def get_encoding_from_headers(headers):
     if 'text' in content_type:
         return 'ISO-8859-1'
 
+    if 'application/json' in content_type:
+        # Assume UTF-8 based on RFC 4627: https://www.ietf.org/rfc/rfc4627.txt since the charset was unset
+        return 'utf-8'
+
 
 def stream_decode_response_unicode(iterator, r):
     """Stream decodes a iterator."""


### PR DESCRIPTION
This PR fixes #5667 by adding a small bit of code to `get_encoding_from_headers` that returns `utf-8` if the content type is set to `application/json` and `charset` is not set. This follows [RFC 4627](https://www.ietf.org/rfc/rfc4627.txt) (ctrl+f for `shall be`) which reads: "JSON text SHALL be encoded in Unicode.  The default encoding is UTF-8."