### PR TITLE
Closes #6565; Add documentation to `certs.where`.

### DIFF
--- a/src/requests/certs.py
+++ b/src/requests/certs.py
@@ -11,7 +11,22 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
 environment, you can change the definition of where() to return a separately
 packaged CA bundle.
 """
-from certifi import where
+from certifi import where as _where
+
+
+def where() -> str:
+    """Returns the path of the default CA-certs bundle that is included with
+    the requests package. This function is essentially an alias of
+    `certify.where`.
+
+    Note that the default path is not necessarily the one being used, as it can
+    be overridden through ``requests.Session().verify``,
+    ``requests.Session().merge_environment_settings``,
+    ``requests.get(verify=...)``, and others.
+
+    """
+    return _where()
+
 
 if __name__ == "__main__":
-    print(where())
+    print(_where())


### PR DESCRIPTION
Closes #6565 by adding documentation to `certs.where`. A wrapper was used so that the `__doc__` attribute of `certifi.where` would be preserved, and to allow for greater intellisense coverage. The second issue brought up in #6565 could not be addressed, as the CA-certs default path is only taken from `certs.where`, and can be overridden on a per-instance level of `Session` instances (for example).