### PR TITLE
Add validation for header name

### DIFF
--- a/requests/_internal_utils.py
+++ b/requests/_internal_utils.py
@@ -5,8 +5,19 @@ requests._internal_utils
 Provides utility functions that are consumed internally by Requests
 which depend on extremely few external helpers (such as compat)
 """
+import re
 
 from .compat import builtin_str
+
+_VALID_HEADER_NAME_RE_BYTE = re.compile(rb"^[^:\s][^:\r\n]*$")
+_VALID_HEADER_NAME_RE_STR = re.compile(r"^[^:\s][^:\r\n]*$")
+_VALID_HEADER_VALUE_RE_BYTE = re.compile(rb"^\S[^\r\n]*$|^$")
+_VALID_HEADER_VALUE_RE_STR = re.compile(r"^\S[^\r\n]*$|^$")
+
+HEADER_VALIDATORS = {
+    bytes: (_VALID_HEADER_NAME_RE_BYTE, _VALID_HEADER_VALUE_RE_BYTE),
+    str: (_VALID_HEADER_NAME_RE_STR, _VALID_HEADER_VALUE_RE_STR),
+}
 
 
 def to_native_string(string, encoding="ascii"):


### PR DESCRIPTION
Following up on #6083, this refactors our header validation function from 2.11.0 to consider the header name. We'd originally avoided adding header name validation because we wanted to limit the change scope to header splitting with new lines. Since then the standard library has made similar changes to ours and now raises a ValueError in `http.client`. This gives us inconsistent errors depending on which portion of the header you provide a bad value.

```python
>>> requests.get("https://httpbin.org/get", headers={":bad": "header"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nateprewitt/Work/OpenSource/requests/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/Users/nateprewitt/Work/OpenSource/requests/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/nateprewitt/Work/OpenSource/requests/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/nateprewitt/Work/OpenSource/requests/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/Users/nateprewitt/Work/OpenSource/requests/requests/adapters.py", line 489, in send
    resp = conn.urlopen(
  File "/Users/nateprewitt/Work/OpenSource/urllib3/src/urllib3/connectionpool.py", line 727, in urlopen
    httplib_response = self._make_request(
  File "/Users/nateprewitt/Work/OpenSource/urllib3/src/urllib3/connectionpool.py", line 433, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/Users/nateprewitt/Work/OpenSource/urllib3/src/urllib3/connection.py", line 309, in request
    super().request(method, url, body=body, headers=headers)
  File "/Users/nateprewitt/.pyenv/versions/3.10.4/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Users/nateprewitt/.pyenv/versions/3.10.4/lib/python3.10/http/client.py", line 1323, in _send_request
    self.putheader(hdr, value)
  File "/Users/nateprewitt/Work/OpenSource/urllib3/src/urllib3/connection.py", line 274, in putheader
    super().putheader(header, *values)
  File "/Users/nateprewitt/.pyenv/versions/3.10.4/lib/python3.10/http/client.py", line 1250, in putheader
    raise ValueError('Invalid header name %r' % (header,))
ValueError: Invalid header name b':bad'
```

This PR ports the [validation scheme](https://github.com/python/cpython/blob/6b9122483f1f26afb0c41bd676f9754ffe726e18/Lib/http/client.py#L139) from http.client for header names and ensures we raise an `InvalidHeader` error consistently in all supported versions.