### PR TITLE
cache proxy configuration to get 12.5% speedup

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -43,11 +43,11 @@ from .utils import (  # noqa: F401
     default_headers,
     get_auth_from_url,
     get_environ_proxies,
+    proxy_config_cache,
     get_netrc_auth,
     requote_uri,
     resolve_proxies,
     rewind_body,
-    should_bypass_proxies,
     to_key_val_list,
 )
 
@@ -448,6 +448,9 @@ class Session(SessionRedirectMixin):
         self.mount("https://", HTTPAdapter())
         self.mount("http://", HTTPAdapter())
 
+        # cache heavy calls to OS APIs to get proxy config, see func:`proxy_config_cache`
+        self.proxy_config_cache = proxy_config_cache()
+
     def __enter__(self):
         return self
 
@@ -756,7 +759,7 @@ class Session(SessionRedirectMixin):
         if self.trust_env:
             # Set environment's proxies.
             no_proxy = proxies.get("no_proxy") if proxies is not None else None
-            env_proxies = get_environ_proxies(url, no_proxy=no_proxy)
+            env_proxies = get_environ_proxies(url, no_proxy=no_proxy, config_cache=self.proxy_config_cache)
             for (k, v) in env_proxies.items():
                 proxies.setdefault(k, v)
 


### PR DESCRIPTION
I didn't plan to submit a PR, I was just playing around, but the speedup I got (granted, on a very superficial benchmark) was so high that I just had to try.

On my Macbook Air M1, 12.5% of runtime of a simplistic benchmark (see below) was spent on calls to `should_bypass_proxies()` which seems to call some OS-dependent code to get proxy bypass config, and I figure in most use cases it will be called repeatedly with a small number of hostnames and it's 100% ok to cache it (*is it?* I'm not an expert in `requests` use cases and maybe some people expect the OS config to change while the process is running and would consider this a breaking change).

Did my best to write clear code and document it well. Wrote tests. Code passes tox (except for py3.7 that I don't have installed).

Before:
```
         1145706 function calls (1139516 primitive calls) in 1.041 seconds

   Ordered by: internal time
   List reduced from 1546 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      800    0.261    0.000    0.261    0.000 {method 'recv_into' of '_socket.socket' objects}
      100    0.060    0.001    0.060    0.001 encoder.py:204(iterencode)
      200    0.056    0.000    0.057    0.000 {built-in method _socket.getaddrinfo}
      200    0.053    0.000    0.053    0.000 {built-in method _socket.gethostbyname}
      100    0.042    0.000    0.042    0.000 decoder.py:343(raw_decode)
      200    0.041    0.000    0.041    0.000 {built-in method _scproxy._get_proxy_settings}
     3800    0.034    0.000    0.041    0.000 shlex.py:133(read_token)
      200    0.030    0.000    0.030    0.000 {built-in method _scproxy._get_proxies}
      200    0.028    0.000    0.028    0.000 {method 'connect' of '_socket.socket' objects}
      200    0.024    0.000    0.025    0.000 {built-in method io.open}
```

After:

```
         916904 function calls (910715 primitive calls) in 0.920 seconds

   Ordered by: internal time
   List reduced from 1533 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      800    0.258    0.000    0.258    0.000 {method 'recv_into' of '_socket.socket' objects}
      200    0.064    0.000    0.064    0.000 {built-in method _socket.getaddrinfo}
      100    0.061    0.001    0.061    0.001 encoder.py:204(iterencode)
      100    0.042    0.000    0.042    0.000 decoder.py:343(raw_decode)
      200    0.035    0.000    0.035    0.000 {built-in method _scproxy._get_proxies}
     3800    0.034    0.000    0.041    0.000 shlex.py:133(read_token)
      200    0.026    0.000    0.026    0.000 {method 'connect' of '_socket.socket' objects}
      200    0.025    0.000    0.026    0.000 {built-in method io.open}
    26/22    0.021    0.001    0.023    0.001 {built-in method _imp.create_dynamic}
        1    0.015    0.015    0.799    0.799 bench.py:3(test)
```

Note these lines in particular:

```
      200    0.064    0.000    0.064    0.000 {built-in method _socket.getaddrinfo}
      200    0.041    0.000    0.041    0.000 {built-in method _scproxy._get_proxy_settings}
```

This is the benchmark I used:

`bench.py`:

```python3
import requests

def test():
    for _ in (range(10)):
        session = requests.Session()
        for _ in range(10):
            response = session.get('http://localhost:8000/home', params={'q': 'who are you?'})
            response.raise_for_status()
            response.content

            response = session.post('http://localhost:8000/api', json={'type': 'query', 'data': list(range(10000))})
            response.raise_for_status()
            response.json()

if __name__ == '__main__':
    test()
```

`bench_server.py`:

```python3
from flask import Flask, request

app = Flask(__name__)

@app.route('/home')
def home():
    return 'Hello, World! ' + 'A' * 10000

@app.route('/api', methods=['POST'])
def api():
    return request.json

if __name__ == '__main__':
    app.run(port=8000)
```

```
gunicorn bench_server:app
```

```
python -m timeit 'import bench; bench.test()'
```

```
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 654 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 664 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 685 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 750 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 759 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ ./toxin.sh -e py38-default "python -m timeit 'import bench; bench.test()'"
1 loop, best of 5: 770 msec per loop
(requests) ➜  requests git:(cache-proxy-config) ✗ python -c 'print(1 - 664/759)'
0.12516469038208167```