### PR TITLE
Add minimum PEP518 build-system specification

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,9 @@
-include README.md LICENSE NOTICE HISTORY.md pytest.ini requirements-dev.txt
+include README.md
+include LICENSE
+include NOTICE
+include HISTORY.md
+include pytest.ini
+include pyproject.toml
+include requirements-dev.txt
+
 recursive-include tests *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = "black"
 src_paths = ["requests", "test"]


### PR DESCRIPTION
We've been missing the minimum PEP 518 build specification in our pyproject.toml. This PR adds that, along with an explicit backend to remove any ambiguity for alternative build tools.