### PR TITLE
Fix broken links in docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,7 +8,7 @@ Keepers of the Crystals
 
 Previous Keepers of Crystals
 ````````````````````````````
-- Kenneth Reitz <me@kennethreitz.org> `@ken-reitz <https://github.com/ken-reitz>`_, reluctant Keeper of the Master Crystal.
+- Kenneth Reitz <me@kennethreitz.org> `@kennethreitz <https://github.com/kennethreitz>`_, reluctant Keeper of the Master Crystal.
 - Cory Benfield <cory@lukasa.co.uk> `@lukasa <https://github.com/lukasa>`_
 - Ian Cordasco <graffatcolmingov@gmail.com> `@sigmavirus24 <https://github.com/sigmavirus24>`_.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,7 @@ dev
   forwarding of `Proxy-Authorization` headers to destination servers when
   following HTTPS redirects.
 
-  When proxies are defined with user info (https://user:pass@proxy:8080), Requests
+  When proxies are defined with user info (`https://user:pass@proxy:8080`), Requests
   will construct a `Proxy-Authorization` header that is attached to the request to
   authenticate with the proxy.
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1099,7 +1099,7 @@ The **connect** timeout is the number of seconds Requests will wait for your
 client to establish a connection to a remote machine (corresponding to the
 `connect()`_) call on the socket. It's a good practice to set connect timeouts
 to slightly larger than a multiple of 3, which is the default `TCP packet
-retransmission window <https://www.hjp.at/doc/rfc/rfc2988.txt>`_.
+retransmission window <https://datatracker.ietf.org/doc/html/rfc2988>`_.
 
 Once your client has connected to the server and sent the HTTP request, the
 **read** timeout is the number of seconds the client will wait for the server

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -291,7 +291,7 @@ versions of Requests.
 For the sake of security we recommend upgrading certifi frequently!
 
 .. _HTTP persistent connection: https://en.wikipedia.org/wiki/HTTP_persistent_connection
-.. _connection pooling: https://urllib3.readthedocs.io/en/latest/reference/index.html#module-urllib3.connectionpool
+.. _connection pooling: https://urllib3.readthedocs.io/en/latest/reference/urllib3.connectionpool.html
 .. _certifi: https://certifiio.readthedocs.io/
 .. _Mozilla trust store: https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -948,7 +948,7 @@ Link Headers
 Many HTTP APIs feature Link headers. They make APIs more self describing and
 discoverable.
 
-GitHub uses these for `pagination <https://developer.github.com/v3/#pagination>`_
+GitHub uses these for `pagination <https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api>`_
 in their API, for example::
 
     >>> url = 'https://api.github.com/users/kennethreitz/repos?page=1&per_page=10'

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -568,6 +568,3 @@ All exceptions that Requests explicitly raises inherit from
 -----------------------
 
 Ready for more? Check out the :ref:`advanced <advanced>` section.
-
-
-If you're on the job market, consider taking `this programming quiz <https://triplebyte.com/a/b1i2FB8/requests-docs-1>`_. A substantial donation will be made to this project, if you find a job through this platform.


### PR DESCRIPTION
Hi,

I noticed a broken link to rfc2988 in the [timeout section of the docs](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) and thought I would fix it.

While doing that, I thought I would run the sphinx `linkcheck` builder to check for other broken links and fix them.

There were a few, some where I've 'fixed'/updated the link are hopefully uncontroversial. 

Some are more controversial - removing sections written by the original author of requests that now have dead links, removing talks with dead links to slides, removing people's now dead GitHub account links. I wasn't sure what the right thing to do here was, but I went with my intuition, and kept commits pretty discrete so I can drop/amend them if the maintainers want me to do something different. If some are controversial enough to slow down the PR, I can always pull out the uncontroversial ones into their own PR for faster merging.