### PR TITLE
Reduce lock thread runs to daily

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *'
 
 permissions:
   issues: write
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'psf'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
             issue-lock-inactive-days: 90
             pr-lock-inactive-days: 90


### PR DESCRIPTION
We moved the lock thread GH action to hourly to push through our initial backlog and never updated it. We're wasting a lot of compute and cluttering our action log with the existing settings. This PR will reduce the job to only run once a day going forward. We'll also update the action from v2 to v3 while we're here.