### PR TITLE
Update close-issues.yml

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - env:
           ISSUE_URL: ${{ github.event.issue.html_url }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh issue close $ISSUE_URL \
             --comment "As described in the template, we won't be able to answer questions on this issue tracker. Please use [Stack Overflow](https://stackoverflow.com/)" \
@@ -26,6 +27,7 @@ jobs:
     steps:
       - env:
           ISSUE_URL: ${{ github.event.issue.html_url }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh issue close $ISSUE_URL \
             --comment "As described in the template, Requests is not accepting feature requests" \


### PR DESCRIPTION
I noticed the auto-labeling was working but not the auto-closing. Looking at recent actions runs I see that we need to specify the token even if we're not giving our own special token. See https://github.com/psf/requests/actions/runs/7057701782/job/19211845073#step:2:13 for additional context, namely

```
 gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```