### PR TITLE
Clarify docs for multipart file uploads

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -386,13 +386,13 @@ parameter of ``None``. If you want to set a maximum size of the chunk,
 you can set a ``chunk_size`` parameter to any integer.
 
 
-.. _multipart:
+.. _multiple_multipart_files_same_field:
 
-POST Multiple Multipart-Encoded Files
--------------------------------------
+POST Multiple Multipart-Encoded Files to the Same Field
+-------------------------------------------------------
 
-You can send multiple files in one request. For example, suppose you want to
-upload image files to an HTML form with a multiple file field 'images'::
+You can send multiple files to the same form field in one request. For example, suppose you want to
+upload image files to an HTML form with a multiple-file field 'images'::
 
     <input type="file" name="images" multiple="true" required="true"/>
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -297,6 +297,9 @@ and it will be encoded automatically:
 
 Note, the ``json`` parameter is ignored if either ``data`` or ``files`` is passed.
 
+
+.. _multipart_file:
+
 POST a Multipart-Encoded File
 -----------------------------
 
@@ -351,8 +354,8 @@ support this, but there is a separate package which does -
 ``requests-toolbelt``. You should read `the toolbelt's documentation
 <https://toolbelt.readthedocs.io>`_ for more details about how to use it.
 
-For sending multiple files in one request refer to the :ref:`advanced <advanced>`
-section.
+For sending multiple files to the same form field in one request, refer to
+:ref:`multiple_multipart_files_same_field`.
 
 .. warning:: It is strongly recommended that you open files in :ref:`binary
              mode <tut-files>`. This is because Requests may attempt to provide

--- a/requests/api.py
+++ b/requests/api.py
@@ -23,11 +23,25 @@ def request(method, url, **kwargs):
     :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
-        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
-        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content-type'`` is a string
-        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
-        to add for the file.
+    :param files: (optional) For uploading files with ``multipart/form-data`` encoding,
+        either a dictionary of ``'field_name': file_info`` items,
+        or a list of ``('field_name', file_info)`` tuples. Each ``file_info`` can be:
+
+        * A ``file_obj``.
+        * A 2-tuple ``('filename', file_obj)``.
+        * A 3-tuple ``('filename', file_obj, 'content_type')``.
+        * A 4-tuple ``('filename', file_obj, 'content_type', custom_headers)``.
+
+        Where:
+
+        * ``file_obj`` is a binary-mode file-like object to read the file contents from.
+          or a ``str`` or ``bytes`` containing the file contents.
+        * ``'content_type'`` is a string defining the content type of the given file.
+        * ``custom_headers`` is a dict-like object containing additional headers
+          to add for the file.
+
+        For an example of the dict syntax, see :ref:`multipart_file`.
+        For an example of the list-of-tuples syntax, see :ref:`multiple_multipart_files_same_field`.
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read


### PR DESCRIPTION
This makes some documentation changes that clarify the `files` argument of `requests.post()` et. al.

## Be more precise when we say "multiple files"

The `files` argument can either be a dict:

```python
files = {
    "field_1": file_1,
    "field_2": file_2,
}
```

Or a list of tuples:

```python
files = [
    ("field_1": file_1),
    ("field_2": file_2),
]
```

A few places implied that to "upload multiple files in one request," you had to use the list-of-tuples syntax. But the dict syntax supports multiple files just fine. The added power in the list-of-tuples syntax seems to be that you can upload multiple files *to the same form field.* So, we now say that.

## Update the reference docs

The API reference documentation did not completely describe what values were acceptable for `files`, and in some cases it was misleading.

* It didn't mention the list-of-tuples syntax at all.
* It said you could pass a "dictionary of `'name': file-like-objects`". The pluralization there makes it look like you can do something like `{"name": [file_1, file_2]}`, but that's not correct.
* It didn't describe what you were allowed to provide as a "`fileobj`". (It can be a file-like object, or `str` contents, or `bytes` contents.)
* It said `name` to refer to the value that Requests uses as the form field name. This could be misconstrued as the file name. [RFC 7578](https://www.rfc-editor.org/rfc/rfc7578) and other examples within Requests call it the "field name" or "form field name."

My sources for these changes:

* The existing [POST a Multipart-Encoded File](https://github.com/psf/requests/blob/7f694b79e114c06fac5ec06019cada5a61e5570f/docs/user/quickstart.rst?plain=1#L300) section.
* The existing [POST Multiple Multipart-Encoded Files](https://github.com/psf/requests/blob/7f694b79e114c06fac5ec06019cada5a61e5570f/docs/user/advanced.rst?plain=1#L391) section.
* [Request's type stubs](https://github.com/python/typeshed/blob/8080e491d2fa92b1b1390c87fac23a1a38dcd919/stubs/requests/requests/sessions.pyi#L91).

It's difficult to describe this API concisely because it accepts so many different input shapes, and these additions do make the rendered docs feel a bit crowded.