### PR TITLE
Fixed warnings message to suggest using secure protocol.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -438,7 +438,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         if not scheme:
             raise MissingSchema(
                 f"Invalid URL {url!r}: No scheme supplied. "
-                f"Perhaps you meant http://{url}?"
+                f"Perhaps you meant https://{url}?"
             )
 
         if not host:


### PR DESCRIPTION
Small update to suggest secure schema in the error message:
> Perhaps you meant https://

Instead of 
> Perhaps you meant http://