### PR TITLE
Fix erroneous use of 'schema' instead of 'scheme'

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -80,11 +80,11 @@ class TooManyRedirects(RequestException):
 
 
 class MissingSchema(RequestException, ValueError):
-    """The URL schema (e.g. http or https) is missing."""
+    """The URL scheme (e.g. http or https) is missing."""
 
 
 class InvalidSchema(RequestException, ValueError):
-    """See defaults.py for valid schemas."""
+    """The URL scheme provided is either invalid or unsupported."""
 
 
 class InvalidURL(RequestException, ValueError):

--- a/requests/models.py
+++ b/requests/models.py
@@ -386,7 +386,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             raise InvalidURL(*e.args)
 
         if not scheme:
-            error = ("Invalid URL {0!r}: No schema supplied. Perhaps you meant http://{0}?")
+            error = ("Invalid URL {0!r}: No scheme supplied. Perhaps you meant http://{0}?")
             error = error.format(to_native_string(url, 'utf8'))
 
             raise MissingSchema(error)


### PR DESCRIPTION
This PR closes #5984 by fixing the error message text for the incorrectly name `*Schema` exceptions. This is a temporary fix to minimize confusion until a time where the exceptions themselves can be renamed.

Also removed defunct reference to the old `defaults.py` module in one of the exceptions.