### PR TITLE
docs: add label to socks heading

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -666,6 +666,8 @@ You override this default certificate bundle by setting the ``REQUESTS_CA_BUNDLE
     >>> import requests
     >>> requests.get('https://example.org')
 
+.. _socks:
+
 SOCKS
 ^^^^^
 


### PR DESCRIPTION
When trying to link via intersphinx, a label must be used. Otherwise a full URL is required, which is less desirable.

Alternately, the project could attempt to use [`sphinx.ext.autosectionlabel`](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html), but that felt too heavy-handed for right now.