### PR TITLE
Remove Python 2 mention on `chardet` behavior

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -717,10 +717,9 @@ If ``chardet`` is installed, ``requests`` uses it, however for python3
 library is an LGPL-licenced dependency and some users of requests
 cannot depend on mandatory LGPL-licensed dependencies.
 
-When you install ``request`` without specifying ``[use_chardet_on_py3]]`` extra,
+When you install ``requests`` without specifying ``[use_chardet_on_py3]`` extra,
 and ``chardet`` is not already installed, ``requests`` uses ``charset-normalizer``
-(MIT-licensed) to guess the encoding. For Python 2, ``requests`` uses only
-``chardet`` and is a mandatory dependency there.
+(MIT-licensed) to guess the encoding.
 
 The only time Requests will not guess the encoding is if no explicit charset
 is present in the HTTP headers **and** the ``Content-Type``


### PR DESCRIPTION
`requests` no longer supports Python 2. A recent commit, 8bce583b9547c7b82d44c8e97f37cf9a16cbe758
removed the `chardet` dependency for Python 2:

```diff
-'chardet>=3.0.2,<5; python_version < "3"',
```

We should edit the docs to remove mention of behavior on Py2.