### PR TITLE
Limit werkzeug<3 for CI only, fixes #6541

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ pytest-cov
 pytest-httpbin==2.0.0
 httpbin==0.10.0
 trustme
+werkzeug<3.0.0
 wheel
 cryptography<40.0.0; python_version <= '3.7' and platform_python_implementation == 'PyPy'


### PR DESCRIPTION
I believe this change will fix CI run failures, such as [these](https://github.com/psf/requests/actions/runs/7038290331).