### PR TITLE
Avoid mutation of proxies input argument

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -757,8 +757,7 @@ class Session(SessionRedirectMixin):
             # Set environment's proxies.
             no_proxy = proxies.get("no_proxy") if proxies is not None else None
             env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
-            for (k, v) in env_proxies.items():
-                proxies.setdefault(k, v)
+            proxies = {**env_proxies, **proxies}
 
             # Look for requests environment configuration
             # and be compatible with cURL.


### PR DESCRIPTION
Resolves #6118

Makes sure that the input argument to `proxies` is not mutated.