### PR TITLE
Reword proxies section and add warning

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -603,10 +603,19 @@ Alternatively you can configure it once for an entire
 
     session.get('http://example.org')
 
-When the proxies configuration is not overridden in python as shown above,
-by default Requests relies on the proxy configuration defined by standard
-environment variables ``http_proxy``, ``https_proxy``, ``no_proxy``, 
-``curl_ca_bundle``, and ``all_proxy``. Uppercase variants of these variables are also supported.
+.. warning::  Setting ``session.proxies`` may behave differently than expected.
+    Values provided will be overwritten by environmental proxies
+    (those returned by `urllib.request.getproxies <https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies>`_).
+    To ensure the use of proxies in the presence of environmental proxies,
+    explicitly specify the ``proxies`` argument on all individual requests as
+    initially explained above.
+
+    See `#2018 <https://github.com/psf/requests/issues/2018>`_ for details.
+
+When the proxies configuration is not overridden per request as shown above,
+Requests relies on the proxy configuration defined by standard
+environment variables ``http_proxy``, ``https_proxy``, ``no_proxy``,
+and ``all_proxy``. Uppercase variants of these variables are also supported.
 You can therefore set them to configure Requests (only set the ones relevant
 to your needs)::
 


### PR DESCRIPTION
This adds a warning around the Session proxies issues in Requests 2.x and cleans up a few erroneous sentences in the following section. Notably, rewording the environment intro to match the warning above, and removing `curl_ca_bundle` which was added in #5670. It's not particularly relevant to this section and is covered elsewhere.

## Preview Render
<img width="738" alt="Screen Shot 2022-02-18 at 6 20 06 PM" src="https://user-images.githubusercontent.com/5271761/154780254-5e7e16ac-b446-4fe8-93d4-917029f8f50e.png">
