### PR TITLE
docs: Update the Red Hat vulnerabilities contact

### DIFF
--- a/docs/community/vulnerabilities.rst
+++ b/docs/community/vulnerabilities.rst
@@ -72,7 +72,7 @@ time, to ensure that they are able to promptly release their downstream
 packages. Currently the list of people we actively contact *ahead of a public
 release* is:
 
-- Jeremy Cline, Red Hat (@jeremycline)
+- Python Maintenance Team, Red Hat (python-maint@redhat.com)
 - Daniele Tricoli, Debian (@eriol)
 
 We will notify these individuals at least a week ahead of our planned release


### PR DESCRIPTION
I am departing Red Hat so it would be best to contact the Python
maintenance team there instead of me if a vulnerability is discovered.

Cc: @hroncok 