### PR TITLE
Fix setuptools deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
-license_file = LICENSE
-provides-extra =
+license_files = LICENSE
+provides_extra =
     socks
     use_chardet_on_py3
-requires-dist =
+requires_dist =
     certifi>=2017.4.17
     charset_normalizer>=2,<4
     idna>=2.5,<4


### PR DESCRIPTION
Update keys used in `setup.cfg` in order to fix the following setuptools deprecation warnings:

> The license_file parameter is deprecated, use license_files instead.

> Usage of dash-separated 'provides-extra' will not be supported
> in future versions. Please use the underscore name 'provides_extra'
> instead

> Usage of dash-separated 'requires-dist' will not be supported
> in future versions. Please use the underscore name 'requires_dist'
> instead