### PR TITLE
Short-circuit raise_for_status code for statuses that will not raise …

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -191,3 +191,4 @@ Patches and Suggestions
 - "Dull Bananas" <dull.bananas0@gmail.com> (`@dullbananas <https://github.com/dullbananas>`_)
 - Alessio Izzo (`@aless10 <https://github.com/aless10>`_)
 - Sylvain Marié (`@smarie <https://github.com/smarie>`_)
+- Paul McGuire (`@ptmcg <https://github.com/ptmcg>`_)

--- a/requests/models.py
+++ b/requests/models.py
@@ -925,6 +925,10 @@ class Response(object):
     def raise_for_status(self):
         """Raises :class:`HTTPError`, if one occurred."""
 
+        # short-circuit if not an error status
+        if self.status_code < 400:
+            return
+
         http_error_msg = ''
         if isinstance(self.reason, bytes):
             # We attempt to decode utf-8 first because some servers


### PR DESCRIPTION
…an exception

This short-circuit code will skip the steps for decoding response.reason if the status code is not an exception-raising status code.