### PR TITLE
allow string/byte subtypes for header

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -1032,15 +1032,17 @@ def check_header_validity(header):
     """
     name, value = header
 
-    for part in header:
-        if type(part) not in HEADER_VALIDATORS:
-            raise InvalidHeader(
-                f"Header part ({part!r}) from {{{name!r}: {value!r}}} must be "
-                f"of type str or bytes, not {type(part)}"
-            )
+    def _get_header_part_validator(part, validator):
+        for valid_type, validators in HEADER_VALIDATORS.items():
+            if isinstance(part, valid_type):
+                return validators[validator]
+        raise InvalidHeader(
+            f"Header part ({part!r}) from {{{name!r}: {value!r}}} must be "
+            f"of type str or bytes, not {type(part)}"
+        )
 
-    _validate_header_part(name, "name", HEADER_VALIDATORS[type(name)][0])
-    _validate_header_part(value, "value", HEADER_VALIDATORS[type(value)][1])
+    _validate_header_part(name, "name", _get_header_part_validator(name, 0))
+    _validate_header_part(value, "value", _get_header_part_validator(value, 1))
 
 
 def _validate_header_part(header_part, header_kind, validator):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1682,11 +1682,16 @@ class TestRequests:
 
     def test_header_validation(self, httpbin):
         """Ensure prepare_headers regex isn't flagging valid header contents."""
+        class StringSubClass(str):
+            def __repr__(self):
+                return "Secret"
+
         valid_headers = {
             "foo": "bar baz qux",
             "bar": b"fbbq",
             "baz": "",
             "qux": "1",
+            "sub": StringSubClass("VerySecret")
         }
         r = requests.get(httpbin("get"), headers=valid_headers)
         for key in valid_headers.keys():


### PR DESCRIPTION
We wrap our secret a in special subclass of string, that prevents leaking confidential information in some circumstances (i.e. stack traces) etc.

The current implementation of the header checks does a `type(val) == str` which is not recommended by PEP8.
Due to this implementation we can't pass this variables as headers. Converting them back to a normal string would defeat the purpose of wrapping them in the first place.

This PR fixes both issues.
