### PR TITLE
Do not overwrite the Authorization header

### DIFF
--- a/docs/user/authentication.rst
+++ b/docs/user/authentication.rst
@@ -36,10 +36,9 @@ Providing the credentials in a tuple like this is exactly the same as the
 netrc Authentication
 ~~~~~~~~~~~~~~~~~~~~
 
-If no authentication method is given with the ``auth`` argument, Requests will
-attempt to get the authentication credentials for the URL's hostname from the
-user's netrc file. The netrc file overrides raw HTTP authentication headers
-set with `headers=`.
+If no authentication method is given with the ``auth`` argument and the
+Authorization header has not been set, Requests will attempt to get the
+authentication credentials for the URL's hostname from the user's netrc file.
 
 If credentials for the hostname are found, the request is sent with HTTP Basic
 Auth.


### PR DESCRIPTION
## Summary

If the Authorization header has been explicitly set by the user, `requests` should not try to overwrite the header with credentials in `.netrc`.

Anecdotally, I was confused for a solid half hour, wondering why any token I passed yielded the same user before I made an unauthenticated call, dumped headers, and suspected `.netrc`.

See [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

## Changes

- Updated the authentication conditional in `prepare_request` to check whether the Authorization header (case-insensitive per [RFC9110#5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1)) is set.
- [Bonus] Added a period at the end of the sentence in a nearby comment.

## Related Issues

- Closes https://github.com/psf/requests/issues/3929