### PR TITLE
Fix bug, the encoding argument should be passed by keyword in open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ test_requirements = [
 
 about = {}
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, "requests", "__version__.py"), "r", "utf-8") as f:
+with open(os.path.join(here, "requests", "__version__.py"), "r", encoding="utf-8") as f:
     exec(f.read(), about)
 
 with open("README.md", "r", "utf-8") as f:


### PR DESCRIPTION
Issue #6242