### PR TITLE
Fix extract_zipped_paths infinite loop when provided invalid unc path

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -245,6 +245,10 @@ def extract_zipped_paths(path):
     archive, member = os.path.split(path)
     while archive and not os.path.exists(archive):
         archive, prefix = os.path.split(archive)
+        if not prefix:
+            # If we don't check for an empty prefix after the split (in other words, archive remains unchanged after the split),
+            # we _can_ end up in an infinite loop on a rare corner case affecting a small number of users
+            break
         member = '/'.join([prefix, member])
 
     if not zipfile.is_zipfile(archive):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -285,6 +285,10 @@ class TestExtractZippedPaths:
         assert os.path.exists(extracted_path)
         assert filecmp.cmp(extracted_path, __file__)
 
+    def test_invalid_unc_path(self):
+        path = r"\\localhost\invalid\location"
+        assert extract_zipped_paths(path) == path
+
 
 class TestContentEncodingDetection:
 


### PR DESCRIPTION
Fixes https://github.com/psf/requests/issues/5850