### PR TITLE
Upgrade to httpbin 0.10.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         make

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,11 +3,7 @@ pytest>=2.8.0,<=6.2.5
 pytest-cov
 pytest-httpbin==2.0.0
 pytest-mock==2.0.0
-httpbin==0.7.0
+httpbin==0.10.0
 trustme
 wheel
 cryptography<40.0.0; python_version <= '3.7' and platform_python_implementation == 'PyPy'
-
-# Flask Stack
-Flask>1.0,<2.0
-markupsafe<2.1


### PR DESCRIPTION
This PR will upgrade the Requests test suite to use the recently released httpbin 0.10.0 that now supports the latest major version of Flask. This will let us remove our pins on pallets projects and hopefully allow distro maintainers to no longer need to support these older versions.

Thanks @mgorny and @kevin1024 for helping get this unblocked and closing out #6070!