### PR TITLE
Move from urlparse to parse_url for prepending schemes

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -601,6 +601,7 @@ def test_parse_header_links(value, expected):
     'value, expected', (
         ('example.com/path', 'http://example.com/path'),
         ('//example.com/path', 'http://example.com/path'),
+        ('example.com:80', 'http://example.com:80'),
     ))
 def test_prepend_scheme_if_needed(value, expected):
     assert prepend_scheme_if_needed(value, 'http') == expected


### PR DESCRIPTION
This addresses the base problem raised in #5855 with the `urlparse` changes in Python 3.9 and potential issues in future 3.7/3.8 releases. We've avoided changing other uses of `urlparse` for now due to issues with `parse_url`'s strict validation requirements when performing parsing.