### PR TITLE
Add success attribute for Response objects

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -933,6 +933,11 @@ class Response(object):
                 l[key] = link
 
         return l
+    
+    @property
+    def success(self):
+        """Returns True if :attr:`status_code` is in between 200 and 299, False if not."""
+        return self.status_code in range(200, 300)
 
     def raise_for_status(self):
         """Raises :class:`HTTPError`, if one occurred."""


### PR DESCRIPTION
Add an attribute that returns True when a status code is a success status code(in between 200 and 299 inclusive).