### PR TITLE
Remove pytest-mock requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 pytest>=2.8.0,<=6.2.5
 pytest-cov
 pytest-httpbin==2.0.0
-pytest-mock==2.0.0
 httpbin==0.10.0
 trustme
 wheel

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from requests.help import info
 
 
@@ -11,15 +13,15 @@ class VersionedPackage:
         self.__version__ = version
 
 
-def test_idna_without_version_attribute(mocker):
+def test_idna_without_version_attribute():
     """Older versions of IDNA don't provide a __version__ attribute, verify
     that if we have such a package, we don't blow up.
     """
-    mocker.patch("requests.help.idna", new=None)
-    assert info()["idna"] == {"version": ""}
+    with mock.patch("requests.help.idna", new=None):
+        assert info()["idna"] == {"version": ""}
 
 
-def test_idna_with_version_attribute(mocker):
+def test_idna_with_version_attribute():
     """Verify we're actually setting idna version when it should be available."""
-    mocker.patch("requests.help.idna", new=VersionedPackage("2.6"))
-    assert info()["idna"] == {"version": "2.6"}
+    with mock.patch("requests.help.idna", new=VersionedPackage("2.6")):
+        assert info()["idna"] == {"version": "2.6"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import tarfile
 import zipfile
 from collections import deque
 from io import BytesIO
+from unittest import mock
 
 import pytest
 
@@ -751,13 +752,13 @@ def test_should_bypass_proxies(url, expected, monkeypatch):
         ("http://user:pass@hostname:5000", "hostname"),
     ),
 )
-def test_should_bypass_proxies_pass_only_hostname(url, expected, mocker):
+def test_should_bypass_proxies_pass_only_hostname(url, expected):
     """The proxy_bypass function should be called with a hostname or IP without
     a port number or auth credentials.
     """
-    proxy_bypass = mocker.patch("requests.utils.proxy_bypass")
-    should_bypass_proxies(url, no_proxy=None)
-    proxy_bypass.assert_called_once_with(expected)
+    with mock.patch("requests.utils.proxy_bypass") as proxy_bypass:
+        should_bypass_proxies(url, no_proxy=None)
+        proxy_bypass.assert_called_once_with(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We missed removing `pytest-mock` in the Python 2.7 deprecation. Since we're not using any specialized functionality in `pytest-mock` and `mock` is available in the standard library through `unittest`, let's prefer that.