### PR TITLE
Adding missing dependancies for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: docs
 init:
-	pip install -e .[socks]
 	pip install -r requirements-dev.txt
 test:
 	# This runs all of the tests, on both Python 2 and Python 3.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-e .[socks]
 pytest>=2.8.0,<=6.2.5
 pytest-cov
 pytest-httpbin==1.0.0
@@ -6,5 +7,3 @@ httpbin==0.7.0
 Flask>=1.0,<2.0
 trustme
 wheel
-Pygments
-PySocks

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,5 @@ httpbin==0.7.0
 Flask>=1.0,<2.0
 trustme
 wheel
+Pygments
+PySocks


### PR DESCRIPTION
Pygments is mandatory for the Flask server. If Pygments is missing PyTest will not run :
```
=== ERRORS ===
___ ERROR collecting docs/_themes/flask_theme_support.py ___
docs\_themes\flask_theme_support.py:2: in <module>
    from pygments.style import Style
E   ModuleNotFoundError: No module named 'pygments'
=== short test summary info ===
ERROR docs/_themes/flask_theme_support.py - ModuleNotFoundError: No module named 'pygments'
```

PySocks is mandatory for test_lowlevel.py, if PySocks is missing 8 tests could fail: 
```
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[http_proxy-http] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[https_proxy-https] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[all_proxy-http] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[all_proxy-https] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[HTTP_PROXY-http] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[HTTPS_PROXY-https] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[ALL_PROXY-http] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
FAILED tests/test_lowlevel.py::test_use_proxy_from_environment[ALL_PROXY-https] - requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
```