### PR TITLE
Don't perform authentication if no credential provided

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -101,7 +101,7 @@ class HTTPBasicAuth(AuthBase):
         # Only perform authentication if username or password was provided, or both
         if self.username is not None or self.password is not None:
             r.headers['Authorization'] = _basic_auth_str(self.username, self.password)
-            return r
+        return r
 
 
 class HTTPProxyAuth(HTTPBasicAuth):
@@ -111,7 +111,7 @@ class HTTPProxyAuth(HTTPBasicAuth):
         # Only perform authentication if username or password was provided, or both
         if self.username is not None or self.password is not None:
             r.headers['Proxy-Authorization'] = _basic_auth_str(self.username, self.password)
-            return r
+        return r
 
 
 class HTTPDigestAuth(AuthBase):
@@ -287,7 +287,7 @@ class HTTPDigestAuth(AuthBase):
     def __call__(self, r):
         # If no credential was provided, ignore
         if self.username is None and self.password is None:
-            return
+            return r
         # Initialize per-thread state, if needed
         self.init_per_thread_state()
         # If we had a saved nonce, skip the 401

--- a/requests/auth.py
+++ b/requests/auth.py
@@ -80,8 +80,11 @@ class HTTPBasicAuth(AuthBase):
     """Attaches HTTP Basic Authentication to the given Request object."""
 
     def __init__(self, username, password):
-        self.username = username
-        self.password = password
+        self.auth = True
+        self.username = '' if username is None else username
+        self.password = '' if password is None else password
+        if username is None and password is None:
+            self.auth = False
 
     def __eq__(self, other):
         return all([
@@ -93,8 +96,9 @@ class HTTPBasicAuth(AuthBase):
         return not self == other
 
     def __call__(self, r):
-        r.headers['Authorization'] = _basic_auth_str(self.username, self.password)
-        return r
+        if self.auth:
+            r.headers['Authorization'] = _basic_auth_str(self.username, self.password)
+            return r
 
 
 class HTTPProxyAuth(HTTPBasicAuth):


### PR DESCRIPTION
## The old behavior:

```python
>>> requests.get('http://127.0.0.1:8080', auth=(None, None))
```

```http
GET / HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: python-requests/2.25.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Authorization: Basic Tm9uZTpOb25l (None:None)
```

The same thing will happen with:

```python
>>> requests.get('http://127.0.0.1:8080', auth=('None', 'None'))
```

This is weird, right!

## Now:
```python
>>> requests.get('http://127.0.0.1:8080', auth=(None, None))
```

```http
GET / HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: python-requests/2.25.0
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
```
(No authentication)

This will be easier if the application allows auth username and password from arguments:

```python
response = self.session.request(
                    self.httpmethod,
                    url,
                    data=self.data,
                    proxies=proxy,
                    verify=False,
                    allow_redirects=self.redirect,
                    headers=dict(self.headers),
                    timeout=self.timeout,
                    auth=(self.user, self.pass)
                )
```

If the user didn't provide credentials, which means they don't need to authenticate, then `self.user == None` and `self.pass == None`. And in this situation, `requests` with my update won't perform authentication!

In the old version (without my update), it will be like:

```python
if self.user and self.pass:
    response = self.session.request(
                        self.httpmethod,
                        url,
                        data=self.data,
                        proxies=proxy,
                        verify=False,
                        allow_redirects=self.redirect,
                        headers=dict(self.headers),
                        timeout=self.timeout,
                        auth=(self.user, self.pass)
                    )
else:
    response = self.session.request(
                        self.httpmethod,
                        url,
                        data=self.data,
                        proxies=proxy,
                        verify=False,
                        allow_redirects=self.redirect,
                        headers=dict(self.headers),
                        timeout=self.timeout
                    )
```