### PR TITLE
Fix missing space in error message

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -1051,7 +1051,7 @@ def _validate_header_part(header, header_part, header_validator_index):
     if not validator.match(header_part):
         header_kind = "name" if header_validator_index == 0 else "value"
         raise InvalidHeader(
-            f"Invalid leading whitespace, reserved character(s), or return"
+            f"Invalid leading whitespace, reserved character(s), or return "
             f"character(s) in header {header_kind}: {header_part!r}"
         )
 


### PR DESCRIPTION
InvalidHeader got a smushed together error message due to no trailing space on first line.