### PR TITLE
refactor: prefer f-strings to format where fits within black lengths

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -94,9 +94,10 @@ def _check_cryptography(cryptography_version):
         return
 
     if cryptography_version < [1, 3, 4]:
-        warning = "Old version of cryptography ({}) may cause slowdown.".format(
-            cryptography_version
+        warning = (
+            f"Old version of cryptography ({cryptography_version}) may cause slowdown."
         )
+
         warnings.warn(warning, RequestsDependencyWarning)
 
 

--- a/requests/auth.py
+++ b/requests/auth.py
@@ -59,8 +59,8 @@ def _basic_auth_str(username, password):
     if isinstance(password, str):
         password = password.encode("latin1")
 
-    authstr = "Basic " + to_native_string(
-        b64encode(b":".join((username, password))).strip()
+    authstr = (
+        f'Basic {to_native_string(b64encode(b":".join((username, password))).strip())}'
     )
 
     return authstr

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -840,9 +840,9 @@ def select_proxy(url, proxies):
         return proxies.get(urlparts.scheme, proxies.get("all"))
 
     proxy_keys = [
-        urlparts.scheme + "://" + urlparts.hostname,
+        f"{urlparts.scheme}://{urlparts.hostname}",
         urlparts.scheme,
-        "all://" + urlparts.hostname,
+        f"all://{urlparts.hostname}",
         "all",
     ]
     proxy = None


### PR DESCRIPTION
Python added f-strings in version 3.6, with [PEP 498](https://www.python.org/dev/peps/pep-0498/). F-strings are a flexible and powerful way to format strings. They make the code shorter and more readable, since the code now looks more like the output.

F-Strings are also more performant than using `.format` (e.g. see [F-String Speed Considerations](https://realpython.com/lessons/f-strings-speed-considerations-performance/), [F-String Benchmarks](https://www.scivision.dev/python-f-string-speed/) for two quick examples) because the python runtime can insert the variables into the string while parsing rather than backtracking to insert them into the placeholders, reducing the number of times the lines need to be processed