### PR TITLE
Add union operator support to CaseInsensitiveDict (PEP 584)

### DIFF
--- a/requests/structures.py
+++ b/requests/structures.py
@@ -60,6 +60,27 @@ class CaseInsensitiveDict(MutableMapping):
     def __len__(self):
         return len(self._store)
 
+    def __or__(self, other):
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        new = self.copy()
+        new.update(other)
+        return new
+
+    def __ror__(self, other):
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        new = CaseInsensitiveDict(other)
+        new.update(self)
+        return new
+
+    def __ior__(self, other):
+        self.update(other)
+
+        return self
+
     def lower_items(self):
         """Like iteritems(), but with all lowercase keys."""
         return ((lowerkey, keyval[1]) for (lowerkey, keyval) in self._store.items())

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -26,6 +26,29 @@ class TestCaseInsensitiveDict:
         del self.case_insensitive_dict[key]
         assert key not in self.case_insensitive_dict
 
+    def test_or(self):
+        assert self.case_insensitive_dict | {"Accept": "application/xml"} == {
+            "Accept": "application/xml"
+        }
+        assert self.case_insensitive_dict | {"Accept-Encoding": "gzip"} == {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+        }
+
+    def test_ror(self):
+        assert {"Accept": "application/xml"} | self.case_insensitive_dict == {
+            "Accept": "application/json"
+        }
+        assert {"Accept-Encoding": "gzip"} | self.case_insensitive_dict == {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+        }
+
+    def test_ior(self):
+        copy = self.case_insensitive_dict.copy()
+        copy |= {"Accept": "application/xml"}
+        assert copy == {"Accept": "application/xml"}
+
     def test_lower_items(self):
         assert list(self.case_insensitive_dict.lower_items()) == [
             ("accept", "application/json")


### PR DESCRIPTION
Adds support for the `|` and `|=` operators for `CaseInsensitiveDict`.

This copies the functionality of `dict` from [PEP 584](https://peps.python.org/pep-0584). Even though this PEP was implemented in 3.9, the functionality implemented to `CaseInsensitiveDict` still works in all currently supported versions (3.7+).

This also brings a level of consistency with other Mapping types, i.e. `OrderedDict`, `MappingProxyType`, `ChainMap`, `WeakKeyDictionary`, and more have this as supported behavior.

The code itself is a slightly modified version of the [reference implementation](https://peps.python.org/pep-0584/#reference-implementation).

Example usage:
```python3
session = Session()
session.headers |= {'Accept', 'application/json'}
```