### PR TITLE
Single-source required python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"]},
     package_dir={"requests": "requests"},
     include_package_data=True,
-    python_requires=">=3.7, <4",
+    python_requires=f">={'.'.join(map(str, REQUIRED_PYTHON))}, <4",
     install_requires=requires,
     license=about["__license__"],
     zip_safe=False,


### PR DESCRIPTION
Since there is a `REQUIRED_PYTHON` tuple, use it to fill the `python_requires` argument of `setup()` to avoid hard-coding current "3.7" in multiple places.