### PR TITLE
Corrected copyright roman numeral in footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Requests"
-copyright = u'MMXVIX. A <a href="https://kenreitz.org/projects">Kenneth Reitz</a> Project'
+copyright = u'MMXIV. A <a href="https://kenreitz.org/projects">Kenneth Reitz</a> Project'
 author = u"Kenneth Reitz"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
I'm quite convinced the current one (`MMXVIX`) is invalid, or at the very least, ambiguous (online converters say it's either 2014, 2024, or invalid).

I made this change assuming it was supposed to mean 2014.