### PR TITLE
Small typo fix in HISTORY.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -73,7 +73,7 @@ dev
   cert verification. All Requests 2.x versions before 2.28.0 are affected. (#6074)
 - Fixed urllib3 exception leak, wrapping `urllib3.exceptions.SSLError` with
   `requests.exceptions.SSLError` for `content` and `iter_content`. (#6057)
-- Fixed issue where invalid Windows registry entires caused proxy resolution
+- Fixed issue where invalid Windows registry entries caused proxy resolution
   to raise an exception rather than ignoring the entry. (#6149)
 - Fixed issue where entire payload could be included in the error message for
   JSONDecodeError. (#6036)


### PR DESCRIPTION
I was going through the release history docs to ensure compatibility safety in case of upgrading the package to the latest version. While doing so found this minuscule typo in the docs, where the word `entries` was written as `entires`.

Forgive me for the petty nitpicking but just thought of proposing a fix 😅 