### PR TITLE
Add support for brotli decoding

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@ dev
 ---
 
 -   \[Short description of non-trivial change.\]
+- Requests Brotli compression, if either the `brotli` or `brotlicffi` package
+  is installed.
 
 2.25.1 (2020-12-16)
 -------------------

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -11,6 +11,9 @@ Encoded Data?
 Requests automatically decompresses gzip-encoded responses, and does
 its best to decode response content to unicode when possible.
 
+When either the `brotli <https://pypi.org/project/Brotli/>`_ or `brotlicffi <https://pypi.org/project/brotlicffi/>`_
+package is installed, requests also decodes Brotli-encoded responses.
+
 You can get direct access to the raw response (and even the socket),
 if needed as well.
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -128,8 +128,8 @@ You can also access the response body as bytes, for non-text requests::
 
 The ``gzip`` and ``deflate`` transfer-encodings are automatically decoded for you.
 
-The ``br``  transfer-encoding is automatically decoded, if either the brotli or
-brotlicffi package is installed.
+The ``br``  transfer-encoding is automatically decoded for you if a Brotli library
+like `brotli <https://pypi.org/project/brotli>`_ or `brotlicffi <https://pypi.org/project/brotli>`_ is installed.
 
 For example, to create an image from binary data returned by a request, you can
 use the following code::

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -128,6 +128,9 @@ You can also access the response body as bytes, for non-text requests::
 
 The ``gzip`` and ``deflate`` transfer-encodings are automatically decoded for you.
 
+The ``br``  transfer-encoding is automatically decoded, if either the brotli or
+brotlicffi package is installed.
+
 For example, to create an image from binary data returned by a request, you can
 use the following code::
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -42,7 +42,10 @@ DEFAULT_CA_BUNDLE_PATH = certs.where()
 
 DEFAULT_PORTS = {'http': 80, 'https': 443}
 
-DEFAULT_ACCEPT_ENCODING = make_headers(accept_encoding=True)["accept-encoding"]
+# Ensure that ', ' is used to preserve previous delimiter behavior.
+DEFAULT_ACCEPT_ENCODING = ", ".join(
+    re.split(r",\s*", make_headers(accept_encoding=True)["accept-encoding"])
+)
 
 
 if sys.platform == 'win32':

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -20,6 +20,7 @@ import tempfile
 import warnings
 import zipfile
 from collections import OrderedDict
+from urllib3.util import make_headers
 
 from .__version__ import __version__
 from . import certs
@@ -820,7 +821,7 @@ def default_headers():
     """
     return CaseInsensitiveDict({
         'User-Agent': default_user_agent(),
-        'Accept-Encoding': ', '.join(('gzip', 'deflate')),
+        'Accept-Encoding': make_headers(accept_encoding=True)["accept-encoding"],
         'Accept': '*/*',
         'Connection': 'keep-alive',
     })

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -42,6 +42,8 @@ DEFAULT_CA_BUNDLE_PATH = certs.where()
 
 DEFAULT_PORTS = {'http': 80, 'https': 443}
 
+DEFAULT_ACCEPT_ENCODING = make_headers(accept_encoding=True)["accept-encoding"]
+
 
 if sys.platform == 'win32':
     # provide a proxy_bypass version on Windows without DNS lookups
@@ -821,7 +823,7 @@ def default_headers():
     """
     return CaseInsensitiveDict({
         'User-Agent': default_user_agent(),
-        'Accept-Encoding': make_headers(accept_encoding=True)["accept-encoding"],
+        'Accept-Encoding': DEFAULT_ACCEPT_ENCODING,
         'Accept': '*/*',
         'Connection': 'keep-alive',
     })


### PR DESCRIPTION
When the `brotli` or `brotlicffi` packages are installed, `urllib3.util.make_headers()` inserts ',br' in the Accept-Encoding header and decodes br from the answers.