### PR TITLE
Remove legacy version check for cryptography

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -84,17 +84,6 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     else:
         raise Exception("You need either charset_normalizer or chardet installed")
 
-def _check_cryptography(cryptography_version):
-    # cryptography < 1.3.4
-    try:
-        cryptography_version = list(map(int, cryptography_version.split('.')))
-    except ValueError:
-        return
-
-    if cryptography_version < [1, 3, 4]:
-        warning = 'Old version of cryptography ({}) may cause slowdown.'.format(cryptography_version)
-        warnings.warn(warning, RequestsDependencyWarning)
-
 # Check imported dependencies for compatibility.
 try:
     check_compatibility(urllib3.__version__, chardet_version, charset_normalizer_version)
@@ -115,10 +104,6 @@ try:
     if not getattr(ssl, "HAS_SNI", False):
         from urllib3.contrib import pyopenssl
         pyopenssl.inject_into_urllib3()
-
-        # Check cryptography version
-        from cryptography import __version__ as cryptography_version
-        _check_cryptography(cryptography_version)
 except ImportError:
     pass
 


### PR DESCRIPTION
It's unlikely that someone would be running [a version of cryptography from before June 2016](https://pypi.org/project/cryptography/1.3.3/) these days.