### PR TITLE
Provide directions for cloning repository despite malformed commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ Requests is ready for the demands of building robust and reliable HTTP–speakin
 
 [![Read the Docs](https://raw.githubusercontent.com/psf/requests/master/ext/ss.png)](https://requests.readthedocs.io)
 
+## Cloning the repository
+
+When cloning the Requests repository, you may need to add the `-c
+fetch.fsck.badTimezone=ignore` flag to avoid an error about a bad commit (see
+[this issue](https://github.com/psf/requests/issues/2690) for more background):
+
+```shell
+git clone -c fetch.fsck.badTimezone=ignore https://github.com/psf/requests.git
+```
+
+You can also apply this setting to your global Git config:
+
+```shell
+git config --global fetch.fsck.badTimezone ignore
+```
+
 ---
 
 [![Kenneth Reitz](https://raw.githubusercontent.com/psf/requests/master/ext/kr.png)](https://kennethreitz.org) [![Python Software Foundation](https://raw.githubusercontent.com/psf/requests/master/ext/psf.png)](https://www.python.org/psf)


### PR DESCRIPTION
Issues #2690, #3008, #3088, #3805 #4254 all refer to the issue with commit 5e6ecdad9f69b1ff789a17733b8edc6fd7091bd8 that cause Git to error out when cloning the repository. As originally discussed in #2690, this issue cannot be avoided without rewriting history, so why don't we instead include some helpful directions at the bottom of the README?