### PR TITLE
Unify interface definition

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -15,7 +15,6 @@ from . import sessions
 
 def request(method, url, **kwargs):
     """Constructs a :class:`Request <Request>`, prepares it and sends it. 
-    Returns :class:`Response <Response>` object.
 
     :param method: method for the new :class:`Request` object.
     :param url: URL for the new :class:`Request` object.
@@ -54,6 +53,8 @@ def request(method, url, **kwargs):
         development or testing.
     :param cert: (optional) if String, path to ssl client cert file (.pem).
         If Tuple, ('cert', 'key') pair.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
 
     Usage::
 
@@ -71,7 +72,7 @@ def request(method, url, **kwargs):
 
 
 def get(url, params=None, **kwargs):
-    r"""Sends a GET request. Returns :class:`Response` object.
+    r"""Sends a GET request.
 
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary or bytes to be sent in the query 
@@ -85,7 +86,7 @@ def get(url, params=None, **kwargs):
 
 
 def options(url, **kwargs):
-    r"""Sends a OPTIONS request. Returns :class:`Response` object.
+    r"""Sends a OPTIONS request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
@@ -97,7 +98,7 @@ def options(url, **kwargs):
 
 
 def head(url, **kwargs):
-    r"""Sends a HEAD request. Returns :class:`Response` object.
+    r"""Sends a HEAD request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes. If
@@ -112,7 +113,7 @@ def head(url, **kwargs):
 
 
 def post(url, data=None, json=None, **kwargs):
-    r"""Sends a POST request. Returns :class:`Response` object.
+    r"""Sends a POST request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -128,7 +129,7 @@ def post(url, data=None, json=None, **kwargs):
 
 
 def put(url, data=None, **kwargs):
-    r"""Sends a PUT request. Returns :class:`Response` object.
+    r"""Sends a PUT request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -142,7 +143,7 @@ def put(url, data=None, **kwargs):
 
 
 def patch(url, data=None, **kwargs):
-    r"""Sends a PATCH request. Returns :class:`Response` object.
+    r"""Sends a PATCH request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -156,7 +157,7 @@ def patch(url, data=None, **kwargs):
 
 
 def delete(url, **kwargs):
-    r"""Sends a DELETE request. Returns :class:`Response` object.
+    r"""Sends a DELETE request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.

--- a/requests/api.py
+++ b/requests/api.py
@@ -16,10 +16,11 @@ from . import sessions
 def request(method, url, **kwargs):
     """Constructs a :class:`Request <Request>`, prepares it and sends it. 
 
-    :param method: method for the new :class:`Request` object.
+    :param method: method for the new :class:`Request` object:
+        ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
     :param url: URL for the new :class:`Request` object.
-    :param params: (optional) Dictionary or bytes to be sent in the query 
-        string for the :class:`Request`.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the :class:`Request`.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
     :param json: (optional) A JSON serializable Python object to send in
@@ -28,15 +29,21 @@ def request(method, url, **kwargs):
         :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the
         :class:`Request`.
-    :param files: (optional) Dictionary of ``'filename': file-like-objects``
-        for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects``
+        (or ``{'name': file-tuple}``) for multipart encoding upload.
+        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``,
+        3-tuple ``('filename', fileobj, 'content_type')``
+        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``,
+        where ``'content-type'`` is a string defining the content type of the
+        given file and ``custom_headers`` a dict-like object containing
+        additional headers to add for the file.
     :param auth: (optional) Auth tuple or callable to enable
         Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How long to wait for the server to send
         data before giving up, as a float, or a :ref:`(connect timeout,
         read timeout) <timeouts>` tuple.
     :type timeout: float or tuple
-    :param allow_redirects: (optional) Set to True by default.
+    :param allow_redirects: (optional) Enable/disable redirection. Set to True by default.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol or protocol and
         hostname to the URL of the proxy.
@@ -86,7 +93,7 @@ def get(url, params=None, **kwargs):
 
 
 def options(url, **kwargs):
-    r"""Sends a OPTIONS request.
+    r"""Sends an OPTIONS request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.

--- a/requests/api.py
+++ b/requests/api.py
@@ -14,37 +14,46 @@ from . import sessions
 
 
 def request(method, url, **kwargs):
-    """Constructs and sends a :class:`Request <Request>`.
+    """Constructs a :class:`Request <Request>`, prepares it and sends it. 
+    Returns :class:`Response <Response>` object.
 
-    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param method: method for the new :class:`Request` object.
     :param url: URL for the new :class:`Request` object.
