### PR TITLE
chore: move coverage config to `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = requests/packages/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,8 @@ testpaths = [
     "requests",
     "tests",
 ]
+
+[tool.coverage.run]
+omit = [
+    "requests/packages/*",
+]


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for the project. Instead of a separate `.coveragerc` for configuring coverage, we now would have the required configuration within the `pyproject.toml` file leading to a overall minimal code structure.