### PR TITLE
Add and use new exception when redirect url is invalid

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -192,3 +192,4 @@ Patches and Suggestions
 - Alessio Izzo (`@aless10 <https://github.com/aless10>`_)
 - Sylvain Marié (`@smarie <https://github.com/smarie>`_)
 - Hod Bin Noon (`@hodbn <https://github.com/hodbn>`_)
+- Łukasz Setla (`@setla <https://github.com/setla>`_)

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -4,7 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
-from urllib3.exceptions import HTTPError as BaseHTTPError
+from urllib3.exceptions import HTTPError as BaseHTTPError, LocationParseError
 
 from .compat import JSONDecodeError as CompatJSONDecodeError
 
@@ -96,6 +96,10 @@ class InvalidSchema(RequestException, ValueError):
 
 class InvalidURL(RequestException, ValueError):
     """The URL provided was somehow invalid."""
+
+
+class InvalidRedirectURL(InvalidURL, InvalidSchema, LocationParseError):
+    """The redirect URL was somehow invalid."""
 
 
 class InvalidHeader(RequestException, ValueError):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -35,6 +35,7 @@ from requests.exceptions import (
     InvalidProxyURL,
     InvalidSchema,
     InvalidURL,
+    InvalidRedirectURL,
     MissingSchema,
     ProxyError,
     ReadTimeout,
@@ -2657,9 +2658,19 @@ class TestPreparingURLs:
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()
 
-    @pytest.mark.parametrize("url, exception", (("http://localhost:-1", InvalidURL),))
-    def test_redirecting_to_bad_url(self, httpbin, url, exception):
-        with pytest.raises(exception):
+    @pytest.mark.parametrize(
+        "url",
+        (
+            ("localhost.localdomain:3128/",),
+            ("10.122.1.1:3128/",),
+            ("http://.example.com",),
+            ("http://☃.net/",),
+            ("http://localhost:-1",),
+            ("http://example.org:non_int_port/",),
+        ),
+    )
+    def test_redirecting_to_bad_url(self, httpbin, url):
+        with pytest.raises(InvalidRedirectURL):
             requests.get(httpbin("redirect-to"), params={"url": url})
 
     @pytest.mark.parametrize(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2669,7 +2669,8 @@ class TestPreparingURLs:
             ("http://example.org:non_int_port/",),
         ),
     )
-    def test_redirecting_to_bad_url(self, httpbin, url):
+    def test_redirecting_to_bad_url(self, httpbin, mocker, url):
+        mocker.patch('requests.utils.proxy_bypass', return_value=False)
         with pytest.raises(InvalidRedirectURL):
             requests.get(httpbin("redirect-to"), params={"url": url})
 


### PR DESCRIPTION
Feature described in issue https://github.com/psf/requests/issues/6120

new `InvalidRedirectURL` inherits `InvalidURL, InvalidSchema, LocationParseError` for backward compatibility 