### PR TITLE
Update 3.10-dev to 3.10 and add pypy-3.7 in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy3 on Mac OS currently fails trying to compile
           # brotlipy. Moving pypy3 to only test linux.
           - python-version: pypy3
+            os: ubuntu-latest
+          - python-version: pypy-3.7
             os: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Updating `3.10-dev` to `3.10` in our CI and adding support for `pypy-3.7` since we're likely to be dropping `pypy3` support soon.