### PR TITLE
Replace git protocol URL in docs with an HTTPS URL

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -22,7 +22,7 @@ Requests is actively developed on GitHub, where the code is
 
 You can either clone the public repository::
 
-    $ git clone git://github.com/psf/requests.git
+    $ git clone https://github.com/psf/requests.git
 
 Or, download the `tarball <https://github.com/psf/requests/tarball/main>`_::
 


### PR DESCRIPTION
As of March 2022, [GitHub has removed support for cloning repositories using the `git://` protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/). This project's installation docs still use a URL starting with `git://` when telling users how to clone the source repo. Let's replace that with the HTTPS URL for this repository.