### PR TITLE
Document that a Response is a context manager

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -641,6 +641,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 class Response:
     """The :class:`Response <Response>` object, which contains a
     server's response to an HTTP request.
+
+    A :class:`Response <Response>` object can be used as a context manager.
     """
 
     __attrs__ = [


### PR DESCRIPTION
This is mentioned in the Advanced Usage page, but not in the API reference. It is mentioned in the API reference for `Session`, so it seems reasonable that it should be mentioned for `Response` as well. It looks like this capability was added in GH-4137, which made the change to the former documentation but not the latter.