### PR TITLE
reenable the warnings plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ src_paths = ["requests", "test"]
 honor_noqa = true
 
 [tool.pytest.ini_options]
-addopts = "-p no:warnings --doctest-modules"
+addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 minversion = "6.2"
 testpaths = [


### PR DESCRIPTION
The warnings plugin was disabled in https://github.com/psf/requests/pull/4056 but that issue is now fixed by
https://github.com/pytest-dev/pytest/pull/2445