### PR TITLE
Disable lock-threads on forks

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   action:
+    if: github.repository_owner == 'psf'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2


### PR DESCRIPTION
I noticed the GH actions in my fork are constantly running lock threads which isn't serving a purpose beyond burning compute time. This PR should restrict the action to just the primary repo.