### PR TITLE
Fix links in docs to the kenreitz.org domain, which expired.

### DIFF
--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -29,12 +29,10 @@ Be Cordial
 
 Requests has one very important rule governing all forms of contribution,
 including reporting bugs or requesting features. This golden rule is
-"`be cordial or be on your way`_".
+"be cordial or be on your way".
 
 **All contributions are welcome**, as long as
 everyone involved is treated with respect.
-
-.. _be cordial or be on your way: https://kenreitz.org/essays/2013/01/27/be-cordial-or-be-on-your-way
 
 .. _early-feedback:
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1027,7 +1027,7 @@ library to use SSLv3::
                 num_pools=connections, maxsize=maxsize,
                 block=block, ssl_version=ssl.PROTOCOL_SSLv3)
 
-.. _`described here`: https://kenreitz.org/essays/2012/06/14/the-future-of-python-http
+.. _`described here`: https://web.archive.org/web/20220204220709/https://kennethreitz.org/essays/2012/06/14/the-future-of-python-http
 .. _`urllib3`: https://github.com/urllib3/urllib3
 
 .. _blocking-or-nonblocking:


### PR DESCRIPTION
When I was studying Contributor’s Guide, I found that links to kenreitz.org are broken.

- "The Future of Python HTTP" was archived by Internet Archive, so I linked there.
- "Be cordial or be on your way" was not archived, so I removed the link.
- "A Kenneth Reitz Project." in a footer is broken too, but I did not touch that link.