### PR TITLE
Cleanup redundant allow_redirects kwargs in api

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -72,7 +72,6 @@ def get(url, params=None, **kwargs):
     :rtype: requests.Response
     """
 
-    kwargs.setdefault('allow_redirects', True)
     return request('get', url, params=params, **kwargs)
 
 
@@ -85,7 +84,6 @@ def options(url, **kwargs):
     :rtype: requests.Response
     """
 
-    kwargs.setdefault('allow_redirects', True)
     return request('options', url, **kwargs)
 
 


### PR DESCRIPTION
Not a big problem, just remove the redundant param `allow_redirects` in API `get()` and `options()`. Cause the underlying calling `Session.request()` has param `allow_redirects` defaults to `True`.

Only leaves

```python
def head(url, **kwargs):
    kwargs.setdefault('allow_redirects', False)
    return request('head', url, **kwargs)
```

in `api.py` to make a contrast that http method `head()` is the only one disallows redirects by default.