### PR TITLE
Pin markupsafe for older versions of Jinja2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@ pytest-cov
 pytest-httpbin==1.0.0
 pytest-mock==2.0.0
 httpbin==0.7.0
-Flask>=1.0,<2.0
 trustme
 wheel
+
+# Flask Stack
+Flask>1.0,<2.0
+markupsafe<2.1


### PR DESCRIPTION
Fix for build issue in #6068. The release of `markupsafe==2.1` broke older versions of Jinja2 (specifically <3.0). We're still stuck on Flask 2.0 because our test suite broke when it was released and never got fixed. This is a temporary patch to get the test suite working again and I'm going to open an issue to track resolving the Flask issue.

Upstream issue: pallets/markupsafe#283