### PR TITLE
Add example and improve docs for RequestException

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -12,13 +12,35 @@ from .compat import JSONDecodeError as CompatJSONDecodeError
 class RequestException(IOError):
     """There was an ambiguous exception that occurred while handling your
     request.
+
+    Exception Handling::
+    
+      import requests
+      s = requests.Session()
+      try:
+          req = s.get('https://httpbin.org/get')
+      except RequestException as e:
+          print("Error: ", e)
+          print("Request: ", e.request)
+          print("Response: ", e.response)
+      finally:
+          s.close()
+    
     """
 
     def __init__(self, *args, **kwargs):
         """Initialize RequestException with `request` and `response` objects."""
         response = kwargs.pop("response", None)
+
+        #: `response` object included as an argument to the `RequestException`.
+        #: `None` by default.
         self.response = response
+
+        #: `request` object included as an argument to the `RequestException`.
+        #: If `request` is `None`, `response.request` is used instead.
+        #: Otherwise `None`.
         self.request = kwargs.pop("request", None)
+
         if response is not None and not self.request and hasattr(response, "request"):
             self.request = self.response.request
         super().__init__(*args, **kwargs)

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -31,7 +31,6 @@ class RequestException(IOError):
           # => Response: None
       finally:
           s.close()  # Close the `Session`
-    
     """
 
     def __init__(self, *args, **kwargs):

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -13,8 +13,7 @@ class RequestException(IOError):
     """There was an ambiguous exception that occurred while handling your
     request.
 
-    Usage::
-    
+    Usage:: 
       import requests
       s = requests.Session()
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -14,6 +14,7 @@ class RequestException(IOError):
     request.
 
     Usage:: 
+
       import requests
       s = requests.Session()
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -13,18 +13,24 @@ class RequestException(IOError):
     """There was an ambiguous exception that occurred while handling your
     request.
 
-    Exception Handling::
+    Usage::
     
       import requests
       s = requests.Session()
+
       try:
           req = s.get('https://httpbin.org/get')
-      except RequestException as e:
-          print("Error: ", e)
-          print("Request: ", e.request)
-          print("Response: ", e.response)
+      except requests.RequestException as e:
+          print("Error:", e)
+          # => Error: HTTPSConnectionPool(host='httpbin.org', port=443): ...
+
+          print("Request:", e.request)
+          # => Request: <PreparedRequest [GET]>
+
+          print("Response:", e.response)
+          # => Response: None
       finally:
-          s.close()
+          s.close()  # Close the `Session`
     
     """
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -21,13 +21,13 @@ class RequestException(IOError):
       try:
           req = s.get('https://httpbin.org/get')
       except requests.RequestException as e:
-          print("Error:", e)
+          print('Error:', e)
           # => Error: HTTPSConnectionPool(host='httpbin.org', port=443): ...
 
-          print("Request:", e.request)
+          print('Request:', e.request)
           # => Request: <PreparedRequest [GET]>
 
-          print("Response:", e.response)
+          print('Response:', e.response)
           # => Response: None
       finally:
           s.close()  # Close the `Session`


### PR DESCRIPTION
I added a brief example of exception handling for `RequestException` and documented the `request` and `response` attributes. PR does not overlap with #6237