### PR TITLE
fix issue #6377

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -290,10 +290,11 @@ def extract_zipped_paths(path):
     # we have a valid zip archive and a valid member of that archive
     tmp = tempfile.gettempdir()
     extracted_path = os.path.join(tmp, member.split("/")[-1])
-    if not os.path.exists(extracted_path):
-        # use read + write to avoid the creating nested folders, we only want the file, avoids mkdir racing condition
-        with atomic_open(extracted_path) as file_handler:
-            file_handler.write(zip_file.read(member))
+
+    # use read + write to avoid the creating nested folders, we only want the file, avoids mkdir racing condition
+    with atomic_open(extracted_path) as file_handler:
+        file_handler.write(zip_file.read(member))
+
     return extracted_path
 
 


### PR DESCRIPTION
fix #6377 
The reason why the file is not overwritten is that the test file in the TMP directory is not cleared after the test is run for the first time, and the directory and filename of the temporary file are the same after each test run.

This code skips overwriting when it finds that the file already exists:

`if not os.path.exists(extracted_path):` in utils.extract_zipped_paths()

**This means that calling this function twice in a row will not be able to detect changes in compressed files？**

So i thought that judgment might be redundant, so I removed it.