### PR TITLE
Remove `__nonzero__` method from `models.Response`

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -738,16 +738,6 @@ class Response:
         """
         return self.ok
 
-    def __nonzero__(self):
-        """Returns True if :attr:`status_code` is less than 400.
-
-        This attribute checks if the status code of the response is between
-        400 and 600 to see if there was a client error or a server error. If
-        the status code, is between 200 and 400, this will return True. This
-        is **not** a check to see if the response code is ``200 OK``.
-        """
-        return self.ok
-
     def __iter__(self):
         """Allows you to use a response as an iterator."""
         return self.iter_content(128)


### PR DESCRIPTION
`__nonzero__` was used in python2 as we now use `__bool__`. It is not used at all in python3.
And since [`setup.py` says](https://github.com/psf/requests/blob/177dd90f18a8f4dc79a7d2049f0a3f4fcc5932a0/setup.py#L10) that `reqeusts` supports only `python >= 3.7`, I don't think that it is really required.

I found this while working on `typeshed` types for `requests`: https://github.com/python/typeshed/blob/3fe1f5d6c46b39b8b4632aadc70477a729241d25/stubs/requests/requests/models.pyi#L107