### PR TITLE
fix order of verify overrides in Sessions

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -760,20 +760,20 @@ class Session(SessionRedirectMixin):
             for (k, v) in env_proxies.items():
                 proxies.setdefault(k, v)
 
-            # Look for requests environment configuration
-            # and be compatible with cURL.
-            if verify is True or verify is None:
-                verify = (
-                    os.environ.get("REQUESTS_CA_BUNDLE")
-                    or os.environ.get("CURL_CA_BUNDLE")
-                    or verify
-                )
-
         # Merge all the kwargs.
         proxies = merge_setting(proxies, self.proxies)
         stream = merge_setting(stream, self.stream)
-        verify = merge_setting(verify, self.verify)
         cert = merge_setting(cert, self.cert)
+        verify = merge_setting(verify, self.verify)
+
+        # Look for requests environment configuration
+        # and be compatible with cURL.
+        if verify is True or verify is None:
+            verify = (
+                os.environ.get("REQUESTS_CA_BUNDLE")
+                or os.environ.get("CURL_CA_BUNDLE")
+                or verify
+            )
 
         return {"proxies": proxies, "stream": stream, "verify": verify, "cert": cert}
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -972,8 +972,8 @@ class TestRequests:
 
         s1 = requests.Session()
         s1.verify = "/session/specific/path"
-        settings = s.merge_environment_settings(
-            url=httpbin("get"), proxies={}, stream=False, verify=True, cert=None
+        settings = s1.merge_environment_settings(
+            url=httpbin("get"), proxies={}, stream=False, verify=None, cert=None
         )
         assert settings["verify"] == s1.verify
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -970,6 +970,13 @@ class TestRequests:
         )
         assert settings["verify"] == expected
 
+        s1 = requests.Session()
+        s1.verify = "/session/specific/path"
+        settings = s.merge_environment_settings(
+            url=httpbin("get"), proxies={}, stream=False, verify=True, cert=None
+        )
+        assert settings["verify"] == s1.verify
+
     def test_http_with_certificate(self, httpbin):
         r = requests.get(httpbin(), cert=".")
         assert r.status_code == 200


### PR DESCRIPTION
Currently, `Session` overrides the request-level `verify` parameter by
reading the environment, and then checks to see if it should choose that
or the session-level settings.

Let's consider the scenario where we've provided `REQUESTS_CA_BUNDLE` in
the environment, and then create a session with `s.verify = 'asdf'`. Now,
the final choice is going to be the environment-provided bundle, rather
than the session-provided setting, which is unexpected behavior.

The correct behavior would be to first do the merge of the request and 
session-level parameters, and then use the environment-provided params
if needed. 