### PR TITLE
fix typo

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -514,8 +514,8 @@ class TestRequests:
         assert p.headers['Authorization'] == _basic_auth_str(username, password)
 
     def test_basicauth_encodes_byte_strings(self):
-        """Ensure b'test' formats as the byte string "test" rather
-        than the unicode string "b'test'" in Python 3.
+        """Ensure b'test' formats as the byte string "b'test'" rather
+        than the unicode string "test" in Python 3.
         """
         auth = (b'\xc5\xafsername', b'test\xc6\xb6')
         r = requests.Request('GET', 'http://localhost', auth=auth)


### PR DESCRIPTION
byte string is `b'test'`, while unicode string is `'test'`