### PR TITLE
Allow tests to run if HTTP proxy env variables are already present,

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -189,21 +189,23 @@ class TestRequests:
     @pytest.mark.parametrize("scheme", ("http://", "HTTP://", "hTTp://", "HttP://"))
     def test_mixed_case_scheme_acceptable(self, httpbin, scheme):
         s = requests.Session()
-        s.proxies = getproxies()
-        parts = urlparse(httpbin("get"))
-        url = scheme + parts.netloc + parts.path
-        r = requests.Request("GET", url)
-        r = s.send(r.prepare())
-        assert r.status_code == 200, f"failed for scheme {scheme}"
+        with override_environ(http_proxy=None, https_proxy=None):
+            s.proxies = getproxies()
+            parts = urlparse(httpbin("get"))
+            url = scheme + parts.netloc + parts.path
+            r = requests.Request("GET", url)
+            r = s.send(r.prepare())
+            assert r.status_code == 200, f"failed for scheme {scheme}"
 
     def test_HTTP_200_OK_GET_ALTERNATIVE(self, httpbin):
         r = requests.Request("GET", httpbin("get"))
         s = requests.Session()
-        s.proxies = getproxies()
+        with override_environ(http_proxy=None, https_proxy=None):
+            s.proxies = getproxies()
 
-        r = s.send(r.prepare())
+            r = s.send(r.prepare())
 
-        assert r.status_code == 200
+            assert r.status_code == 200
 
     def test_HTTP_302_ALLOW_REDIRECT_GET(self, httpbin):
         r = requests.get(httpbin("redirect", "1"))
@@ -578,8 +580,9 @@ class TestRequests:
         ),
     )
     def test_errors(self, url, exception):
-        with pytest.raises(exception):
-            requests.get(url, timeout=1)
+        with override_environ(http_proxy=None, https_proxy=None):
+            with pytest.raises(exception):
+                requests.get(url, timeout=1)
 
     def test_proxy_error(self):
         # any proxy related error (address resolution, no route to host, etc) should result in a ProxyError
@@ -602,14 +605,14 @@ class TestRequests:
             requests.get(httpbin(), proxies={"http": "http:///example.com:8080"})
 
     def test_respect_proxy_env_on_send_self_prepared_request(self, httpbin):
-        with override_environ(http_proxy=INVALID_PROXY):
+        with override_environ(no_proxy=None, http_proxy=INVALID_PROXY):
             with pytest.raises(ProxyError):
                 session = requests.Session()
                 request = requests.Request("GET", httpbin())
                 session.send(request.prepare())
 
     def test_respect_proxy_env_on_send_session_prepared_request(self, httpbin):
-        with override_environ(http_proxy=INVALID_PROXY):
+        with override_environ(no_proxy=None, http_proxy=INVALID_PROXY):
             with pytest.raises(ProxyError):
                 session = requests.Session()
                 request = requests.Request("GET", httpbin())
@@ -617,7 +620,7 @@ class TestRequests:
                 session.send(prepared)
 
     def test_respect_proxy_env_on_send_with_redirects(self, httpbin):
-        with override_environ(http_proxy=INVALID_PROXY):
+        with override_environ(no_proxy=None, http_proxy=INVALID_PROXY):
             with pytest.raises(ProxyError):
                 session = requests.Session()
                 url = httpbin("redirect/1")
@@ -626,13 +629,13 @@ class TestRequests:
                 session.send(request.prepare())
 
     def test_respect_proxy_env_on_get(self, httpbin):
-        with override_environ(http_proxy=INVALID_PROXY):
+        with override_environ(no_proxy=None, http_proxy=INVALID_PROXY):
             with pytest.raises(ProxyError):
                 session = requests.Session()
                 session.get(httpbin())
 
     def test_respect_proxy_env_on_request(self, httpbin):
-        with override_environ(http_proxy=INVALID_PROXY):
+        with override_environ(no_proxy=None, http_proxy=INVALID_PROXY):
             with pytest.raises(ProxyError):
                 session = requests.Session()
                 session.request(method="GET", url=httpbin())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,8 @@ def override_environ(**kwargs):
     save_env = dict(os.environ)
     for key, value in kwargs.items():
         if value is None:
-            del os.environ[key]
+            with contextlib.suppress(KeyError):
+                del os.environ[key]
         else:
             os.environ[key] = value
     try:


### PR DESCRIPTION
Hello,

The following tests fail if HTTP proxy environment variables are already set:

```
FAILED tests/test_requests.py::TestRequests::test_mixed_case_scheme_acceptable
FAILED tests/test_requests.py::TestRequests::test_HTTP_302_ALLOW_REDIRECT_GET
FAILED tests/test_requests.py::TestRequests::test_errors[http://doesnotexist.google.com-ConnectionError]
FAILED tests/test_requests.py::TestRequests::test_respect_proxy_env_on_send_self_prepared_request
FAILED tests/test_requests.py::TestRequests::test_respect_proxy_env_on_send_session_prepared_request
FAILED tests/test_requests.py::TestRequests::test_respect_proxy_env_on_send_with_redirects
FAILED tests/test_requests.py::TestRequests::test_respect_proxy_env_on_get - ...
FAILED tests/test_requests.py::TestRequests::test_respect_proxy_env_on_request
```

The variables affecting the tests are:

 * `http_proxy` (and `https_proxy` potentially)
 * `no_proxy`

Fixed by overriding their value if they are already present in the environment.

The `override_environ` function would fail if attempting to delete a variable that is not in the environment. Added a `suppress(KeyError)` construct around the `del` instruction to fix it.

Thanks,
Oilvier