### PR TITLE
To work just like normal browsers, default headers in  requests.api.get(), requests.api.request(), requests.models.Request.__init__() and requests.sessions.Session.request() are set

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -57,10 +57,28 @@ def request(method, url, **kwargs):
     # Use the default headers
     try:
         if headers is None:
-            headers = {
-                'User-Agent':
-                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+            if sys.platform.lower() == 'win32':
+                headers = {
+                    'User-Agent':
+                    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                    }
+            elif sys.platform.lower() == 'linux':
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
+            elif sys.platform.lower() == 'darwin':
+                headers = {
+                    'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8'
                 }
+            else:
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
     except NameError:
         pass
 
@@ -88,10 +106,28 @@ def get(url, params=None, **kwargs):
     # Use the default headers
     try:
         if headers is None:
-            headers = {
-                'User-Agent':
-                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+            if sys.platform.lower() == 'win32':
+                headers = {
+                    'User-Agent':
+                    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                    }
+            elif sys.platform.lower() == 'linux':
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
+            elif sys.platform.lower() == 'darwin':
+                headers = {
+                    'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8'
                 }
+            else:
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
     except NameError:
         pass
 

--- a/requests/api.py
+++ b/requests/api.py
@@ -54,6 +54,17 @@ def request(method, url, **kwargs):
       <Response [200]>
     """
 
+    # Use the default headers
+    try:
+        if headers is None:
+            headers = {
+                'User-Agent':
+                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                }
+    except NameError:
+        pass
+
+
     # By using the 'with' statement we are sure the session is closed, thus we
     # avoid leaving sockets open which can trigger a ResourceWarning in some
     # cases, and look like a memory leak in others.
@@ -73,6 +84,18 @@ def get(url, params=None, **kwargs):
     """
 
     kwargs.setdefault('allow_redirects', True)
+
+    # Use the default headers
+    try:
+        if headers is None:
+            headers = {
+                'User-Agent':
+                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                }
+    except NameError:
+        pass
+
+
     return request('get', url, params=params, **kwargs)
 
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -229,11 +229,28 @@ class Request(RequestHooksMixin):
 
         # Use the default headers if None is passed
         if headers is None:
-            headers = {
-                'User-Agent':
-                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+            if sys.platform.lower() == 'win32':
+                headers = {
+                    'User-Agent':
+                    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                    }
+            elif sys.platform.lower() == 'linux':
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
+            elif sys.platform.lower() == 'darwin':
+                headers = {
+                    'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8'
                 }
-
+            else:
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
 
         # Default empty dicts for dict params.
         data = [] if data is None else data

--- a/requests/models.py
+++ b/requests/models.py
@@ -227,6 +227,14 @@ class Request(RequestHooksMixin):
             method=None, url=None, headers=None, files=None, data=None,
             params=None, auth=None, cookies=None, hooks=None, json=None):
 
+        # Use the default headers if None is passed
+        if headers is None:
+            headers = {
+                'User-Agent':
+                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                }
+
+
         # Default empty dicts for dict params.
         data = [] if data is None else data
         files = [] if files is None else files

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -512,6 +512,15 @@ class Session(SessionRedirectMixin):
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response
         """
+
+        # Use the default headers if None is passed
+        if headers is None:
+            headers = {
+                'User-Agent':
+                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                }
+
+                
         # Create the Request.
         req = Request(
             method=method.upper(),

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -515,12 +515,30 @@ class Session(SessionRedirectMixin):
 
         # Use the default headers if None is passed
         if headers is None:
-            headers = {
-                'User-Agent':
-                'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+            if sys.platform.lower() == 'win32':
+                headers = {
+                    'User-Agent':
+                    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+                    }
+            elif sys.platform.lower() == 'linux':
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
+            elif sys.platform.lower() == 'darwin':
+                headers = {
+                    'User-Agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8'
                 }
+            else:
+                headers = {
+                    'User-Agent':
+                 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36',
+                 'Accept-Language': 'en-US, en;q=0.5'
+                 }
 
-                
+
         # Create the Request.
         req = Request(
             method=method.upper(),


### PR DESCRIPTION
The headers argument in `requests.api.get()`, `requests.api.request()`, `requests.models.Request.__init__()` and `requests.sessions.Session.request()` are set to a default dictionary value rather than NoneType Data Type to handle errors like 503 server error though the URL is correct. Some websites block webscrapers. To avoid being blocked, this default headers is very useful. This works in Mac OS X, Linux and Windows as of January 2020.

For example, https://www.amazon.com blocks Web-scrapers nowadays. Before this change, the returned response object's status code was always 503 though the website existed. 

![before](https://user-images.githubusercontent.com/74560907/105088248-a2b6a980-5ac1-11eb-9bcd-8b50717e7a31.png)

After this change, the returned response object's status code is always 200.

![after](https://user-images.githubusercontent.com/74560907/105088322-bcf08780-5ac1-11eb-9216-f566fa137d46.png)
