### PR TITLE
Adding native support for Bearer token authentication objects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -192,3 +192,4 @@ Patches and Suggestions
 - Alessio Izzo (`@aless10 <https://github.com/aless10>`_)
 - Sylvain Marié (`@smarie <https://github.com/smarie>`_)
 - Hod Bin Noon (`@hodbn <https://github.com/hodbn>`_)
+- Karien Lessing (`@Karien98 <https://github.com/Karien98>`_)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,7 +15,7 @@ from urllib3.util import Timeout as Urllib3Timeout
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.auth import HTTPDigestAuth, _basic_auth_str
+from requests.auth import HTTPDigestAuth, _basic_auth_str, _bearer_token_auth_str
 from requests.compat import (
     JSONDecodeError,
     Morsel,
@@ -1999,6 +1999,21 @@ class TestRequests:
         assert isinstance(s, builtin_str)
         assert s == auth_str
 
+      @pytest.mark.parametrize(
+        "token, auth_str",
+        (
+            ("test", "Bearer dGVzdA=="),
+            (
+                "dGVzdDp0ZXN0".encode(),
+                "Bearer ZEdWemREcDBaWE4w",
+            ),
+        ),
+    )
+    def test_bearer_token_auth_str(self, token, auth_str):
+        s = _bearer_token_auth_str(token)
+        assert isinstance(s, builtin_str)
+        assert s == auth_str      
+        
     def test_requests_history_is_saved(self, httpbin):
         r = requests.get(httpbin("redirect/5"))
         total = r.history[-1].history


### PR DESCRIPTION
added to auth.py:
class HTTPBearerTokenAuth(AuthBase):
def _bearer_token_auth_str(token):

added 1 test case to test_requests.py

All tests passed locally