### PR TITLE
Skip the test requiring trustme when it is not available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import threading
 
 import pytest
 from requests.compat import urljoin
-import trustme
 
 
 def prepare_url(value):
@@ -38,6 +37,10 @@ def httpbin_secure(httpbin_secure):
 
 @pytest.fixture
 def nosan_server(tmp_path_factory):
+    # delay importing until the fixture in order to make it possible
+    # to deselect the test via command-line when trustme is not available
+    import trustme
+
     tmpdir = tmp_path_factory.mktemp("certs")
     ca = trustme.CA()
     # only commonName, no subjectAltName


### PR DESCRIPTION
Modify the nosan_server fixture to cause test_https_warnings to be
skipped when trustme is not installed on the system, rather than causing
the whole test suite to fail unconditionally.  This makes it possible
to run all the remaining tests on systems where trustme cannot be
installed due to its dependencies.