### PR TITLE
Document that the timeout can be an int

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -65,9 +65,9 @@ class BaseAdapter(object):
         :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
         :param stream: (optional) Whether to stream the request content.
         :param timeout: (optional) How long to wait for the server to send
-            data before giving up, as a float, or a :ref:`(connect timeout,
+            data before giving up, as an int, a float, or a :ref:`(connect timeout,
             read timeout) <timeouts>` tuple.
-        :type timeout: float or tuple
+        :type timeout: int or float or tuple
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
             to a CA bundle to use
@@ -397,9 +397,9 @@ class HTTPAdapter(BaseAdapter):
         :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
         :param stream: (optional) Whether to stream the request content.
         :param timeout: (optional) How long to wait for the server to send
-            data before giving up, as a float, or a :ref:`(connect timeout,
+            data before giving up, as an int, a float, or a :ref:`(connect timeout,
             read timeout) <timeouts>` tuple.
-        :type timeout: float or tuple or urllib3 Timeout object
+        :type timeout: int or float or tuple or urllib3 Timeout object
         :param verify: (optional) Either a boolean, in which case it controls whether
             we verify the server's TLS certificate, or a string, in which case it
             must be a path to a CA bundle to use

--- a/requests/api.py
+++ b/requests/api.py
@@ -32,9 +32,9 @@ def request(method, url, **kwargs):
         to add for the file.
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How many seconds to wait for the server to send data
-        before giving up, as a float, or a :ref:`(connect timeout, read
+        before giving up, as an int, a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
-    :type timeout: float or tuple
+    :type timeout: int or float or tuple
     :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -491,9 +491,9 @@ class Session(SessionRedirectMixin):
         :param auth: (optional) Auth tuple or callable to enable
             Basic/Digest/Custom HTTP Auth.
         :param timeout: (optional) How long to wait for the server to send
-            data before giving up, as a float, or a :ref:`(connect timeout,
+            data before giving up, as an int, a float, or a :ref:`(connect timeout,
             read timeout) <timeouts>` tuple.
-        :type timeout: float or tuple
+        :type timeout: int or float or tuple
         :param allow_redirects: (optional) Set to True by default.
         :type allow_redirects: bool
         :param proxies: (optional) Dictionary mapping protocol or protocol and


### PR DESCRIPTION
Requests simply delegates to `urllib3.util.Timeout`, and urllib3 has of course supported ints for a very long time – at least Sept 2013 per the docstring changes, but likely much longer than that. The [timeout section in the advanced docs](https://github.com/psf/requests/blob/c2b307dbefe21177af03f9feb37181a89a799fcc/docs/user/advanced.rst#timeouts) actually has an example that uses an int, but the API docs (via function docstrings) don't mention this so far.