### PR TITLE
refactor: prefer dictionary comphrension to loop

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -461,11 +461,7 @@ def dict_from_cookiejar(cj):
     :rtype: dict
     """
 
-    cookie_dict = {}
-
-    for cookie in cj:
-        cookie_dict[cookie.name] = cookie.value
-
+    cookie_dict = {cookie.name: cookie.value for cookie in cj}
     return cookie_dict
 
 


### PR DESCRIPTION
A dictionary comprehension can create the dictionary on one line, cutting out the clutter of declaring an empty dict and then adding items.

Squeezing code onto one line can make it more difficult to read, but for comprehensions this isn't the case. All of the elements that you need are nicely presented, and once you are used to the syntax it is actually more readable than the for loop version. Given the attribute names, this is still readable due to lack of conditional behavior.

Another point is that the assignment is now more of an atomic operation - we're declaring what `cookie_dict` is rather than giving instructions on how to build it. This makes the code read like more of a narrative, since going forward we will care more about what `cookie_dict` is than the details of its construction.

Finally comprehensions will usually execute more quickly than building the collection in a loop, which is another factor if performance is a consideration. As cookies are variable in quantity, this may be of value in this location