### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# You can configure git to automatically use this file with the following config:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Add automatic code formatting to Requests
+2a6f290bc09324406708a4d404a88a45d848ddf9


### PR DESCRIPTION
Follow up to #6095 to add a .git-blame-ignore-revs file. This allows us to strip large cosmetic commits from the git blame history to help keep the information relevant to actual logic changes.