### PR TITLE
Fix inconsistent exception for JSONDecode error

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -900,6 +900,8 @@ class Response(object):
                     # and the server didn't bother to tell us what codec *was*
                     # used.
                     pass
+                except JSONDecodeError as e:
+                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
 
         try:
             return complexjson.loads(self.text, **kwargs)


### PR DESCRIPTION
This PR should address #6084 by adding appropriate handling for alternative utf encodings. The previous change in #5856 only accounted for the happy path where we would attempt to load directly from `.text`. This patch will now ensure we're also catching and raising the appropriate exception when we guess the encoding based on byte sequencing.