### PR TITLE
Add support for 3.10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy3 on Mac OS currently fails trying to compile

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=2.8.0,<=3.10.1
+pytest>=2.8.0,<=6.2.5
 pytest-cov
 pytest-httpbin==1.0.0
 pytest-mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
This will make sure we don't introduce any regressions into the code base prior to the official 3.10 release. At that point, we'll promote this to the normal test runner on all platforms.