### PR TITLE
Call url.lower() once inside get_adapter

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -784,8 +784,9 @@ class Session(SessionRedirectMixin):
 
         :rtype: requests.adapters.BaseAdapter
         """
+        lower_url = url.lower()
         for prefix, adapter in self.adapters.items():
-            if url.lower().startswith(prefix.lower()):
+            if lower_url.startswith(prefix.lower()):
                 return adapter
 
         # Nothing matches :-/


### PR DESCRIPTION
This is a re-proposal of https://github.com/psf/requests/pull/5497 three years later. The typical use-case for adaptaters is to create one and then mount it for both `http://` and `https://`. When using https:// URLs, this result in two calls to `url.lower()`, whereas with the optimization by @dbaxa this is computed only once.
IMHO the `prefix.lower()` thing should also be computed only once when we add the adapter, but I don’t know if this could break some code.