### PR TITLE
Set verify=True by default as documented

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -512,7 +512,7 @@ class Session(SessionRedirectMixin):
         proxies=None,
         hooks=None,
         stream=None,
-        verify=None,
+        verify=True,
         cert=None,
         json=None,
     ):


### PR DESCRIPTION
The [documentation](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification) clearly states that the default for `verify` is `True`. Via [merge_environment_settings()](https://github.com/psf/requests/blob/96b22fa18c00831656ee4b286bf1c9062459b00a/src/requests/sessions.py#L766-L771) and [merge_settings()](https://github.com/psf/requests/blob/96b22fa18c00831656ee4b286bf1c9062459b00a/src/requests/sessions.py#L61-L71) the behaviour of `None` is made the same as `True` because `self.verify` is [initialized](https://github.com/psf/requests/blob/96b22fa18c00831656ee4b286bf1c9062459b00a/src/requests/sessions.py#L424) as `True` but this is rather non-intuitive. Let's make the actual default of request() function `True` as per the documentation. 