### PR TITLE
5677: Rebuild proxies on Session#send

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -633,7 +633,7 @@ class Session(SessionRedirectMixin):
         kwargs.setdefault('stream', self.stream)
         kwargs.setdefault('verify', self.verify)
         kwargs.setdefault('cert', self.cert)
-        kwargs.setdefault('proxies', self.proxies)
+        kwargs.setdefault('proxies', self.rebuild_proxies(request, self.proxies))
 
         # It's possible that users might accidentally send a Request object.
         # Guard against that specific failure case.


### PR DESCRIPTION
- Adds some test cases to highlight the issue, some of those seem excessive, I would like suggestions on how to combine them.
- Rebuilds the proxy configuration on `send`, making it behave like `requests.Session#request` that already did that.  
