### PR TITLE
sets a default timeout and resolves #3070

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -469,7 +469,7 @@ class Session(SessionRedirectMixin):
 
     def request(self, method, url,
             params=None, data=None, headers=None, cookies=None, files=None,
-            auth=None, timeout=None, allow_redirects=True, proxies=None,
+            auth=None, timeout=1000, allow_redirects=True, proxies=None,
             hooks=None, stream=None, verify=None, cert=None, json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it.
         Returns :class:`Response <Response>` object.


### PR DESCRIPTION
This sets a (very high) default timeout which is guaranteed not to create any breaking changes while also fixing the longstanding issue of requests possibly hanging indefinitely in any script where the dev forgot to include a timeout. I would like to urge this commit make it into the next minor release version with the possibility of lowering the timeout to 300 seconds in the next major release version.

Please see the discussion at https://github.com/psf/requests/issues/3070