### PR TITLE
Update docs with for passing an array as a param

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -80,6 +80,16 @@ You can also pass a list of items as a value::
     >>> r = requests.get('https://httpbin.org/get', params=payload)
     >>> print(r.url)
     https://httpbin.org/get?key1=value1&key2=value2&key2=value3
+  
+**NOTE:** A lot of servers out there expect keys with an array as their value
+to be suffixed with a ``[]``. This is not compulsory, however it could save you
+from unexpected responses returned by third party servers.
+
+    >>> payload = {'key1': 'value1', 'key2[]': ['value2', 'value3']}
+
+    >>> r = requests.get('https://httpbin.org/get', params=payload)
+    >>> print(r.url)
+    https://httpbin.org/get?key1=value1&key2%5B%5D=value2&key2%5B%5D=value3
 
 Response Content
 ----------------


### PR DESCRIPTION
When passing an array for a `GET` request, some servers expect the key to be suffixed with a `[]`
to parse the URL correctly. Adding a note in the documentation for this case.

Further, Is it a good idea to make this behavior a default one? Concatenate a `[]` to the end of all keys
whose value is an array. Would love to hear your thoughts!