### PR TITLE
request/cookies.py -> RequestCookieJar inheritance update from collections

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -48,6 +48,7 @@ from http import cookiejar as cookielib
 from http.cookies import Morsel
 from io import StringIO
 
+
 # --------------
 # Legacy Imports
 # --------------

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -10,6 +10,9 @@ requests.utils imports from here, so be careful with imports.
 import calendar
 import copy
 import time
+# with python versions greater than 3.10^ using the MytableMapping directly throws an error
+# as a fix calling it directly from collections.abd inside the RequestCookieJar
+import collections.abc
 
 from ._internal_utils import to_native_string
 from .compat import Morsel, MutableMapping, cookielib, urlparse, urlunparse
@@ -173,7 +176,7 @@ class CookieConflictError(RuntimeError):
     """
 
 
-class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
+class RequestsCookieJar(cookielib.CookieJar, collections.abc.MutableMapping):
     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
     interface.
 
@@ -185,6 +188,10 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
     compatibility with external client code. All requests code should work
     out of the box with externally provided instances of ``CookieJar``, e.g.
     ``LWPCookieJar`` and ``FileCookieJar``.
+
+    Calling the MutableMapping directly from <! collections.abc >
+    bypasses errors on linux machines using python 3.10^ and other 
+    version compatability for pymongo.
 
     Unlike a regular CookieJar, this class is pickleable.
 


### PR DESCRIPTION
I have updated the RequestCookieJar class to be compatible with python3.10^ on Linux machines using python3.10^ as the default versions and also compatibility with pymongo.


**The error**
```
module 'collections' has no attribute 'MutableMapping'
```



<details>

<summary>Pymongo full error</summary>

>You can add text within a collapsed section. 

You can add an image or a code block, too.

```python
File "<root-folder>/<app/folder>", line 4, in <module>
    from pymongo import MongoClient
  File "<root-folder>/.local/lib/python3.10/site-packages/pymongo/__init__.py", line 92, in <module>
    from pymongo.mongo_client import MongoClient
  File "<root-folder>/.local/lib/python3.10/site-packages/pymongo/mongo_client.py", line 59, in <module>
    from pymongo import (
  File "<root-folder>/.local/lib/python3.10/site-packages/pymongo/uri_parser.py", line 32, in <module>
    from pymongo.srv_resolver import _HAVE_DNSPYTHON, _SrvResolver
  File "<root-folder>/.local/lib/python3.10/site-packages/pymongo/srv_resolver.py", line 21, in <module>
    from dns import resolver
  File "<root-folder>/.local/lib/python3.10/site-packages/dns/resolver.py", line 39, in <module>
    import dns.query
  File "<root-folder>/.local/lib/python3.10/site-packages/dns/query.py", line 47, in <module>
    import requests
  File "<root-folder>/.local/lib/python3.10/site-packages/requests/__init__.py", line 63, in <module>
    from . import utils
  File "<root-folder>/.local/lib/python3.10/site-packages/requests/utils.py", line 27, in <module>
    from .cookies import RequestsCookieJar, cookiejar_from_dict
  File "<root-folder>/.local/lib/python3.10/site-packages/requests/cookies.py", line 172, in <module>
    class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
AttributeError: module 'collections' has no attribute 'MutableMapping'
```

</details>