### PR TITLE
v2.25.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,17 @@ dev
 
 -   \[Short description of non-trivial change.\]
 
+2.25.1 (2020-12-16)
+-------------------
+
+**Bugfixes**
+
+- Requests now treats `application/json` as `utf8` by default. Resolving
+  inconsistencies between `r.text` and `r.json` output. (#5673)
+
+**Dependencies**
+
+- Requests now supports chardet v4.x.
 
 2.25.0 (2020-11-11)
 ------------------

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.25.0'
-__build__ = 0x022500
+__version__ = '2.25.1'
+__build__ = 0x022501
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
2.25.1 (2020-12-16)
-------------------

**Bugfixes**

- Requests now treats `application/json` as `utf8` by default. Resolving
  inconsistencies between `r.text` and `r.json` output. (#5673)

**Dependencies**

- Requests now supports chardet v4.x.