### PR TITLE
Update lock-issues.yml

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 * * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
Run this hourly. I'm not seeing any effects, let's see if
running it more frequently will allow it to avoid the GitHub ratelimit

https://github.com/dessant/lock-threads#why-are-only-some-issues-and-pull-requests-processed