### PR TITLE
remove task comment

### DIFF
--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -94,7 +94,6 @@ class TestTestServer:
     @pytest.mark.skip(reason="this fails non-deterministically under pytest-xdist")
     def test_request_recovery(self):
         """can check the requests content"""
-        # TODO: figure out why this sometimes fails when using pytest-xdist.
         server = Server.basic_response_server(requests_to_handle=2)
         first_request = b"put your hands up in the air"
         second_request = b"put your hand down in the floor"


### PR DESCRIPTION
This PR removes a task comment (i.e. a comment referring to a work that could/should be done in the future or was already done).