### PR TITLE
Update Dependency with `chardet>=3.0.2,<6`

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -75,8 +75,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     if chardet_version:
         major, minor, patch = chardet_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, < 5.0.0
-        assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
+        # chardet_version >= 3.0.2, < 6.0.0
+        assert (3, 0, 2) <= (major, minor, patch) < (6, 0, 0)
     elif charset_normalizer_version:
         major, minor, patch = charset_normalizer_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
     extras_require={
         "security": [],
         "socks": ["PySocks>=1.5.6, !=1.5.7"],
-        "use_chardet_on_py3": ["chardet>=3.0.2,<5"],
+        "use_chardet_on_py3": ["chardet>=3.0.2,<6"],
     },
     project_urls={
         "Documentation": "https://requests.readthedocs.io",


### PR DESCRIPTION
https://github.com/chardet/chardet/releases/tag/5.0.0 was released on 2022-06-25 with remove of Python 3.6 support, which also align with our Python > 3.6 requirement.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>