### PR TITLE
Autoclose specific issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -1,6 +1,9 @@
 ---
 name: Request for Help
 about: Guidance on using Requests.
+labels:
+- "Question/Not a bug"
+- "actions/autoclose-qa"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels:
+- "Feature Request"
+- "actions/autoclose-feat"
 
 ---
 

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          GITHUB_TOKEN: ${{ secrets.MY_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           gh issue close $ISSUE_URL \
@@ -26,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          GITHUB_TOKEN: ${{ secrets.MY_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           gh issue close $ISSUE_URL \

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -18,7 +18,7 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           gh issue close $ISSUE_URL \
-            --comment "As described in the template, this is not the appropriate place for questions. Please use Stack Overflow" \
+            --comment "As described in the template, we won't be able to answer questions on this issue tracker. Please use [Stack Overflow](https://stackoverflow.com/)" \
             --reason completed
           gh issue lock $ISSUE_URL --reason off_topic
   close_feature_request:

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,35 @@
+name: 'Autoclose Issues'
+
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  close_qa:
+    if: github.event.label.name == 'actions/autoclose-qa'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.MY_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue close $ISSUE_URL \
+            --comment "As described in the template, this is not the appropriate place for questions. Please use Stack Overflow" \
+            --reason completed
+          gh issue lock $ISSUE_URL --reason off_topic
+  close_feature_request:
+    if: github.event.label.name == 'actions/autoclose-feat'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GITHUB_TOKEN: ${{ secrets.MY_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue close $ISSUE_URL \
+            --comment "As described in the template, Requests is not accepting feature requests" \
+            --reason "not planned"
+          gh issue lock $ISSUE_URL --reason off_topic


### PR DESCRIPTION
We spend a fair amount of time closing issues because people don't read the template closely or understand what they're being told. Let's take advantage of being able to auto-label an issue based on the template and then trigger a workflow to auto-magically close the issue with a message and lock the issue.