### PR TITLE
Fix creating non-listening sockets in tests on some platforms

### DIFF
--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -78,7 +78,9 @@ class Server(threading.Thread):
     def _create_socket_and_bind(self):
         sock = socket.socket()
         sock.bind((self.host, self.port))
-        sock.listen(0)
+        # NB: when Python 2.7 is no longer supported, the argument
+        # can be removed to use a default backlog size
+        sock.listen(5)
         return sock
 
     def _close_server_sock_ignore_errors(self):


### PR DESCRIPTION
Fix the listen() invocation for the test server not to pass a backlog
value of zero.  The value of zero means no backlog which effectively
means that the socket can not accept any connections.  This does not
matter for the majority of platforms since the value is only advisory
and the platform tends to go with a bigger backlog anyway.  However,
a few platforms (e.g. alpha or riscv Linux) do take the value literally,
and therefore the tests fail since they are unable to connect to
the server.  Let Python use a 'default reasonable value' instead.