### PR TITLE
Try charset_normalizer first

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -8,9 +8,9 @@ compatibility until the next major version.
 """
 
 try:
-    import chardet
-except ImportError:
     import charset_normalizer as chardet
+except ImportError:
+    import chardet
 
 import sys
 


### PR DESCRIPTION
The newer `charset_normalizer` is installed as a dependency in a lot of cases, so there isn't much point in going to `chardet` as a first stop.  It might even be possible to switch to an unconditional import.