### PR TITLE
Fix monthly download badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requests allows you to send HTTP/1.1 requests extremely easily. There’s no nee
 
 Requests is one of the most downloaded Python packages today, pulling in around `30M downloads / week`— according to GitHub, Requests is currently [depended upon](https://github.com/psf/requests/network/dependents?package_id=UGFja2FnZS01NzA4OTExNg%3D%3D) by `1,000,000+` repositories. You may certainly put your trust in this code.
 
-[![Downloads](https://pepy.tech/badge/requests/month)](https://pepy.tech/project/requests)
+[![Downloads](https://static.pepy.tech/badge/requests/month)](https://pepy.tech/project/requests)
 [![Supported Versions](https://img.shields.io/pypi/pyversions/requests.svg)](https://pypi.org/project/requests)
 [![Contributors](https://img.shields.io/github/contributors/psf/requests.svg)](https://github.com/psf/requests/graphs/contributors)
 


### PR DESCRIPTION
This PR fixes the monthly download badge in the README.

**At the moment:**
<img width="791" alt="image" src="https://github.com/psf/requests/assets/11357413/189384fd-d24b-4e36-8e6d-a763581d207e">


**With this PR:**
<img width="765" alt="image" src="https://github.com/psf/requests/assets/11357413/0174ed1a-82f1-475f-8245-dad2c57c11fc">
