### PR TITLE
Add Explanation of why Timeout is Doubled.

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -62,7 +62,15 @@ with the first request, but not the second::
 
 If you want to manually add cookies to your session, use the
 :ref:`Cookie utility functions <api-cookies>` to manipulate
-:attr:`Session.cookies <requests.Session.cookies>`.
+:attr:`Session.cookies <requests.Session.cookies>`.**You need to be careful when using the timeout argument.**
+
+If the specified domain has multiple IP addresses, `urllib3`_ will continue to try another IP address when the specified connection timeout is reached. Also, the connection timeout is applied for each attempt.
+Requests are affected by this because you are using `urllib3`_.
+This phenomenon can wait longer than you expect. Maybe it's the time that doubled the connection timeout.
+Of course there may be more.
+You can also consider extreme solutions, such as having the specified domain name return only one IP address.
+For example, if DNS returns both IPv4 DNS records (A) and IPv6 DNS records (AAAA), patch it so that it does not return IPv6.
+However, new issues may arise.
 
 Sessions can also be used as context managers::
 
@@ -1123,3 +1131,17 @@ coffee.
     r = requests.get('https://github.com', timeout=None)
 
 .. _`connect()`: https://linux.die.net/man/2/connect
+
+**You need to be careful when using the timeout argument.**
+
+If the specified domain has multiple IP addresses, `urllib3`_ will continue to try another IP address when the specified connection timeout is reached. Also, the connection timeout is applied for each attempt.
+
+Requests are affected by this because you are using `urllib3`_.
+
+This phenomenon can wait longer than you expect. Maybe it's the time that doubled the connection timeout.
+Of course there may be more.
+
+You can also consider extreme solutions, such as having the specified domain name return only one IP address.
+For example, if DNS returns both IPv4 DNS records (A) and IPv6 DNS records (AAAA), patch it so that it does not return IPv6.
+
+However, new issues may arise.


### PR DESCRIPTION
## Added Explanation for why Timeout is Doubled.
- In this Pull Request I have Tried to Solve #5773 .

./docs/user/advanced.rst
```diff
+ **You need to be careful when using the timeout argument.**
+ If the specified domain has multiple IP addresses, `urllib3`_ will continue to try another IP address when the specified connection timeout is reached. Also, the connection timeout is applied for each attempt.
+ Requests are affected by this because you are using `urllib3`_.
+ This phenomenon can wait longer than you expect. Maybe it's the time that doubled the connection timeout.
+ Of course there may be more.
+ You can also consider extreme solutions, such as having the specified domain name return only one IP address.
+ For example, if DNS returns both IPv4 DNS records (A) and IPv6 DNS records (AAAA), patch it so that it does not return IPv6.
+ However, new issues may arise.
```

If it Suits Your Needs Consider Merging this Pull Request.