### PR TITLE
Updated to new be-cordial-or-be-on-your-way URL and CoC now references Python Community CoC

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,6 @@
-Be cordial or be on your way.
+# Treat each other well
 
-https://kenreitz.org/essays/2013/01/27/be-cordial-or-be-on-your-way
+Everyone participating in the _requests_ project, and in particular in the issue tracker,
+pull requests, and social media activity, is expected to treat other people with respect
+and more generally to follow the guidelines articulated in the
+[Python Community Code of Conduct](https://www.python.org/psf/codeofconduct/).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 Be cordial or be on your way.
 
-https://www.kennethreitz.org/essays/be-cordial-or-be-on-your-way
+https://kenreitz.org/essays/2013/01/27/be-cordial-or-be-on-your-way

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -34,7 +34,7 @@ including reporting bugs or requesting features. This golden rule is
 **All contributions are welcome**, as long as
 everyone involved is treated with respect.
 
-.. _be cordial or be on your way: https://www.kennethreitz.org/essays/be-cordial-or-be-on-your-way
+.. _be cordial or be on your way: https://kenreitz.org/essays/2013/01/27/be-cordial-or-be-on-your-way
 
 .. _early-feedback:
 


### PR DESCRIPTION
The current  documentation contains two references to Kenneth Reitz's "Be Cordial or Be on Your Way" but the URL for this has now changed. The PR replaces these with the current URL.