### PR TITLE
docs: Remove non needed spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 Requests allows you to send HTTP/1.1 requests extremely easily. There’s no need to manually add query strings to your URLs, or to form-encode your `PUT` & `POST` data — but nowadays, just use the `json` method!
 
-Requests is one of the most downloaded Python packages today, pulling in around `30M downloads / week`— according to GitHub, Requests is currently [depended upon](https://github.com/psf/requests/network/dependents?package_id=UGFja2FnZS01NzA4OTExNg%3D%3D) by `1,000,000+` repositories. You may certainly put your trust in this code.
+Requests is one of the most downloaded Python packages today, pulling in around `30M downloads/week`— according to GitHub, Requests is currently [depended upon](https://github.com/psf/requests/network/dependents?package_id=UGFja2FnZS01NzA4OTExNg%3D%3D) by `1,000,000+` repositories. You may certainly put your trust in this code.
 
 [![Downloads](https://pepy.tech/badge/requests/month)](https://pepy.tech/project/requests)
 [![Supported Versions](https://img.shields.io/pypi/pyversions/requests.svg)](https://pypi.org/project/requests)


### PR DESCRIPTION
I'm sorry for my OCD 😅
There is some extra spacing. This doesn't match the spacing of the badge `downloads/month`

![image](https://user-images.githubusercontent.com/72306953/226908616-73cdf003-4d45-4199-a8c4-0731b9e0a551.png)
