### PR TITLE
Pass `chunk_size` to `Response.iter_*` methods in a consistent way

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -697,7 +697,7 @@ class Response(object):
 
     def __iter__(self):
         """Allows you to use a response as an iterator."""
-        return self.iter_content(128)
+        return self.iter_content(chunk_size=128)
 
     @property
     def ok(self):
@@ -835,7 +835,7 @@ class Response(object):
             if self.status_code == 0 or self.raw is None:
                 self._content = None
             else:
-                self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
+                self._content = b''.join(self.iter_content(chunk_size=CONTENT_CHUNK_SIZE)) or b''
 
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3


### PR DESCRIPTION
Use case: we would like to set a default `chunk_size` as shown in the new test.

Current behavior errors (as shown in the first test-only commit):

```
>               self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
E               TypeError: iter_content() got multiple values for argument 'chunk_size'

.tox\default\lib\site-packages\requests\models.py:838: TypeError
```

The alternative would be adding a new instance attribute to serve as a fallback but I doubt new features are being considered before the next major release and we are currently blocked on this https://github.com/DataDog/integrations-core/pull/10183

cc @nateprewitt WDYT?