-    :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the query string for the :class:`Request`.
+    :param params: (optional) Dictionary or bytes to be sent in the query 
+        string for the :class:`Request`.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
-    :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
-    :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
-        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
-        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content-type'`` is a string
-        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
-        to add for the file.
-    :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
-    :param timeout: (optional) How many seconds to wait for the server to send data
-        before giving up, as a float, or a :ref:`(connect timeout, read
-        timeout) <timeouts>` tuple.
+    :param json: (optional) A JSON serializable Python object to send in
+        the body of the :class:`Request`.
+    :param headers: (optional) Dictionary of HTTP Headers to send with the
+        :class:`Request`.
+    :param cookies: (optional) Dict or CookieJar object to send with the
+        :class:`Request`.
+    :param files: (optional) Dictionary of ``'filename': file-like-objects``
+        for multipart encoding upload.
+    :param auth: (optional) Auth tuple or callable to enable
+        Basic/Digest/Custom HTTP Auth.
+    :param timeout: (optional) How long to wait for the server to send
+        data before giving up, as a float, or a :ref:`(connect timeout,
+        read timeout) <timeouts>` tuple.
     :type timeout: float or tuple
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Set to True by default.
     :type allow_redirects: bool
-    :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
-    :param verify: (optional) Either a boolean, in which case it controls whether we verify
-            the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``.
-    :param stream: (optional) if ``False``, the response content will be immediately downloaded.
-    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
-    :return: :class:`Response <Response>` object
-    :rtype: requests.Response
+    :param proxies: (optional) Dictionary mapping protocol or protocol and
+        hostname to the URL of the proxy.
+    :param stream: (optional) whether to immediately download the response
+        content. Defaults to ``False``.
+    :param verify: (optional) Either a boolean, in which case it controls
+        whether we verify the server's TLS certificate, or a string, in
+        which case it must be a path to a CA bundle to use. Defaults to
+        ``True``. When set to ``False``, requests will accept any TLS
+        certificate presented by the server, and will ignore hostname
+        mismatches and/or expired certificates, which will make your
+        application vulnerable to man-in-the-middle (MitM) attacks.
+        Setting verify to ``False``  may be useful during local
+        development or testing.
+    :param cert: (optional) if String, path to ssl client cert file (.pem).
+        If Tuple, ('cert', 'key') pair.
 
     Usage::
 
@@ -62,11 +71,11 @@ def request(method, url, **kwargs):
 
 
 def get(url, params=None, **kwargs):
-    r"""Sends a GET request.
+    r"""Sends a GET request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
-    :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the query string for the :class:`Request`.
+    :param params: (optional) Dictionary or bytes to be sent in the query 
+        string for the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
@@ -76,7 +85,7 @@ def get(url, params=None, **kwargs):
 
 
 def options(url, **kwargs):
-    r"""Sends an OPTIONS request.
+    r"""Sends a OPTIONS request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
@@ -88,7 +97,7 @@ def options(url, **kwargs):
 
 
 def head(url, **kwargs):
-    r"""Sends a HEAD request.
+    r"""Sends a HEAD request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes. If
@@ -103,12 +112,13 @@ def head(url, **kwargs):
 
 
 def post(url, data=None, json=None, **kwargs):
-    r"""Sends a POST request.
+    r"""Sends a POST request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
+    :param json: (optional) A JSON serializable Python object to send in
+        the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
@@ -118,12 +128,11 @@ def post(url, data=None, json=None, **kwargs):
 
 
 def put(url, data=None, **kwargs):
-    r"""Sends a PUT request.
+    r"""Sends a PUT request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
@@ -133,12 +142,11 @@ def put(url, data=None, **kwargs):
 
 
 def patch(url, data=None, **kwargs):
-    r"""Sends a PATCH request.
+    r"""Sends a PATCH request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, list of tuples, bytes, or file-like
         object to send in the body of the :class:`Request`.
-    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
@@ -148,7 +156,7 @@ def patch(url, data=None, **kwargs):
 
 
 def delete(url, **kwargs):
-    r"""Sends a DELETE request.
+    r"""Sends a DELETE request. Returns :class:`Response` object.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -473,10 +473,11 @@ class Session(SessionRedirectMixin):
             hooks=None, stream=None, verify=None, cert=None, json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it. 
 
-        :param method: method for the new :class:`Request` object.
+        :param method: method for the new :class:`Request` object:
+            ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
         :param url: URL for the new :class:`Request` object.
