### PR TITLE
Run tox in parallel using -p instead of detox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	pip install -r requirements-dev.txt
 test:
 	# This runs all of the tests, on both Python 2 and Python 3.
-	detox
+	tox -p
 ci:
 	pytest tests --junitxml=report.xml
 


### PR DESCRIPTION
This updates `make test` to run tests in parallel using `tox -p` instead of `detox`. This has been supported since tox 3.7.0 and detox's PyPI page recommends switching to it.