### PR TITLE
v2.29.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,14 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+2.29.0 (2023-04-26)
+-------------------
+
+**Improvements**
+
+- Requests now defers chunked requests to the urllib3 implementation to improve
+  standardization. (#6226)
+- Requests relaxes header component requirements to support bytes/str subclasses. (#6356)
 
 2.28.2 (2023-01-12)
 -------------------

--- a/requests/__version__.py
+++ b/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.28.2"
-__build__ = 0x022802
+__version__ = "2.29.0"
+__build__ = 0x022900
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache 2.0"


### PR DESCRIPTION
2.29.0 (2023-04-26)
-------------------

**Improvements**

- Requests now defers chunked requests to the urllib3 implementation to improve
  standardization. (#6226)
- Requests relaxes header component requirements to support bytes/str subclasses. (#6356)