### PR TITLE
Make chardet/charset_normalizer optional dependencies

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -44,17 +44,7 @@ import urllib3
 import warnings
 from .exceptions import RequestsDependencyWarning
 
-try:
-    from charset_normalizer import __version__ as charset_normalizer_version
-except ImportError:
-    charset_normalizer_version = None
-
-try:
-    from chardet import __version__ as chardet_version
-except ImportError:
-    chardet_version = None
-
-def check_compatibility(urllib3_version, chardet_version, charset_normalizer_version):
+def check_compatibility(urllib3_version):
     urllib3_version = urllib3_version.split('.')
     assert urllib3_version != ['dev']  # Verify urllib3 isn't installed from git.
 
@@ -70,20 +60,6 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     assert minor >= 21
     assert minor <= 26
 
-    # Check charset_normalizer for compatibility.
-    if chardet_version:
-        major, minor, patch = chardet_version.split('.')[:3]
-        major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, < 5.0.0
-        assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
-    elif charset_normalizer_version:
-        major, minor, patch = charset_normalizer_version.split('.')[:3]
-        major, minor, patch = int(major), int(minor), int(patch)
-        # charset_normalizer >= 2.0.0 < 3.0.0
-        assert (2, 0, 0) <= (major, minor, patch) < (3, 0, 0)
-    else:
-        raise Exception("You need either charset_normalizer or chardet installed")
-
 def _check_cryptography(cryptography_version):
     # cryptography < 1.3.4
     try:
@@ -97,10 +73,9 @@ def _check_cryptography(cryptography_version):
 
 # Check imported dependencies for compatibility.
 try:
-    check_compatibility(urllib3.__version__, chardet_version, charset_normalizer_version)
+    check_compatibility(urllib3.__version__)
 except (AssertionError, ValueError):
-    warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
-                  "version!".format(urllib3.__version__, chardet_version, charset_normalizer_version),
+    warnings.warn("urllib3 ({}) doesn't match a supported version!".format(urllib3.__version__),
                   RequestsDependencyWarning)
 
 # Attempt to enable urllib3's fallback for SNI support

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -11,10 +11,13 @@ Python 3.
 try:
     import chardet
 except ImportError:
-    import charset_normalizer as chardet
-    import warnings
+    try:
+        import charset_normalizer as chardet
+        import warnings
 
-    warnings.filterwarnings('ignore', 'Trying to detect', module='charset_normalizer')
+        warnings.filterwarnings('ignore', 'Trying to detect', module='charset_normalizer')
+    except ImportError:
+        chardet = None
 
 
 import sys

--- a/requests/compat.py
+++ b/requests/compat.py
@@ -12,6 +12,10 @@ try:
     import chardet
 except ImportError:
     import charset_normalizer as chardet
+    import warnings
+
+    warnings.filterwarnings('ignore', 'Trying to detect', module='charset_normalizer')
+
 
 import sys
 

--- a/requests/packages.py
+++ b/requests/packages.py
@@ -1,12 +1,6 @@
 import sys
 
-try:
-    import chardet
-except ImportError:
-    import charset_normalizer as chardet
-    import warnings
-
-    warnings.filterwarnings('ignore', 'Trying to detect', module='charset_normalizer')
+from requests.compat import chardet
 
 # This code exists for backwards compatibility reasons.
 # I don't like it either. Just look the other way. :)
@@ -19,8 +13,9 @@ for package in ('urllib3', 'idna'):
         if mod == package or mod.startswith(package + '.'):
             sys.modules['requests.packages.' + mod] = sys.modules[mod]
 
-target = chardet.__name__
-for mod in list(sys.modules):
-    if mod == target or mod.startswith(target + '.'):
-        sys.modules['requests.packages.' + target.replace(target, 'chardet')] = sys.modules[mod]
+if chardet:
+    target = chardet.__name__
+    for mod in list(sys.modules):
+        if mod == target or mod.startswith(target + '.'):
+            sys.modules['requests.packages.' + target.replace(target, 'chardet')] = sys.modules[mod]
 # Kinda cool, though, right?

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ if sys.argv[-1] == 'publish':
 packages = ['requests']
 
 requires = [
-    'charset_normalizer~=2.0.0; python_version >= "3"',
-    'chardet>=3.0.2,<5; python_version < "3"',
     'idna>=2.5,<3; python_version < "3"',
     'idna>=2.5,<4; python_version >= "3"',
     'urllib3>=1.21.1,<1.27',
@@ -104,7 +102,8 @@ setup(
         'security': [],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
         'socks:sys_platform == "win32" and python_version == "2.7"': ['win_inet_pton'],
-        'use_chardet_on_py3': ['chardet>=3.0.2,<5']
+        'chardet': ['chardet>=3.0.2,<5'],
+        'charset_normalizer': ['charset_normalizer~=2.0.0; python_version >= "3"'],
     },
     project_urls={
         'Documentation': 'https://requests.readthedocs.io',

--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -42,15 +42,22 @@ class Server(threading.Thread):
         self.stop_event = threading.Event()
 
     @classmethod
-    def text_response_server(cls, text, request_timeout=0.5, **kwargs):
-        def text_response_handler(sock):
+    def response_server(cls, response, request_timeout=0.5, **kwargs):
+        def response_handler(sock):
             request_content = consume_socket_content(sock, timeout=request_timeout)
-            sock.send(text.encode('utf-8'))
+            sock.send(response)
 
             return request_content
 
+        return Server(response_handler, **kwargs)
 
-        return Server(text_response_handler, **kwargs)
+    @classmethod
+    def text_response_server(cls, text, request_timeout=0.5, **kwargs):
+        return cls.response_server(
+            response=text.encode('utf-8'),
+            request_timeout=request_timeout,
+            **kwargs
+        )
 
     @classmethod
     def basic_response_server(cls, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{27,36,37,38,39}-{default,use_chardet_on_py3}
+envlist =
+    py27-{chardet,default}
+    py{36,37,38,39}-{default,chardet,charset_normalizer}
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -11,8 +13,14 @@ commands =
 
 [testenv:default]
 
-[testenv:use_chardet_on_py3]
+[testenv:chardet]
 extras =
     security
     socks
-    use_chardet_on_py3
+    chardet
+
+[testenv:charset_normalizer]
+extras =
+    security
+    socks
+    charset_normalizer


### PR DESCRIPTION
An implementation of #5871 for consideration.

Unlike my suggestion in #5871, this implementation _prefers_ `chardet` / `charset_normalizer` if it's available, with the idea that those libraries should hopefully do a better job than trying to decode the payload in the two most likely encodings.

Decoding ASCII and UTF-8 (["UTF-8 is used by 97.0% of all the websites whose character encoding we know."](https://w3techs.com/technologies/details/en-utf8)) will continue to work without those libraries, and a helpful error is raised in other cases.

This is still missing documentation, changelogs, etc. – help appreciated.

Considering the switchover to `charset_normalizer` has broken some users' workflows anyway, I think it wouldn't be too much of an additional breaking change to do this without a major version bump.
