### PR TITLE
Cleanup the docs sidebar

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -8,39 +8,11 @@
   <iframe src="https://ghbtns.com/github-btn.html?user=psf&repo=requests&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-<style>
-  .algolia-autocomplete {
-    width: 100%;
-    height: 1.5em
-  }
-
-  .algolia-autocomplete a {
-    border-bottom: none !important;
-  }
-
-  #doc_search {
-    width: 100%;
-    height: 100%;
-  }
-</style>
-<input id="doc_search" placeholder="Search the doc" autofocus />
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
-  apiKey: 'f177061e2354c50a97bfc635e827ffab',
-  indexName: 'python-requests',
-  inputSelector: '#doc_search',
-  debug: false // Set debug to true if you want to inspect the dropdown
-})" async></script>
 
 <p>
   Requests is an elegant and simple HTTP library for Python, built for
   human beings.
 </p>
-<p>Sponsored by <strong><a href="https://www.govcert.lu">CERT Gouvernemental - GOVCERT.LU</a></strong>.</p>
-
-<script async type="text/javascript"
-  src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=CKYI5K3E&placement=pythonrequestsorg"
-  id="_carbonads_js"></script>
 
 <h3>Useful Links</h3>
 <ul>
@@ -59,20 +31,6 @@
   <li><a href="https://github.com/psf/requests">Requests @ GitHub</a></li>
   <li><a href="https://pypi.org/project/requests/">Requests @ PyPI</a></li>
   <li><a href="https://github.com/psf/requests/issues">Issue Tracker</a></li>
-</ul>
-
-
-<h3>Translations</h3>
-
-<ul>
-  <li><a href="https://requests.readthedocs.io/">English</a></li>
-  <li><a href="https://fr.python-requests.org/">French</a></li>
-  <li><a href="https://de.python-requests.org/">German</a></li>
-  <li><a href="https://jp.python-requests.org/">Japanese</a></li>
-  <li><a href="https://cn.python-requests.org/">Chinese</a></li>
-  <li><a href="https://pt.python-requests.org/">Portuguese</a></li>
-  <li><a href="https://it.python-requests.org/">Italian</a></li>
-  <li><a href="https://es.python-requests.org/">Spanish</a></li>
 </ul>
 
 <div id="native-ribbon">

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -2,41 +2,12 @@
   <iframe src="https://ghbtns.com/github-btn.html?user=psf&repo=requests&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-<style>
-  .algolia-autocomplete {
-    width: 100%;
-    height: 1.5em
-  }
-
-  .algolia-autocomplete a {
-    border-bottom: none !important;
-  }
-
-  #doc_search {
-    width: 100%;
-    height: 100%;
-  }
-</style>
-<input id="doc_search" placeholder="Search the doc" autofocus />
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
-  apiKey: 'f177061e2354c50a97bfc635e827ffab',
-  indexName: 'python-requests',
-  inputSelector: '#doc_search',
-  debug: false // Set debug to true if you want to inspect the dropdown
-})" async></script>
 
 <p>
   Requests is an elegant and simple HTTP library for Python, built for
   human beings. You are currently looking at the documentation of the
   development release.
 </p>
-
-<p>Sponsored by <strong><a href="https://www.govcert.lu">CERT Gouvernemental - GOVCERT.LU</a></strong>.</p>
-
-  <script async type="text/javascript"
-    src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=pythonrequestsorg"
-    id="_carbonads_js"></script>
 
 <h3>Useful Links</h3>
 <ul>
@@ -57,15 +28,3 @@
   <li><a href="https://github.com/psf/requests/issues">Issue Tracker</a></li>
 </ul>
 
-  <h3>Translations</h3>
-
-  <ul>
-    <li><a href="https://requests.readthedocs.io/">English</a></li>
-    <li><a href="https://fr.python-requests.org/">French</a></li>
-    <li><a href="https://de.python-requests.org/">German</a></li>
-    <li><a href="https://jp.python-requests.org/">Japanese</a></li>
-    <li><a href="https://cn.python-requests.org/">Chinese</a></li>
-    <li><a href="https://pt.python-requests.org/">Portuguese</a></li>
-    <li><a href="https://it.python-requests.org/">Italian</a></li>
-    <li><a href="https://es.python-requests.org/">Spanish</a></li>
-  </ul>


### PR DESCRIPTION
This PR should address some of the issues raised in #6142. The translation guides are mostly 10+ years out of date at this point. We're going to remove them from the sidebar for now since they're providing limited value.

We're also removing the algolia search bar as it's not functioning as intended. Several features have been added to RTD since we introduced algolia, and there's better options at this point. We may look at adding something like [this](https://docs.readthedocs.io/en/stable/guides/advanced-search.html) in a future PR, but for now the quicksearch at the bottom of the sidebar should be sufficient.