### PR TITLE
url param gets added when empty param is passed

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -119,6 +119,8 @@ class RequestEncodingMixin:
         elif hasattr(data, "__iter__"):
             result = []
             for k, vs in to_key_val_list(data):
+                if not isinstance(vs, basestring) and not vs:
+                    vs = ''
                 if isinstance(vs, basestring) or not hasattr(vs, "__iter__"):
                     vs = [vs]
                 for v in vs:


### PR DESCRIPTION
Have added the fix for the issue mentioned here - https://github.com/psf/requests/issues/6557

Since empty lists, dicts, tuples aren't of none type they should be added in the url string. 