### PR TITLE
fix session proxy issue

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -514,7 +514,7 @@ class Session(SessionRedirectMixin):
         )
         prep = self.prepare_request(req)
 
-        proxies = proxies or {}
+        proxies = proxies or self.proxies or {}
 
         settings = self.merge_environment_settings(
             prep.url, proxies, stream, verify, cert


### PR DESCRIPTION
Fix session proxy issue where Session.proxies is ignore on self.request().

#### Reproducible Code

```python
import requests
s = requests.Session()
s.proxies = proxy
s.get("https://google.com").text
```

