### PR TITLE
Bug/6294 zero bytes files are chunked

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -545,7 +545,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                     "Streamed bodies and files are mutually exclusive."
                 )
 
-            if length:
+            if length is not None:
                 self.headers["Content-Length"] = builtin_str(length)
             else:
                 self.headers["Transfer-Encoding"] = "chunked"
@@ -573,7 +573,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         """Prepare Content-Length header based on request method and body"""
         if body is not None:
             length = super_len(body)
-            if length:
+            if length is not None:
                 # If length exists, set it. Otherwise, we fallback
                 # to Transfer-Encoding: chunked.
                 self.headers["Content-Length"] = builtin_str(length)

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -191,10 +191,10 @@ def super_len(o):
                     # partially read file-like objects
                     o.seek(current_position or 0)
                 except OSError:
-                    total_length = 0
+                    total_length = None
 
     if total_length is None:
-        total_length = 0
+        return total_length
 
     return max(0, total_length - current_position)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2157,7 +2157,7 @@ class TestRequests:
         resp.close()
         assert resp.raw.closed
 
-    def test_empty_stream_with_auth_does_not_set_content_length_header(self, httpbin):
+    def test_empty_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
         """Ensure that a byte stream with size 0 will not set both a Content-Length
         and Transfer-Encoding header.
         """
@@ -2166,8 +2166,8 @@ class TestRequests:
         file_obj = io.BytesIO(b"")
         r = requests.Request("POST", url, auth=auth, data=file_obj)
         prepared_request = r.prepare()
-        assert "Transfer-Encoding" in prepared_request.headers
-        assert "Content-Length" not in prepared_request.headers
+        assert "Transfer-Encoding" not in prepared_request.headers
+        assert "Content-Length" in prepared_request.headers
 
     def test_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
         """Ensure that a byte stream with size > 0 will not set both a Content-Length

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -130,6 +130,12 @@ class TestRequests:
         req = requests.Request(method, httpbin(method.lower()), data="").prepare()
         assert req.headers["Content-Length"] == "0"
 
+    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS"))
+    def test_empty_file_content_length(self, httpbin, method):
+        data = io.BytesIO(b"")
+        req = requests.Request(method, httpbin(method.lower()), data=data).prepare()
+        assert req.headers["Content-Length"] == "0"
+
     def test_override_content_length(self, httpbin):
         headers = {"Content-Length": "not zero"}
         r = requests.Request("POST", httpbin("post"), headers=headers).prepare()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,7 +92,7 @@ class TestSuperLen:
             def seek(self, offset, whence):
                 pass
 
-        assert super_len(NoLenBoomFile()) == 0
+        assert super_len(NoLenBoomFile()) is None
 
     def test_string(self):
         assert super_len("Test") == 4
@@ -149,7 +149,7 @@ class TestSuperLen:
 
     def test_super_len_with_no_matches(self):
         """Ensure that objects without any length methods default to 0"""
-        assert super_len(object()) == 0
+        assert super_len(object()) == None
 
 
 class TestToKeyValList:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -148,8 +148,14 @@ class TestSuperLen:
         assert length == len(file_data)
 
     def test_super_len_with_no_matches(self):
-        """Ensure that objects without any length methods default to 0"""
-        assert super_len(object()) == None
+        """Ensure that objects without any length methods default to None"""
+        assert super_len(object()) is None
+
+    def test_super_len_with_pipe(self):
+        """Ensure that ojects with a fileno that are not regular files default to length None"""
+        r, w = os.pipe()
+        rf = os.fdopen(r, "rb")
+        assert super_len(rf) is None
 
 
 class TestToKeyValList:


### PR DESCRIPTION
See bug #6294 for original bug report.

This PR provides a possible fix for this, reverting the change in #2896.

The change in #2896 definitely causes some bad side effects, since not all web servers handle "chunked" transfer encoding (i.e. some don't handle it, some don't handle it well).

### Problem demonstration

Given a simple bottle application:
```python
from bottle import run, put, request, default_app

app = default_app()

@app.put("/")
def receive_file():
    upload = request.body.read()
    for head, val in request.headers.items():
        print("%-30s:\t%s" % (head, val))
    clength = request.headers.get("Content-Length", "not-set")
    cencoding = request.headers.get("Transfer-Encoding", "not-set")
    return { 'size': len(upload), 'content-length': clength, 'transfer-encoding': cencoding }

if __name__ == '__main__':
    app.run(host='localhost', port=8880)
```

And a simple requests script:
```python
import requests
import io
empty_obj = io.BytesIO(b'')
resp = requests.put('http://localhost:8880/', data=empty_obj)
print(resp.status_code)
if resp.status_code == 200:
    print(resp.json())
```

## Working Scenario

```
$ python server.py
Bottle v0.12.25 server starting up (using WSGIRefServer())...
Listening on http://localhost:8880/
Hit Ctrl-C to quit.

Content-Length                :	
Content-Type                  :	text/plain
Host                          :	localhost:8880
User-Agent                    :	python-requests/2.31.0
Accept-Encoding               :	gzip, deflate, br
Accept                        :	*/*
Connection                    :	keep-alive
Transfer-Encoding             :	chunked
127.0.0.1 - - [03/Nov/2023 15:51:51] "PUT / HTTP/1.1" 200 65
```
Test script output:
```
200
{'size': 0, 'content-length': '', 'transfer-encoding': 'chunked'}
```

## Failing Scenario
```
$ gunicorn -b localhost:8880 server:app
[2023-11-03 15:52:05 +0100] [1326049] [INFO] Starting gunicorn 21.2.0
[2023-11-03 15:52:05 +0100] [1326049] [INFO] Listening at: http://127.0.0.1:8880 (1326049)
[2023-11-03 15:52:05 +0100] [1326049] [INFO] Using worker: sync
[2023-11-03 15:52:05 +0100] [1326050] [INFO] Booting worker with pid: 1326050
```
Test script output:
```
400
```

### The Original Issue

The change causing this problem in the first place was due to failing to upload data read from a subprocess pipe.

This patch adds a check to `super_len` that avoids returning length 0 for file handles that are not regular files.