### PR TITLE
🛠 fix: Adapter overwrite passed-in retry

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -142,6 +142,8 @@ class HTTPAdapter(BaseAdapter):
     ):
         if max_retries == DEFAULT_RETRIES:
             self.max_retries = Retry(0, read=False)
+        elif isinstance(max_retries, Retry):
+            self.max_retries = max_retries
         else:
             self.max_retries = Retry.from_int(max_retries)
         self.config = {}


### PR DESCRIPTION
According to the API reference of `max_retries` of `requests.adapters.HTTPAdapter`

> The maximum number of retries each connection should attempt. Note, this applies only to failed DNS lookups, socket connections and connection timeouts, never to requests where data has made it to the server. By default, Requests does not retry failed connections. If you need granular control over the conditions under which we retry a request, **import urllib3’s Retry class and pass that instead.**

A widely used example can be found in this [StackOverflow answer](https://stackoverflow.com/a/35504626/10325430) and is also under review in #6258.

However, the current source code does not really accept the passed-in `Retry` instance. Instead, it will silently discard and replace it with the default `Retry` instance.

This 2-line fix intends to fix the bug and restore its behavior to expect.