### PR TITLE
fix: pass response (self) to ConnectionError constructor

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -819,7 +819,7 @@ class Response:
                 except DecodeError as e:
                     raise ContentDecodingError(e)
                 except ReadTimeoutError as e:
-                    raise ConnectionError(e)
+                    raise ConnectionError(e, response=self)
                 except SSLError as e:
                     raise RequestsSSLError(e)
             else:


### PR DESCRIPTION
As far as I can tell, this is the only internal construction of `ConnectionError` that doesn't include `request` or `response`.

Part of improving typing for exceptions in requests: https://github.com/python/typeshed/pull/8989