### PR TITLE
Enhance `super_len` to count encoded bytes for str

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -134,6 +134,9 @@ def super_len(o):
     total_length = None
     current_position = 0
 
+    if isinstance(o, str):
+        o = o.encode("utf-8")
+
     if hasattr(o, "__len__"):
         total_length = len(o)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1808,6 +1808,23 @@ class TestRequests:
 
         assert p.headers["Content-Length"] == length
 
+    def test_content_length_for_bytes_data(self, httpbin):
+        data = "This is a string containing multi-byte UTF-8 ☃️"
+        encoded_data = data.encode("utf-8")
+        length = str(len(encoded_data))
+        req = requests.Request("POST", httpbin("post"), data=encoded_data)
+        p = req.prepare()
+
+        assert p.headers["Content-Length"] == length
+
+    def test_content_length_for_string_data_counts_bytes(self, httpbin):
+        data = "This is a string containing multi-byte UTF-8 ☃️"
+        length = str(len(data.encode("utf-8")))
+        req = requests.Request("POST", httpbin("post"), data=data)
+        p = req.prepare()
+
+        assert p.headers["Content-Length"] == length
+
     def test_nonhttp_schemes_dont_check_URLs(self):
         test_urls = (
             "data:image/gif;base64,R0lGODlhAQABAHAAACH5BAUAAAAALAAAAAABAAEAAAICRAEAOw==",


### PR DESCRIPTION
This is a possible fix for issue #6586.

I am not at all confident that this is an appropriate change for Requests. All of the unit tests pass locally for me (specifically `make ci`).