### PR TITLE
(Github Actions [Lint, CodeQL Analysis]) Update action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -38,7 +38,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: "python"
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.0.0
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Currently at the moment, Lint is behind by one version for this repository and CodeQL Analysis is behind by two versions. I've updated to the latest versions for them and have checked the repositories used in the files and have confirmed that the versions exists.