### PR TITLE
Add PATCH example to the Quickstart of documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ Patches and Suggestions
 - Peter Manser
 - Jeremy Selier
 - Jens Diemer
+- Jeffrey Tse (`@jeffreytse <https://github.com/jeffreytse>`_)
 - Alex (`@alopatin <https://github.com/alopatin>`_)
 - Tom Hogans <tomhsx@gmail.com>
 - Armin Ronacher

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Release v\ |version|. (:ref:`Installation <install>`)
 
 .. image:: https://pepy.tech/badge/requests
     :target: https://pepy.tech/project/requests
-    
+
 .. image:: https://img.shields.io/pypi/l/requests.svg
     :target: https://pypi.org/project/requests/
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -39,10 +39,11 @@ example, this is how you make an HTTP POST request::
 
     >>> r = requests.post('https://httpbin.org/post', data = {'key':'value'})
 
-Nice, right? What about the other HTTP request types: PUT, DELETE, HEAD and
-OPTIONS? These are all just as simple::
+Nice, right? What about the other HTTP request types: PUT, PATCH, DELETE, HEAD
+and OPTIONS? These are all just as simple::
 
     >>> r = requests.put('https://httpbin.org/put', data = {'key':'value'})
+    >>> r = requests.patch('https://httpbin.org/patch', data = {'key':'value'})
     >>> r = requests.delete('https://httpbin.org/delete')
     >>> r = requests.head('https://httpbin.org/get')
     >>> r = requests.options('https://httpbin.org/get')


### PR DESCRIPTION
This PR mades users understand that the library supports the patch method and the simple use of it quickly.