### PR TITLE
Remove strict parameter

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -193,7 +193,6 @@ class HTTPAdapter(BaseAdapter):
             num_pools=connections,
             maxsize=maxsize,
             block=block,
-            strict=True,
             **pool_kwargs,
         )
 


### PR DESCRIPTION
Now that requests dropped support for Python 2.7, this parameter is no longer needed and raises a warning when using urllib3 2.0.

See https://github.com/urllib3/urllib3/issues/2263 for details.