### PR TITLE
Use SPDX License ID correctly

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -35,7 +35,7 @@ The other HTTP methods are supported - see `requests.api`. Full documentation
 is at <https://requests.readthedocs.io>.
 
 :copyright: (c) 2017 by Kenneth Reitz.
-:license: Apache 2.0, see LICENSE for more details.
+:license: Apache-2.0, see LICENSE for more details.
 """
 
 import warnings

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -9,6 +9,6 @@ __version__ = "2.27.1"
 __build__ = 0x022701
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
-__license__ = "Apache 2.0"
+__license__ = "Apache-2.0"
 __copyright__ = "Copyright 2022 Kenneth Reitz"
 __cake__ = "\u2728 \U0001f370 \u2728"


### PR DESCRIPTION
[Software Package Data Exchange (SPDX)](https://spdx.org/) is an open standard for communication software bill of material information.

According to the [SPDX License List](https://spdx.org/licenses) `Apache-2.0` is an unambiguous short identifier for the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), which holds for the requests project.

This PR proposes to use this SPDX Identifier rather than `Apache 2.0` (without hyphen). Note that the proposed change does not change the license of the project but rather declares it unambiguously in a machine-readable format. As a result, the packaged version on PyPi will also be updated once requests is built again and all metadata crawlers will benefit from the change.