### PR TITLE
Make raise_for_status() chainable

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -941,6 +941,8 @@ class Response(object):
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)
+            
+        return self
 
     def close(self):
         """Releases the connection back to the pool. Once this method has been


### PR DESCRIPTION
Frequently, I find myself doing the following:
```python
r = requests.get(url)
r.raise_for_status()
json = r.json()
```

I thought it may be useful to be able to do the following instead, where `raise_for_status()` is chainable:
```python
r = requests.get(url)
json = r.raise_for_status().json()
```