### PR TITLE
v2.28.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,15 +6,34 @@ dev
 
 - \[Short description of non-trivial change.\]
 
-**Bugfixes**
 
-- Fixed urllib3 exception leak, wrapping `urllib3.exceptions.SSLError` with
-  `requests.exceptions.SSLError` for `content` and `iter_content`.
+2.28.0 (2022-06-09)
+-------------------
 
 **Deprecations**
 
-- ⚠️ Requests has officially dropped support for Python 2.7. ⚠️
-- Requests has officially dropped support for Python 3.6 (including pypy3).
+- ⚠️ Requests has officially dropped support for Python 2.7. ⚠️ (#6091)
+- Requests has officially dropped support for Python 3.6 (including pypy3.6). (#6091)
+
+**Improvements**
+
+- Wrap JSON parsing issues in Request's JSONDecodeError for payloads without
+  an encoding to make `json()` API consistent. (#6097)
+- Parse header components consistently, raising an InvalidHeader error in
+  all invalid cases. (#6154)
+- Added provisional 3.11 support with current beta build. (#6155)
+- Requests got a makeover and we decided to paint it black. (#6095)
+
+**Bugfixes**
+
+- Fixed bug where setting `CURL_CA_BUNDLE` to an empty string would disable
+  cert verification. All Requests 2.x versions before 2.28.0 are affected. (#6074)
+- Fixed urllib3 exception leak, wrapping `urllib3.exceptions.SSLError` with
+  `requests.exceptions.SSLError` for `content` and `iter_content`. (#6057)
+- Fixed issue where invalid Windows registry entires caused proxy resolution
+  to raise an exception rather than ignoring the entry. (#6149)
+- Fixed issue where entire payload could be included in the error message for
+  JSONDecodeError. (#6036)
 
 2.27.1 (2022-01-05)
 -------------------

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.27.1"
-__build__ = 0x022701
+__version__ = "2.28.0"
+__build__ = 0x022800
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache 2.0"


### PR DESCRIPTION
2.28.0 (2022-06-09)
-------------------

**Deprecations**

- ⚠️ Requests has officially dropped support for Python 2.7. ⚠️ (#6091)
- Requests has officially dropped support for Python 3.6 (including pypy3). (#6091)

**Improvements**

- Wrap JSON parsing issues in Request's JSONDecodeError for payloads without
  an encoding to make `json()` API consistent. (#6097)
- Parse header components consistently, raising an InvalidHeader error in
  all invalid cases. (#6154)
- Added provisional 3.11 support with current beta build. (#6155)
- Requests got a makeover and we decided to paint it black. (#6095)

**Bugfixes**

- Fixed bug where setting `CURL_CA_BUNDLE` to an empty string would disable
  cert verification. All Requests 2.x versions before 2.28.0 are affected. (#6074)
- Fixed urllib3 exception leak, wrapping `urllib3.exceptions.SSLError` with
  `requests.exceptions.SSLError` for `content` and `iter_content`. (#6057)
- Fixed issue where invalid Windows registry entires caused proxy resolution
  to raise an exception rather than ignoring the entry. (#6149)
- Fixed issue where entire payload could be included in the error message for
  JSONDecodeError. (#6079 