### PR TITLE
Allow charset normalizer >=2 and <3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ provides-extra =
     use_chardet_on_py3
 requires-dist =
     certifi>=2017.4.17
-    charset_normalizer~=2.0.0
+    charset_normalizer>=2,<3
     idna>=2.5,<4
     urllib3>=1.21.1,<1.27
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 requires = [
-    "charset_normalizer~=2.0.0",
+    "charset_normalizer>=2,<3",
     "idna>=2.5,<4",
     "urllib3>=1.21.1,<1.27",
     "certifi>=2017.4.17",


### PR DESCRIPTION
The current definition `charset_normalizer~=2.0.0` does not allow charset-normalizer 2.1.0 which has been released a couple of hours ago. The newer version seems to be compatible with requests and [the compatibility check](https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L80-L84) suggests that requests should allow versions up to 3.0.