### PR TITLE
"TOO_EARLY" type definition for status code 425

### DIFF
--- a/src/requests/status_codes.py
+++ b/src/requests/status_codes.py
@@ -79,7 +79,7 @@ _codes = {
     422: ("unprocessable_entity", "unprocessable"),
     423: ("locked",),
     424: ("failed_dependency", "dependency"),
-    425: ("unordered_collection", "unordered"),
+    425: ("unordered_collection", "unordered", "too_early"),
     426: ("upgrade_required", "upgrade"),
     428: ("precondition_required", "precondition"),
     429: ("too_many_requests", "too_many"),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2808,3 +2808,5 @@ class TestPreparingURLs:
         assert r2 == 425
         assert r3 == 425
         assert r4 == 425
+        assert r5 == 425
+        assert r6 == 425

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2795,3 +2795,16 @@ class TestPreparingURLs:
         with pytest.raises(requests.exceptions.JSONDecodeError) as excinfo:
             r.json()
         assert excinfo.value.doc == r.text
+
+    def test_status_code_425(self):
+        r1 = requests.codes.get("TOO_EARLY")
+        r2 = requests.codes.get("too_early")
+        r3 = requests.codes.get("UNORDERED")
+        r4 = requests.codes.get("unordered")
+        r5 = requests.codes.get("UNORDERED_COLLECTION")
+        r6 = requests.codes.get("unordered_collection")
+
+        assert r1 == 425
+        assert r2 == 425
+        assert r3 == 425
+        assert r4 == 425


### PR DESCRIPTION
Addressing issue #6584:
- Added "too_early" to type definition of status code 425
- Added tests for retrieving 425 when querying type definitions
- In accordance with RFC 4918 and 8470.
