### PR TITLE
Add json arguments to .put and .patch

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -119,7 +119,7 @@ def post(url, data=None, json=None, **kwargs):
     return request('post', url, data=data, json=json, **kwargs)
 
 
-def put(url, data=None, **kwargs):
+def put(url, data=None, json=None, **kwargs):
     r"""Sends a PUT request.
 
     :param url: URL for the new :class:`Request` object.
@@ -131,10 +131,10 @@ def put(url, data=None, **kwargs):
     :rtype: requests.Response
     """
 
-    return request('put', url, data=data, **kwargs)
+    return request('put', url, data=data, json=json, **kwargs)
 
 
-def patch(url, data=None, **kwargs):
+def patch(url, data=None, json=None, **kwargs):
     r"""Sends a PATCH request.
 
     :param url: URL for the new :class:`Request` object.
@@ -146,7 +146,7 @@ def patch(url, data=None, **kwargs):
     :rtype: requests.Response
     """
 
-    return request('patch', url, data=data, **kwargs)
+    return request('patch', url, data=data, json=json, **kwargs)
 
 
 def delete(url, **kwargs):


### PR DESCRIPTION
This PR adds the `json` argument to both the `put` and `patch` function definitions. This is to bring them into agreement with the docstring of each function and to mirror the definition of `post`.
This should not change any functionally as the `json` arg would be captured by the `**kwargs` expansion. 

Obviously, if this difference was intentional, feel free to close without merging. Alternatively, if you prefer I can quickly put together a pr to update the docstring. It was just something that briefly tripped me up and I figured it was quick and easy to change.  