### PR TITLE
v2.26.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,15 +5,29 @@ dev
 ---
 
 -   \[Short description of non-trivial change.\]
-- Requests Brotli compression, if either the `brotli` or `brotlicffi` package
-  is installed.
+
+2.26.0 (2021-07-13)
+-------------------
+
+**Improvements**
+
+- Requests now supports Brotli compression, if either the `brotli` or
+  `brotlicffi` package is installed. (#5783)
+
+- `Session.send` now correctly resolves proxy configurations from both
+  the Session and Request. Behavior now matches `Session.request`. (#5681)
+
+**Bugfixes**
+
+- Fixed a race condition in zip extraction when using Requests in parallel
+  from zip archive. (#5707)
 
 **Dependencies**
 
 - Instead of `chardet`, use the MIT-licensed `charset_normalizer` for Python3
   to remove license ambiguity for projects bundling requests. If `chardet`
   is already installed on your machine it will be used instead of `charset_normalizer`
-  to keep backwards compatibility.
+  to keep backwards compatibility. (#5797)
 
   You can also install `chardet` while installing requests by
   specifying `[use_chardet_on_py3]` extra as follows:
@@ -24,12 +38,15 @@ dev
 
   Python2 still depends upon the `chardet` module.
 
+- Requests now supports `idna` 3.x on Python 3. `idna` 2.x will continue to
+  be used on Python 2 installations. (#5711)
+
 **Deprecations**
 
 - The `requests[security]` extra has been converted to a no-op install.
-  PyOpenSSL is no longer the recommended secure option for Requests.
+  PyOpenSSL is no longer the recommended secure option for Requests. (#5867)
 
-- Requests has officially dropped support for Python 3.5.
+- Requests has officially dropped support for Python 3.5. (#5867)
 
 2.25.1 (2020-12-16)
 -------------------

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = 'requests'
 __description__ = 'Python HTTP for Humans.'
 __url__ = 'https://requests.readthedocs.io'
-__version__ = '2.25.1'
-__build__ = 0x022501
+__version__ = '2.26.0'
+__build__ = 0x022600
 __author__ = 'Kenneth Reitz'
 __author_email__ = 'me@kennethreitz.org'
 __license__ = 'Apache 2.0'


### PR DESCRIPTION
2.26.0 (2021-07-13)
-------------------

**Improvements**

- Requests now supports Brotli compression, if either the `brotli` or
  `brotlicffi` package is installed. (#5783)

- `Session.send` now correctly resolves proxy configurations from both
  the Session and Request. Behavior now matches `Session.request`. (#5681)

**Bugfixes**

- Fixed a race condition in zip extraction when using Requests in parallel
  from zip archive. (#5707)

**Dependencies**

- Instead of `chardet`, use the MIT-licensed `charset_normalizer` for Python3
  to remove license ambiguity for projects bundling requests. If `chardet`
  is already installed on your machine it will be used instead of `charset_normalizer`
  to keep backwards compatibility. (#5797)

  You can also install `chardet` while installing requests by
  specifying `[use_chardet_on_py3]` extra as follows:

    ```shell
    pip install "requests[use_chardet_on_py3]"
    ```
  Note that installation of `chardet` in your environment through any means will disable use
  of `charset_normalizer`.

  Python 2.7 still depends upon the `chardet` module.

- Requests now supports `idna` 3.x on Python 3. `idna` 2.x will continue to
  be used on Python 2 installations. (#5711)

**Deprecations**

- The `requests[security]` extra has been converted to a no-op install.
  PyOpenSSL is no longer the recommended secure option for Requests. (#5867)

- Requests has officially dropped support for Python 3.5. (#5867)
