### PR TITLE
utils.py: default to utf-8 for text/csv (#5746)

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -507,6 +507,9 @@ def get_encoding_from_headers(headers):
         # Assume UTF-8 based on RFC 4627: https://www.ietf.org/rfc/rfc4627.txt since the charset was unset
         return 'utf-8'
 
+    if 'text/csv' in content_type:
+        # Assume UTF-8 based on RFC 7111: https://tools.ietf.org/html/rfc7111 since the charset was unset
+        return 'utf-8'
 
 def stream_decode_response_unicode(iterator, r):
     """Stream decodes a iterator."""


### PR DESCRIPTION
This is a super quick attempt to address https://github.com/psf/requests/issues/5746 -- an invitation for feedback. Would appreciate your opinions. Thanks!