### PR TITLE
Run 3.11 CI on all platforms

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu-18.04, macOS-latest, windows-latest]
         include:
           # pypy-3.7 on Mac OS currently fails trying to compile
@@ -17,9 +17,6 @@ jobs:
           - python-version: pypy-3.7
             os: ubuntu-latest
             experimental: false
-          - python-version: 3.11-dev
-            os: ubuntu-latest
-            experimental: true
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Start testing 3.11-dev on both Windows and macOS since we're publishing 2.28.0 claiming support for 3.11 with our trove classifier.