### PR TITLE
enhance RequestEncodingMixin._encode_params to support complex dict struct when content-type is x-www-form-urlencoded

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -8,43 +8,46 @@ This module contains the primary objects that power Requests.
 """
 
 import datetime
-from io import UnsupportedOperation
+import sys
 
-from urllib3.exceptions import (
-    DecodeError, ReadTimeoutError, ProtocolError, LocationParseError)
+# Import encoding now, to avoid implicit import later.
+# Implicit import within threads may cause LookupError when standard library is in a ZIP,
+# such as in Embedded Python. See https://github.com/psf/requests/issues/3578.
+import encodings.idna
+
 from urllib3.fields import RequestField
 from urllib3.filepost import encode_multipart_formdata
 from urllib3.util import parse_url
+from urllib3.exceptions import (
+    DecodeError, ReadTimeoutError, ProtocolError, LocationParseError)
 
-from ._internal_utils import to_native_string, unicode_is_ascii
+from io import UnsupportedOperation
+from .hooks import default_hooks
+from .structures import CaseInsensitiveDict
+
 from .auth import HTTPBasicAuth
+from .cookies import cookiejar_from_dict, get_cookie_header, _copy_cookie_jar
+from .exceptions import (
+    HTTPError, MissingSchema, InvalidURL, ChunkedEncodingError,
+    ContentDecodingError, ConnectionError, StreamConsumedError)
+from ._internal_utils import to_native_string, unicode_is_ascii
+from .utils import (
+    guess_filename, get_auth_from_url, requote_uri,
+    stream_decode_response_unicode, to_key_val_list, parse_header_links,
+    iter_slices, guess_json_utf, super_len, check_header_validity, unfold_complex_data_key)
 from .compat import (
     Callable, Mapping,
     cookielib, urlunparse, urlsplit, urlencode, str, bytes,
     is_py2, chardet, builtin_str, basestring)
 from .compat import json as complexjson
-from .cookies import cookiejar_from_dict, get_cookie_header, _copy_cookie_jar
-from .exceptions import (
-    HTTPError, MissingSchema, InvalidURL, ChunkedEncodingError,
-    ContentDecodingError, ConnectionError, StreamConsumedError)
-from .hooks import default_hooks
 from .status_codes import codes
-from .structures import CaseInsensitiveDict
-from .utils import (
-    guess_filename, get_auth_from_url, requote_uri,
-    stream_decode_response_unicode, to_key_val_list, parse_header_links,
-    iter_slices, guess_json_utf, super_len, check_header_validity, unfold_complex_data_key)
-
-# Import encoding now, to avoid implicit import later.
-# Implicit import within threads may cause LookupError when standard library is in a ZIP,
-# such as in Embedded Python. See https://github.com/psf/requests/issues/3578.
 
 #: The set of HTTP status codes that indicate an automatically
 #: processable redirect.
 REDIRECT_STATI = (
-    codes.moved,  # 301
-    codes.found,  # 302
-    codes.other,  # 303
+    codes.moved,               # 301
+    codes.found,               # 302
+    codes.other,               # 303
     codes.temporary_redirect,  # 307
     codes.permanent_redirect,  # 308
 )
@@ -224,8 +227,9 @@ class Request(RequestHooksMixin):
     """
 
     def __init__(self,
-                 method=None, url=None, headers=None, files=None, data=None,
-                 params=None, auth=None, cookies=None, hooks=None, json=None):
+            method=None, url=None, headers=None, files=None, data=None,
+            params=None, auth=None, cookies=None, hooks=None, json=None):
+
         # Default empty dicts for dict params.
         data = [] if data is None else data
         files = [] if files is None else files
@@ -307,8 +311,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self._body_position = None
 
     def prepare(self,
-                method=None, url=None, headers=None, files=None, data=None,
-                params=None, auth=None, cookies=None, hooks=None, json=None):
+            method=None, url=None, headers=None, files=None, data=None,
+            params=None, auth=None, cookies=None, hooks=None, json=None):
         """Prepares the entire request with the given parameters."""
 
         self.prepare_method(method)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -21,24 +21,26 @@ import warnings
 import zipfile
 from collections import OrderedDict
 
-from . import certs
 from .__version__ import __version__
+from . import certs
 # to_native_string is unused here, but imported here for backwards compatibility
+from ._internal_utils import to_native_string
 from .compat import parse_http_list as _parse_list_header
 from .compat import (
     quote, urlparse, bytes, str, unquote, getproxies,
     proxy_bypass, urlunparse, basestring, integer_types, is_py3,
     proxy_bypass_environment, getproxies_environment, Mapping)
 from .cookies import cookiejar_from_dict
+from .structures import CaseInsensitiveDict
 from .exceptions import (
     InvalidURL, InvalidHeader, FileModeWarning, UnrewindableBodyError)
