### PR TITLE
Add response object to JSONDecodeError

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -965,14 +965,14 @@ class Response:
                     # used.
                     pass
                 except JSONDecodeError as e:
-                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
+                    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos, response=self)
 
         try:
             return complexjson.loads(self.text, **kwargs)
         except JSONDecodeError as e:
             # Catch JSON-related errors and raise as requests.JSONDecodeError
             # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
-            raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
+            raise RequestsJSONDecodeError(e.msg, e.doc, e.pos, response=self)
 
     @property
     def links(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2751,6 +2751,7 @@ class TestPreparingURLs:
             r.json()
         assert isinstance(excinfo.value, RequestException)
         assert isinstance(excinfo.value, JSONDecodeError)
+        assert hasattr(excinfo.value, "response")
         assert r.text not in str(excinfo.value)
 
     def test_json_decode_persists_doc_attr(self, httpbin):


### PR DESCRIPTION
Add response object to JSONDecodeError.

We used to use the following code, but since 2.27, errors on json parse failure are now caught as RequestException.
Since there is basically `response` in the `.json()` phase, we would like to add it in JSONDecodeError for convenience.

```python
def my_post(url, payload):
    try:
        res = requests.post(url, json=payload)
        res.raise_for_status()
        return res.json()
    except requests.exceptions.RequestException as e:
        logger.warning("Failed to send data %s", e.response.status_code)
    except Exception as e:
        ...
```
```
AttributeError
'NoneType' object has no attribute 'status_code'
```