### PR TITLE
Custom HTTP adapters via Session constructor

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -359,7 +359,7 @@ class Session(SessionRedirectMixin):
         'max_redirects',
     ]
 
-    def __init__(self):
+    def __init__(self, http_adapter=None):
 
         #: A case-insensitive dictionary of headers to be sent on each
         #: :class:`Request <Request>` sent from this
@@ -418,8 +418,8 @@ class Session(SessionRedirectMixin):
 
         # Default connection adapters.
         self.adapters = OrderedDict()
-        self.mount('https://', HTTPAdapter())
-        self.mount('http://', HTTPAdapter())
+        self.mount('https://', http_adapter or HTTPAdapter())
+        self.mount('http://', http_adapter or HTTPAdapter())
 
     def __enter__(self):
         return self

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -12,6 +12,9 @@ import warnings
 import re
 
 import io
+
+from urllib3 import Retry
+
 import requests
 import pytest
 from requests.adapters import HTTPAdapter
@@ -138,6 +141,14 @@ class TestRequests:
         request = requests.Request('GET', 'http://example.com/', params=param_ordered_dict)
         prep = session.prepare_request(request)
         assert prep.url == 'http://example.com/?z=1&a=1&k=1&d=1'
+
+    def test_init_http_adapter(self):
+        retry = Retry(3, backoff_factor=1.)
+        http_adapter = requests.adapters.HTTPAdapter(pool_connections=1, max_retries=retry)
+        session = requests.Session(http_adapter=http_adapter)
+
+        for adapter_key in ("http://", "https://",):
+            assert session.adapters[adapter_key] == http_adapter
 
     def test_params_bytes_are_encoded(self):
         request = requests.Request('GET', 'http://example.com',

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -147,7 +147,7 @@ class TestRequests:
         http_adapter = requests.adapters.HTTPAdapter(pool_connections=1, max_retries=retry)
         session = requests.Session(http_adapter=http_adapter)
 
-        for adapter_key in ("http://", "https://",):
+        for adapter_key in ('http://', 'https://',):
             assert session.adapters[adapter_key] == http_adapter
 
     def test_params_bytes_are_encoded(self):


### PR DESCRIPTION
I often find myself having to do the following when using `Session` with custom retrying logic:
```
retry = Retry(3, backoff_factor=1.)
http_adapter = requests.adapters.HTTPAdapter(pool_connections=4, max_retries=retry)
session = requests.Session()
session.mount('https://', http_adapter)
session.mount('http://', http_adapter)
```

Having to mount the adapter myself for such a simple use-case seems superfluous, error-prone and not very user-friendly so I'm suggesting we open up the Session constructor a little bit:

```
retry = Retry(3, backoff_factor=1.)
http_adapter = requests.adapters.HTTPAdapter(pool_connections=4, max_retries=retry)
session = requests.Session(http_adapter=http_adapter)
```