### PR TITLE
support adding headers when using proxies

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,24 @@
+import requests
+
+
+def uc_unicom(ip):
+    try:
+        headers = {
+            'user-agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 Edg/111.0.1661.41'
+        }
+        proxies = {
+            'http': f'http://{ip}',
+            'https': f'http://{ip}',
+            'headers': {
+                'Proxy-Authorization': 'Basic dXNlcjpwd2Q='
+            }
+        }
+        response = requests.get('https://api.ip.sb/ip', headers=headers, proxies=proxies)
+        print(response.text)
+    except Exception as e:
+        print(e)
+
+
+
+if __name__ == '__main__':
+    uc_unicom('127.0.0.1:8080')


### PR DESCRIPTION
In some cases, when using a proxy, it is necessary to specify specific header content. Therefore, I have implemented this functionality in a simple way.

usage：
https://github.com/anysoft/requests/blob/e6b05c5edba85b6b383b39fdde4b3ab9b514f6db/tests/test_proxy.py
``` python
import requests


def uc_unicom(ip):
    try:
        headers = {
            'user-agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Mobile Safari/537.36 Edg/111.0.1661.41'
        }
        proxies = {
            'http': f'http://{ip}',
            'https': f'http://{ip}',
            'headers': {
                'Proxy-Authorization': 'Basic dXNlcjpwd2Q=',
                'Q-GUID': 'XXXX',
            }
        }
        response = requests.get('https://api.ip.sb/ip', headers=headers, proxies=proxies)
        print(response.text)
    except Exception as e:
        print(e)



if __name__ == '__main__':
    uc_unicom('127.0.0.1:8080')

```