### PR TITLE
Bump chardet to 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if sys.argv[-1] == 'publish':
 packages = ['requests']
 
 requires = [
-    'chardet>=3.0.2,<4',
+    'chardet>=4.0.0,<5',
     'idna>=2.5,<3',
     'urllib3>=1.21.1,<1.27',
     'certifi>=2017.4.17'


### PR DESCRIPTION
Bump chardet version to >=4.0.0,<5 

Chardets 4.0.0 release notes: https://github.com/chardet/chardet/releases/tag/4.0.0