### PR TITLE
Add 3.12 classifier and tox configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-{default, use_chardet_on_py3}
+envlist = py{37,38,39,310,311,312}-{default, use_chardet_on_py3}
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Tests have been running smoothly for the last few months and now that we're in RC phase for Python 3.12, we should be able to formalize support.