### PR TITLE
Add Cloudflare-specific HTTP status codes

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -101,6 +101,19 @@ _codes = {
     509: ("bandwidth_limit_exceeded", "bandwidth"),
     510: ("not_extended",),
     511: ("network_authentication_required", "network_auth", "network_authentication"),
+    # Cloudflare-specific HTTP status codes
+    520: ("unknown_error",),
+    521: ("web_server_is_down",),
+    522: ("connection_timed_out",),
+    523: ("origin_is_unreachable",),
+    524: ("a_timeout_occurred",),
+    525: ("ssl_handshake_failed",),
+    526: ("invalid_ssl_certificate",),
+    527: ("railgun_error",),
+    530: ("origin_dns_error",),
+    531: ("origin_connection_timeout",),
+    532: ("origin_read_timeout",),
+    533: ("origin_uncertain_error",),
 }
 
 codes = LookupDict(name="status_codes")


### PR DESCRIPTION
### Add Cloudflare-specific HTTP status codes

This pull request adds the Cloudflare-specific HTTP status codes to the project. Cloudflare uses these status codes to represent various error scenarios that are specific to their services. The new codes range from 520 to 533.

### Changes Made
- Added constants for Cloudflare-specific HTTP status codes to the existing `_codes` dictionary.

### New Status Codes
- 520: UNKNOWN ERROR
- 521: WEB SERVER IS DOWN
- 522: CONNECTION TIMED OUT
- 523: ORIGIN IS UNREACHABLE
- 524: A TIMEOUT OCCURRED
- 525: SSL HANDSHAKE FAILED
- 526: INVALID SSL CERTIFICATE
- 527: RAILGUN ERROR
- 530: ORIGIN DNS ERROR
- 531: ORIGIN CONNECTION TIMEOUT
- 532: ORIGIN READ TIMEOUT
- 533: ORIGIN UNCERTAIN ERROR

These additions expand our support for a wider range of recognized HTTP status codes, especially relevant for integrating with Cloudflare services.

Please review and merge this pull request if the changes are deemed appropriate for the project.
