### PR TITLE
Support missing SNIMissingWarning in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,9 +2,13 @@
 
 import warnings
 
-from urllib3.exceptions import SNIMissingWarning
+try:
+    from urllib3.exceptions import SNIMissingWarning
 
-# urllib3 sets SNIMissingWarning to only go off once,
-# while this test suite requires it to always fire
-# so that it occurs during test_requests.test_https_warnings
-warnings.simplefilter("always", SNIMissingWarning)
+    # urllib3 1.x sets SNIMissingWarning to only go off once,
+    # while this test suite requires it to always fire
+    # so that it occurs during test_requests.test_https_warnings
+    warnings.simplefilter("always", SNIMissingWarning)
+except ImportError:
+    # urllib3 2.0 removed that warning and errors out instead
+    SNIMissingWarning = None

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -50,6 +50,7 @@ from requests.structures import CaseInsensitiveDict
 
 from .compat import StringIO
 from .utils import override_environ
+from tests import SNIMissingWarning
 
 # Requests to this URL should always fail with a connection timeout (nothing
 # listening on that port)
@@ -974,6 +975,7 @@ class TestRequests:
         r = requests.get(httpbin(), cert=".")
         assert r.status_code == 200
 
+    @pytest.mark.skipif(SNIMissingWarning is None, reason="urllib3 2.0 removed that warning and errors out instead")
     def test_https_warnings(self, nosan_server):
         """warnings are emitted with requests.get"""
         host, port, ca_bundle = nosan_server

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -48,9 +48,9 @@ from requests.models import PreparedRequest, urlencode
 from requests.sessions import SessionRedirectMixin
 from requests.structures import CaseInsensitiveDict
 
+from . import SNIMissingWarning
 from .compat import StringIO
 from .utils import override_environ
-from tests import SNIMissingWarning
 
 # Requests to this URL should always fail with a connection timeout (nothing
 # listening on that port)
@@ -975,7 +975,10 @@ class TestRequests:
         r = requests.get(httpbin(), cert=".")
         assert r.status_code == 200
 
-    @pytest.mark.skipif(SNIMissingWarning is None, reason="urllib3 2.0 removed that warning and errors out instead")
+    @pytest.mark.skipif(
+        SNIMissingWarning is None,
+        reason="urllib3 2.0 removed that warning and errors out instead",
+    )
     def test_https_warnings(self, nosan_server):
         """warnings are emitted with requests.get"""
         host, port, ca_bundle = nosan_server


### PR DESCRIPTION
urllib3 2.0 only supports OpenSSL 1.1.1+ which means SNI is mandatory, and removed the warning altogether.