### PR TITLE
fix: Remove '<4' from python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"]},
     package_dir={"requests": "requests"},
     include_package_data=True,
-    python_requires=">=3.7, <4",
+    python_requires=">=3.7",
     install_requires=requires,
     license=about["__license__"],
     zip_safe=False,


### PR DESCRIPTION
Resolves #6332

The 

https://github.com/psf/requests/blob/61c324da43dd8b775d3930d76265538b3ca27bc1/setup.py#L97

cap was added in PR #6091.

As discussed in https://discuss.python.org/t/use-of-less-than-next-major-version-e-g-4-in-python-requires-setup-py/1066 and [other places](https://iscinumpy.dev/post/bound-version-constraints/) by the PyPA, use of upper bounds with `python_requires` for _future_ versions of Python is unintended use of `python_requires` and actively discouraged.

c.f. https://github.com/pypa/packaging.python.org/pull/850 for further detail.