### PR TITLE
handle failure in apparent_encoding gracefully

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -789,7 +789,12 @@ class Response:
     @property
     def apparent_encoding(self):
         """The apparent encoding, provided by the charset_normalizer or chardet libraries."""
-        return chardet.detect(self.content)["encoding"]
+        try:
+            return chardet.detect(self.content)["encoding"]
+        except TypeError:
+            # Somehow, we received a str here, so return no apparent_encoding, and
+            # let the `text` property deal with it gracefully
+            return None
 
     def iter_content(self, chunk_size=1, decode_unicode=False):
         """Iterates over the response data.  When stream=True is set on the
@@ -915,7 +920,6 @@ class Response:
         """
 
         # Try charset from content-type
-        content = None
         encoding = self.encoding
 
         if not self.content:


### PR DESCRIPTION
Under certain circumstances, we have seen the content of our response come back as a `str` instead of `bytes`.  When that happens, and we use `response.text`, the library is throwing a `TypeError`.  This PR catches that exception, and lets the `text` property gracefully handle coercing the content to a `str`.

In our case, this happened when we received a `ConnectionError`, however, I believe there may be some other situations where this could occur.