### PR TITLE
add docstring parameter hooks

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -543,6 +543,8 @@ class Session(SessionRedirectMixin):
         :type allow_redirects: bool
         :param proxies: (optional) Dictionary mapping protocol or protocol and
             hostname to the URL of the proxy.
+        :param hooks: (optional) Dictionary mapping hook name to one event or
+            list of events, event must be callable.
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify


### PR DESCRIPTION
When I read the source code, I found that the  `request` method misses parameter hooks in docstring