### PR TITLE
quickstart.rst: r.json() can raise JSONDecodeError on Py3

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -150,7 +150,9 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,
-attempting ``r.json()`` raises ``ValueError: No JSON object could be decoded``.
+attempting ``r.json()`` raises ``ValueError: No JSON object could be decoded`` on
+Python 2 and raises ``simplejson.JSONDecodeError`` or ``json.JSONDecodeError`` on
+Python 3.
 
 It should be noted that the success of the call to ``r.json()`` does **not**
 indicate the success of the response. Some servers may return a JSON object in a

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -150,9 +150,9 @@ There's also a builtin JSON decoder, in case you're dealing with JSON data::
 
 In case the JSON decoding fails, ``r.json()`` raises an exception. For example, if
 the response gets a 204 (No Content), or if the response contains invalid JSON,
-attempting ``r.json()`` raises ``ValueError: No JSON object could be decoded`` on
-Python 2 and raises ``simplejson.JSONDecodeError`` or ``json.JSONDecodeError`` on
-Python 3.
+attempting ``r.json()`` raises ``simplejson.JSONDecodeError`` if simplejson is
+installed or raises ``ValueError: No JSON object could be decoded`` on Python 2 or
+``json.JSONDecodeError`` on Python 3.
 
 It should be noted that the success of the call to ``r.json()`` does **not**
 indicate the success of the response. Some servers may return a JSON object in a

--- a/requests/models.py
+++ b/requests/models.py
@@ -877,7 +877,12 @@ class Response(object):
         r"""Returns the json-encoded content of a response, if any.
 
         :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
-        :raises ValueError: If the response body does not contain valid json.
+        :raises simplejson.JSONDecodeError: If the response body does not
+            contain valid json and simplejson is installed.
+        :raises json.JSONDecodeError: If the response body does not contain
+            valid json and simplejson is not installed on Python 3.
+        :raises ValueError: If the response body does not contain valid
+            json and simplejson is not installed on Python 2.        
         """
 
         if not self.encoding and self.content and len(self.content) > 3:


### PR DESCRIPTION
% `python2 -c "import requests ; requests.get('https://github.com').json()"`
% `python3 -c "import requests ; requests.get('https://github.com').json()"`

Python | Simplejson is installed  | Simplejson is NOT installed
--- | --- | ---
Python 2 | simplejson.JSONDecodeError | ValueError
Python 3 | simplejson.JSONDecodeError | json.JSONDecodeError