### PR TITLE
Suppress context when requests.exceptions.JSONDecodeError is raised.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -965,14 +965,14 @@ class Response:
                     # used.
                     pass
                 except JSONDecodeError as e:
-                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
+                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos) from None
 
         try:
             return complexjson.loads(self.text, **kwargs)
         except JSONDecodeError as e:
             # Catch JSON-related errors and raise as requests.JSONDecodeError
             # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
-            raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
+            raise RequestsJSONDecodeError(e.msg, e.doc, e.pos) from None
 
     @property
     def links(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2752,6 +2752,8 @@ class TestPreparingURLs:
         assert isinstance(excinfo.value, RequestException)
         assert isinstance(excinfo.value, JSONDecodeError)
         assert r.text not in str(excinfo.value)
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__
 
     def test_json_decode_persists_doc_attr(self, httpbin):
         r = requests.get(httpbin("bytes/20"))


### PR DESCRIPTION
When a JSON response cannot be parsed, requests catch json.JSONDecodeError (or simplejson.JSONDecodeError) and raise requests.exceptions.JSONDecodeError instead. Because this happens in an except block, unhandled exceptions were printed in a chain:

```
Traceback (most recent call last):
...
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
...
requests.exceptions.JSONDecodeError: [Errno Expecting value] ...
```

This seems unnecessary and it increases cognitive overhead whean examining errors.

As requests.exceptions.JSONDecodeError inherits json.JSONDecodeError and we copy all atrributes from the later to the former, `raise ... from None` seems more approriate than `raise ... from e`.