### PR TITLE
✅ Fix the tests suite on master by pinning Flask

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ pytest-cov
 pytest-httpbin<1.0
 pytest-mock==2.0.0
 httpbin==0.7.0
+Flask>=1.0,<2.0
 wheel


### PR DESCRIPTION
httpbin does not limit Flask version. Latest 2.0 brings BC-break on the tests suite.

This is a temporary fix. Waiting upon further investigation.