### PR TITLE
Update Dependency with `charset_normalizer>=2.0.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ provides-extra =
     use_chardet_on_py3
 requires-dist =
     certifi>=2017.4.17
-    charset_normalizer~=2.0.0
+    charset_normalizer>=2.0.0
     idna>=2.5,<4
     urllib3>=1.21.1,<1.27
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 requires = [
-    "charset_normalizer~=2.0.0",
+    "charset_normalizer>=2.0.0",
     "idna>=2.5,<4",
     "urllib3>=1.21.1,<1.27",
     "certifi>=2017.4.17",


### PR DESCRIPTION
https://github.com/Ousret/charset_normalizer/releases/tag/2.1.0 was released on 2022-06-20, with our current dependency with `charset_normalizer~=2.0.0` we couldn't upgrade to 2.1.0 accordingly.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>