### PR TITLE
Fix output of test_lowlevel tests in case of timeout

### DIFF
--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -115,7 +115,8 @@ class Server(threading.Thread):
 
     def __enter__(self):
         self.start()
-        self.ready_event.wait(self.WAIT_EVENT_TIMEOUT)
+        if not self.ready_event.wait(self.WAIT_EVENT_TIMEOUT):
+            raise RuntimeError("Timeout waiting for server to be ready.")
         return self.host, self.port
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
Hello,

The tests in `test_lowlevel.py` use the `testserver.server.Server` thread object.

When using the object as a context manager, we wait until the server thread is ready with a timeout.

Unfortunately, if the timeout is reached, we would not propagate the error. Instead, we would return from the `__enter__` method and access the `with` body with an uninitialized value for `port` (i.e., `port = 0`).

Therefore, the tests would fail with:

```
E           urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7fc3a3e30a90>: Failed to establish a new connection: [Errno 111] Connection refused

/usr/lib/python3/dist-packages/urllib3/connection.py:181: NewConnectionError
```
Reading this error does not make it obvious that this is the result of a timeout.

Fixed by raising an error in case of timeout, which makes it more obvious:

```
        if not self.ready_event.wait(self.WAIT_EVENT_TIMEOUT):
>           raise RuntimeError("Timeout waiting for server to be ready.")
E           RuntimeError: Timeout waiting for server to be ready.

tests/testserver/server.py:119: RuntimeError
```
_The reason why I had a timeout on my end was because my environment was not resolving "localhost" as it should have. Requests were going through the DNS and therefore end-up hitting the timeout_

The resolution was happening and taking forever during this instruction:
```
sock.bind((self.host, self.port))
```

Thanks,
Olivier