### PR TITLE
Perform correct length measurement for Python strings in HTTP request `data`

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -140,7 +140,7 @@ def super_len(o):
     elif isinstance(o, str):
         # str with unicode chars might have multi-byte UTF-8
         # representations, so they must be encoded
-        total_length = len(o.encode('utf-8'))
+        total_length = len(o.encode("utf-8"))
 
     elif hasattr(o, "len"):
         total_length = o.len

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -134,8 +134,13 @@ def super_len(o):
     total_length = None
     current_position = 0
 
-    if hasattr(o, "__len__"):
+    if hasattr(o, "__len__") and not isinstance(o, str):
         total_length = len(o)
+
+    elif isinstance(o, str):
+        # str with unicode chars might have multi-byte UTF-8
+        # representations, so they must be encoded
+        total_length = len(o.encode('utf-8'))
 
     elif hasattr(o, "len"):
         total_length = o.len

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1808,6 +1808,23 @@ class TestRequests:
 
         assert p.headers["Content-Length"] == length
 
+    def test_content_length_for_bytes_data(self, httpbin):
+        data = "This is a string containing multi-byte UTF-8 ☃️"
+        encoded_data = data.encode("utf-8")
+        length = str(len(encoded_data))
+        req = requests.Request("POST", httpbin("post"), data=encoded_data)
+        p = req.prepare()
+
+        assert p.headers["Content-Length"] == length
+
+    def test_content_length_for_string_data_counts_bytes(self, httpbin):
+        data = "This is a string containing multi-byte UTF-8 ☃️"
+        length = str(len(data.encode("utf-8")))
+        req = requests.Request("POST", httpbin("post"), data=data)
+        p = req.prepare()
+
+        assert p.headers["Content-Length"] == length
+
     def test_nonhttp_schemes_dont_check_URLs(self):
         test_urls = (
             "data:image/gif;base64,R0lGODlhAQABAHAAACH5BAUAAAAALAAAAAABAAEAAAICRAEAOw==",


### PR DESCRIPTION
This PR addresses the problem detailed in #6586. The fix involves measuring the encoded byte-length of the string as per [RFC 9910](https://www.rfc-editor.org/rfc/rfc9110#field.content-length).

This PR includes two tests that verify the fix addresses the problem. Additionally, all tests pass locally, so no regressions have occurred.