### PR TITLE
Disable requests[security] and remove 3.5 support references

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy3 on Mac OS currently fails trying to compile

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,13 @@ dev
 
   Python2 still depends upon the `chardet` module.
 
+**Deprecations**
+
+- The `requests[security]` extra has been converted to a no-op install.
+  PyOpenSSL is no longer the recommended secure option for Requests.
+
+- Requests has officially dropped support for Python 3.5.
+
 2.25.1 (2020-12-16)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Requests is available on PyPI:
 $ python -m pip install requests
 ```
 
-Requests officially supports Python 2.7 & 3.5+.
+Requests officially supports Python 2.7 & 3.6+.
 
 ## Supported Features & Best–Practices
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -55,7 +55,7 @@ Chris Adams gave an excellent summary on
 Python 3 Support?
 -----------------
 
-Yes! Requests officially supports Python 2.7 & 3.5+ and PyPy.
+Yes! Requests officially supports Python 2.7 & 3.6+ and PyPy.
 
 Python 2 Support?
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 2.7 & 3.5+, and runs great on PyPy.
+Requests officially supports Python 2.7 & 3.6+, and runs great on PyPy.
 
 
 The User Guide

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     package_data={'': ['LICENSE', 'NOTICE']},
     package_dir={'requests': 'requests'},
     include_package_data=True,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=requires,
     license=about['__license__'],
     zip_safe=False,
@@ -91,7 +91,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -102,7 +101,7 @@ setup(
     cmdclass={'test': PyTest},
     tests_require=test_requirements,
     extras_require={
-        'security': ['pyOpenSSL >= 0.14', 'cryptography>=1.3.4'],
+        'security': [],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
         'use_chardet_on_py3': ['chardet>=3.0.2,<5']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}-{default,use_chardet_on_py3}
+envlist = py{27,36,37,38,39}-{default,use_chardet_on_py3}
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
## requests[security]

This PR will remove functionality from the `requests[security]` extra. We initially removed default support for PyOpenSSL in Requests 2.24.0 (#5443) as it is now considered less secure. Deprecation of the `extras_require` was announced in [Requests 2.25.0](https://github.com/psf/requests/blob/master/HISTORY.md#2250-2020-11-11) and we're officially removing the `extras_require` functionality in Requests 2.26.0. 

Projects currently using `requests[security]` after this change will continue to operate as if performing a standard requests installation (secure by default).

While not recommended, if PyOpenSSL support is still a requirement in your project, you may install `urllib3[secure]` and add `urllib3.contrib.pyopenssl.inject_into_urllib3()` to your code to re-enable the functionality.

## Python 3.5 Support

We will also be removing support for Python 3.5 in Requests 2.26.0 as announced in the [2.25.0 release notes](https://github.com/psf/requests/blob/master/HISTORY.md#2250-2020-11-11).