### PR TITLE
docs: specify sphinx dirhtml builder, use references instead of absolutes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  builder: "dirhtml"
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -192,3 +192,4 @@ Patches and Suggestions
 - Alessio Izzo (`@aless10 <https://github.com/aless10>`_)
 - Sylvain Marié (`@smarie <https://github.com/smarie>`_)
 - Hod Bin Noon (`@hodbn <https://github.com/hodbn>`_)
+- Mike Fiedler (`@miketheman <https://github.com/miketheman>`_)

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -16,15 +16,15 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart/">Quickstart</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced/">Advanced Usage</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/api/">API Reference</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/community/updates/#release-history">Release History</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing/">Contributors Guide</a></li>
+  <li><a href="{{ pathto('user/quickstart') }}">Quickstart</a></li>
+  <li><a href="{{ pathto('user/advanced') }}">Advanced Usage</a></li>
+  <li><a href="{{ pathto('api') }}">API Reference</a></li>
+  <li><a href="{{ pathto('community/updates') + '#release-history' }}">Release History</a></li>
+  <li><a href="{{ pathto('dev/contributing') }}">Contributors Guide</a></li>
 
   <p></p>
 
-  <li><a href="https://requests.readthedocs.io/en/latest/community/recommended/">Recommended Packages and Extensions</a></li>
+  <li><a href="{{ pathto('community/recommended') }}">Recommended Packages and Extensions</a></li>
 
   <p></p>
 

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -16,11 +16,11 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced.html">Advanced Usage</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/api.html">API Reference</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/community/updates.html#release-history">Release History</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing.html">Contributors Guide</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart/">Quickstart</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced/">Advanced Usage</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/api/">API Reference</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/community/updates/#release-history">Release History</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing/">Contributors Guide</a></li>
 
   <p></p>
 

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -11,15 +11,15 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart/">Quickstart</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced/">Advanced Usage</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/api/">API Reference</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/community/updates/#release-history">Release History</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing/">Contributors Guide</a></li>
+  <li><a href="{{ pathto('user/quickstart') }}">Quickstart</a></li>
+  <li><a href="{{ pathto('user/advanced') }}">Advanced Usage</a></li>
+  <li><a href="{{ pathto('api') }}">API Reference</a></li>
+  <li><a href="{{ pathto('community/updates') + '#release-history' }}">Release History</a></li>
+  <li><a href="{{ pathto('dev/contributing') }}">Contributors Guide</a></li>
 
   <p></p>
 
-  <li><a href="https://requests.readthedocs.io/en/latest/community/recommended/">Recommended Packages and Extensions</a></li>
+  <li><a href="{{ pathto('community/recommended') }}">Recommended Packages and Extensions</a></li>
 
   <p></p>
 

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -11,15 +11,15 @@
 
 <h3>Useful Links</h3>
 <ul>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart.html">Quickstart</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced.html">Advanced Usage</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/api.html">API Reference</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/community/updates.html#release-history">Release History</a></li>
-  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing.html">Contributors Guide</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/user/quickstart/">Quickstart</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/user/advanced/">Advanced Usage</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/api/">API Reference</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/community/updates/#release-history">Release History</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/dev/contributing/">Contributors Guide</a></li>
 
   <p></p>
 
-  <li><a href="https://requests.readthedocs.io/en/latest/community/recommended.html">Recommended Packages and Extensions</a></li>
+  <li><a href="https://requests.readthedocs.io/en/latest/community/recommended/">Recommended Packages and Extensions</a></li>
 
   <p></p>
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -22,7 +22,7 @@ Custom User-Agents?
 -------------------
 
 Requests allows you to easily override User-Agent strings, along with
-any other HTTP Header. See `documentation about headers <https://requests.readthedocs.io/en/latest/user/quickstart/#custom-headers>`_.
+any other HTTP Header. See :ref:`documentation about headers <custom-headers>`.
 
 
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -201,6 +201,8 @@ may better fit your use cases.
    were returned, use ``Response.raw``.
 
 
+.. _custom-headers:
+
 Custom Headers
 --------------
 


### PR DESCRIPTION
With the requirement of a configuration file, the default builder of `dirhtml` that RTD used to use is no longer specified. This leads to URLs ending in `.html` now, which
breaks other exisitng references.

Refs: #6603
Refs: https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-builder
Refs: https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.dirhtml.DirectoryHTMLBuilder