-from .structures import CaseInsensitiveDict
 
 NETRC_FILES = ('.netrc', '_netrc')
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
 DEFAULT_PORTS = {'http': 80, 'https': 443}
+
 
 if sys.platform == 'win32':
     # provide a proxy_bypass version on Windows without DNS lookups
@@ -54,10 +56,10 @@ if sys.platform == 'win32':
 
         try:
             internetSettings = winreg.OpenKey(winreg.HKEY_CURRENT_USER,
-                                              r'Software\Microsoft\Windows\CurrentVersion\Internet Settings')
+                r'Software\Microsoft\Windows\CurrentVersion\Internet Settings')
             # ProxyEnable could be REG_SZ or REG_DWORD, normalizing it
             proxyEnable = int(winreg.QueryValueEx(internetSettings,
-                                                  'ProxyEnable')[0])
+                                              'ProxyEnable')[0])
             # ProxyOverride is almost always a string
             proxyOverride = winreg.QueryValueEx(internetSettings,
                                                 'ProxyOverride')[0]
@@ -75,13 +77,12 @@ if sys.platform == 'win32':
             if test == '<local>':
                 if '.' not in host:
                     return True
-            test = test.replace(".", r"\.")  # mask dots
-            test = test.replace("*", r".*")  # change glob sequence
-            test = test.replace("?", r".")  # change glob char
+            test = test.replace(".", r"\.")     # mask dots
+            test = test.replace("*", r".*")     # change glob sequence
+            test = test.replace("?", r".")      # change glob char
             if re.match(test, host, re.I):
                 return True
         return False
-
 
     def proxy_bypass(host):  # noqa
         """Return True, if the host should be bypassed.
@@ -942,16 +943,16 @@ def guess_json_utf(data):
     # determine the encoding. Also detect a BOM, if present.
     sample = data[:4]
     if sample in (codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE):
-        return 'utf-32'  # BOM included
+        return 'utf-32'     # BOM included
     if sample[:3] == codecs.BOM_UTF8:
         return 'utf-8-sig'  # BOM included, MS style (discouraged)
     if sample[:2] in (codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE):
-        return 'utf-16'  # BOM included
+        return 'utf-16'     # BOM included
     nullcount = sample.count(_null)
     if nullcount == 0:
         return 'utf-8'
     if nullcount == 2:
-        if sample[::2] == _null2:  # 1st and 3rd are null
+        if sample[::2] == _null2:   # 1st and 3rd are null
             return 'utf-16-be'
         if sample[1::2] == _null2:  # 2nd and 4th are null
             return 'utf-16-le'

--- a/tests/test_encode_params.py
+++ b/tests/test_encode_params.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from requests.utils import unfold_complex_data_key
+
+
+def test_util_unfold_complex_data_key():
+    data = OrderedDict({
+        "id": "857-37-9333",
+        "label": u"周",
+        "count": 0,
+        "properties": {
+            "name": "Rich Hintz",
+            "city": "New Edythstad",
+            "gender": "male",
+            "age": 24,
+            "profile": [
+                "Zondy",
+                "ZTESoft",
+                "YunWen",
+                "Ci123"
+            ]
+        }
+    })
+
+    result = []
+    unfold_complex_data_key(None, data, result)
+    assert result.__str__() == "[('count', 0), ('properties[profile][0]', 'Zondy'), ('properties[profile][1]', 'ZTESoft'), ('properties[profile][2]', 'YunWen'), ('properties[profile][3]', 'Ci123'), ('properties[city]', 'New Edythstad'), ('properties[age]', 24), ('properties[name]', 'Rich Hintz'), ('properties[gender]', 'male'), ('id', '857-37-9333'), ('label', u'\u5468')]"


### PR DESCRIPTION
Add an util's method in `utils.py`, named `unfold_complex_data_key`, called by `RequestEncodingMixin._encode_params` to support complex dict struct when content-type is `x-www-form-urlencoded`.
The function unfold_complex_data_key just do the follow work:
Unfold complex dict which has deep level key or list to simple list[tuple]
when requests.post()'s pemeter data is 
`
 {
           "id": "857-37-9333",
           "label": "User",
           "count": 0,
           "properties": {
               "name": "Rich Hintz",
               "city": "New Edythstad",
               "gender": "male",
               "age": 24,
               "profile": [
                   "Zondy",
                   "ZTESoft",
                   "YunWen",
                   "Ci123"
               ]
           }
}
`
encoding the date to follow format:
`
[
        ('id','857-37-9333'),
        ('label','User'),
        ('count',0),
        ('properties[name]','Rich Hintz'),
        ('properties[city]','New Edythstad')
        ('properties[gender]','male'),
        ('properties[age]',24),
        ('properties[profile][0]','Zondy'),
        ('properties[profile][1]','ZTESoft'),
        ('properties[profile][2]','YunWen'),
        ('properties[profile][3]','Ci123'),
]
`