### PR TITLE
fix docstring typo: a -> as

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -859,7 +859,7 @@ def select_proxy(url, proxies):
 def resolve_proxies(request, proxies, trust_env=True):
     """This method takes proxy information from a request and configuration
     input to resolve a mapping of target proxies. This will consider settings
-    such a NO_PROXY to strip proxy configurations.
+    such as NO_PROXY to strip proxy configurations.
 
     :param request: Request or PreparedRequest
     :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs


### PR DESCRIPTION
Hi,

I noticed a typo in this docstring, thought I would write a quick PR to fix it.

As far as I can see, this docstring doesn't get added to the rendered html docs on https://requests.readthedocs.io/en/latest/ - they are only visible when viewing the source code.

I've not bothered running tests etc. given its such a small change, but please let me know if there's more you want me to do for this.

Thanks for requests!