### PR TITLE
Update `certifi` dependency to patch known vulnerability.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ provides-extra =
     socks
     use_chardet_on_py3
 requires-dist =
-    certifi>=2017.4.17
+    certifi>=2022.12.07
     charset_normalizer>=2,<4
     idna>=2.5,<4
     urllib3>=1.21.1,<1.27

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requires = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
     "urllib3>=1.21.1,<1.27",
-    "certifi>=2017.4.17",
+    "certifi>=2022.12.07",
 ]
 test_requirements = [
     "pytest-httpbin==0.0.7",


### PR DESCRIPTION
`certifi>=2017.11.05, < 2022.12.07` has a known security vulnerability, described [here](https://github.com/advisories/GHSA-43fp-rhv2-5gv8). The currently supported `certifi` range `certifi>=2017.4.17` includes these vulnerable versions.

This pull request updates `certifi` to `2022.12.07` which patches the vulnerability.