### PR TITLE
Rewrite version checks and split using iteration protocol

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -63,22 +63,17 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
         urllib3_version.append('0')
 
     # Check urllib3 for compatibility.
-    major, minor, patch = urllib3_version  # noqa: F811
-    major, minor, patch = int(major), int(minor), int(patch)
+    major, minor, patch = map(int, urllib3_version)  # noqa: F811
     # urllib3 >= 1.21.1, <= 1.26
-    assert major == 1
-    assert minor >= 21
-    assert minor <= 26
+    assert (1, 21, 1) <= (major, minor, patch) <= (1, 26)
 
     # Check charset_normalizer for compatibility.
     if chardet_version:
-        major, minor, patch = chardet_version.split('.')[:3]
-        major, minor, patch = int(major), int(minor), int(patch)
+        major, minor, patch = map(int, chardet_version.split('.')[:3])
         # chardet_version >= 3.0.2, < 5.0.0
         assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
     elif charset_normalizer_version:
-        major, minor, patch = charset_normalizer_version.split('.')[:3]
-        major, minor, patch = int(major), int(minor), int(patch)
+        major, minor, patch = map(int, charset_normalizer_version.split('.')[:3])
         # charset_normalizer >= 2.0.0 < 3.0.0
         assert (2, 0, 0) <= (major, minor, patch) < (3, 0, 0)
     else:


### PR DESCRIPTION
Make use of `map` and sequence unpacking in an iteration context to make the codes a little bit declarative.