-        :param params: (optional) Dictionary or bytes to be sent in the query 
-            string for the :class:`Request`.
+        :param params: (optional) Dictionary, list of tuples or bytes to send
+            in the query string for the :class:`Request`.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
             object to send in the body of the :class:`Request`.
         :param json: (optional) A JSON serializable Python object to send in
@@ -485,15 +486,21 @@ class Session(SessionRedirectMixin):
             :class:`Request`.
         :param cookies: (optional) Dict or CookieJar object to send with the
             :class:`Request`.
-        :param files: (optional) Dictionary of ``'filename': file-like-objects``
-            for multipart encoding upload.
+        :param files: (optional) Dictionary of ``'name': file-like-objects``
+            (or ``{'name': file-tuple}``) for multipart encoding upload.
+            ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``,
+            3-tuple ``('filename', fileobj, 'content_type')``
+            or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``,
+            where ``'content-type'`` is a string defining the content type of the
+            given file and ``custom_headers`` a dict-like object containing
+            additional headers to add for the file.
         :param auth: (optional) Auth tuple or callable to enable
             Basic/Digest/Custom HTTP Auth.
         :param timeout: (optional) How long to wait for the server to send
             data before giving up, as a float, or a :ref:`(connect timeout,
             read timeout) <timeouts>` tuple.
         :type timeout: float or tuple
-        :param allow_redirects: (optional) Set to True by default.
+        :param allow_redirects: (optional) Enable/disable redirection. Set to True by default.
         :type allow_redirects: bool
         :param proxies: (optional) Dictionary mapping protocol or protocol and
             hostname to the URL of the proxy.
@@ -558,7 +565,7 @@ class Session(SessionRedirectMixin):
         return self.request('GET', url, **kwargs)
 
     def options(self, url, **kwargs):
-        r"""Sends a OPTIONS request.
+        r"""Sends an OPTIONS request.
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -471,17 +471,17 @@ class Session(SessionRedirectMixin):
             params=None, data=None, headers=None, cookies=None, files=None,
             auth=None, timeout=None, allow_redirects=True, proxies=None,
             hooks=None, stream=None, verify=None, cert=None, json=None):
-        """Constructs a :class:`Request <Request>`, prepares it and sends it.
+        """Constructs a :class:`Request <Request>`, prepares it and sends it. 
         Returns :class:`Response <Response>` object.
 
         :param method: method for the new :class:`Request` object.
         :param url: URL for the new :class:`Request` object.
-        :param params: (optional) Dictionary or bytes to be sent in the query
+        :param params: (optional) Dictionary or bytes to be sent in the query 
             string for the :class:`Request`.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
             object to send in the body of the :class:`Request`.
-        :param json: (optional) json to send in the body of the
-            :class:`Request`.
+        :param json: (optional) A JSON serializable Python object to send in
+            the body of the :class:`Request`.
         :param headers: (optional) Dictionary of HTTP Headers to send with the
             :class:`Request`.
         :param cookies: (optional) Dict or CookieJar object to send with the
@@ -500,14 +500,15 @@ class Session(SessionRedirectMixin):
             hostname to the URL of the proxy.
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
-        :param verify: (optional) Either a boolean, in which case it controls whether we verify
-            the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
-            ``False``, requests will accept any TLS certificate presented by
-            the server, and will ignore hostname mismatches and/or expired
-            certificates, which will make your application vulnerable to
-            man-in-the-middle (MitM) attacks. Setting verify to ``False`` 
-            may be useful during local development or testing.
+        :param verify: (optional) Either a boolean, in which case it controls
+            whether we verify the server's TLS certificate, or a string, in
+            which case it must be a path to a CA bundle to use. Defaults to
+            ``True``. When set to ``False``, requests will accept any TLS
+            certificate presented by the server, and will ignore hostname
+            mismatches and/or expired certificates, which will make your
+            application vulnerable to man-in-the-middle (MitM) attacks.
+            Setting verify to ``False``  may be useful during local
+            development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response
@@ -547,11 +548,13 @@ class Session(SessionRedirectMixin):
         r"""Sends a GET request. Returns :class:`Response` object.
 
         :param url: URL for the new :class:`Request` object.
+        :param params: (optional) Dictionary or bytes to be sent in the query 
+            string for the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
-        kwargs.setdefault('allow_redirects', True)
         return self.request('GET', url, **kwargs)
 
     def options(self, url, **kwargs):
@@ -559,17 +562,20 @@ class Session(SessionRedirectMixin):
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
-        kwargs.setdefault('allow_redirects', True)
         return self.request('OPTIONS', url, **kwargs)
 
     def head(self, url, **kwargs):
         r"""Sends a HEAD request. Returns :class:`Response` object.
 
         :param url: URL for the new :class:`Request` object.
-        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :param \*\*kwargs: Optional arguments that ``request`` takes. If
+            `allow_redirects` is not provided, it will be set to `False` (as
+            opposed to the default :meth:`request` behavior).
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
@@ -582,8 +588,10 @@ class Session(SessionRedirectMixin):
         :param url: URL for the new :class:`Request` object.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
             object to send in the body of the :class:`Request`.
-        :param json: (optional) json to send in the body of the :class:`Request`.
+        :param json: (optional) A JSON serializable Python object to send in
+            the body of the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
@@ -596,6 +604,7 @@ class Session(SessionRedirectMixin):
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
             object to send in the body of the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
@@ -608,6 +617,7 @@ class Session(SessionRedirectMixin):
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
             object to send in the body of the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 
@@ -618,6 +628,7 @@ class Session(SessionRedirectMixin):
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -472,7 +472,6 @@ class Session(SessionRedirectMixin):
             auth=None, timeout=None, allow_redirects=True, proxies=None,
             hooks=None, stream=None, verify=None, cert=None, json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it. 
-        Returns :class:`Response <Response>` object.
 
         :param method: method for the new :class:`Request` object.
         :param url: URL for the new :class:`Request` object.
@@ -511,6 +510,7 @@ class Session(SessionRedirectMixin):
             development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
+        :return: :class:`Response <Response>` object
         :rtype: requests.Response
         """
         # Create the Request.
@@ -545,7 +545,7 @@ class Session(SessionRedirectMixin):
         return resp
 
     def get(self, url, **kwargs):
-        r"""Sends a GET request. Returns :class:`Response` object.
+        r"""Sends a GET request.
 
         :param url: URL for the new :class:`Request` object.
         :param params: (optional) Dictionary or bytes to be sent in the query 
@@ -558,7 +558,7 @@ class Session(SessionRedirectMixin):
         return self.request('GET', url, **kwargs)
 
     def options(self, url, **kwargs):
-        r"""Sends a OPTIONS request. Returns :class:`Response` object.
+        r"""Sends a OPTIONS request.
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
@@ -569,7 +569,7 @@ class Session(SessionRedirectMixin):
         return self.request('OPTIONS', url, **kwargs)
 
     def head(self, url, **kwargs):
-        r"""Sends a HEAD request. Returns :class:`Response` object.
+        r"""Sends a HEAD request.
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes. If
@@ -583,7 +583,7 @@ class Session(SessionRedirectMixin):
         return self.request('HEAD', url, **kwargs)
 
     def post(self, url, data=None, json=None, **kwargs):
-        r"""Sends a POST request. Returns :class:`Response` object.
+        r"""Sends a POST request.
 
         :param url: URL for the new :class:`Request` object.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -598,7 +598,7 @@ class Session(SessionRedirectMixin):
         return self.request('POST', url, data=data, json=json, **kwargs)
 
     def put(self, url, data=None, **kwargs):
-        r"""Sends a PUT request. Returns :class:`Response` object.
+        r"""Sends a PUT request.
 
         :param url: URL for the new :class:`Request` object.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -611,7 +611,7 @@ class Session(SessionRedirectMixin):
         return self.request('PUT', url, data=data, **kwargs)
 
     def patch(self, url, data=None, **kwargs):
-        r"""Sends a PATCH request. Returns :class:`Response` object.
+        r"""Sends a PATCH request.
 
         :param url: URL for the new :class:`Request` object.
         :param data: (optional) Dictionary, list of tuples, bytes, or file-like
@@ -624,7 +624,7 @@ class Session(SessionRedirectMixin):
         return self.request('PATCH', url, data=data, **kwargs)
 
     def delete(self, url, **kwargs):
-        r"""Sends a DELETE request. Returns :class:`Response` object.
+        r"""Sends a DELETE request.
 
         :param url: URL for the new :class:`Request` object.
         :param \*\*kwargs: Optional arguments that ``request`` takes.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -551,7 +551,7 @@ class Session(SessionRedirectMixin):
 
         return resp
 
-    def get(self, url, **kwargs):
+    def get(self, url, params=None, **kwargs):
         r"""Sends a GET request.
 
         :param url: URL for the new :class:`Request` object.


### PR DESCRIPTION
With this pull request I am trying to get rid of some differences in the interface definition and doc strings of `requests.api` and `requests.sessions.Session`.

In not all cases there was an obvious right choice and some discussion might be necessary.