### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
-        include:
-          # pypy-3.7 on Windows and Mac OS currently fails trying to compile
-          # cryptography. Moving pypy-3.7 to only test linux.
-          - python-version: pypy-3.7
-            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 # Pinning to avoid unexpected breakages.
 # Used by RTD to generate docs.
-Sphinx==4.2.0
+Sphinx==7.2.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 pytest>=2.8.0,<=6.2.5
 pytest-cov
 pytest-httpbin==2.0.0
-httpbin==0.10.0
+httpbin~=0.10.0
 trustme
 wheel
 cryptography<40.0.0; python_version <= '3.7' and platform_python_implementation == 'PyPy'


### PR DESCRIPTION
This PR will bring in a few changes to fix our CI suite. The release of `httpbin` 0.10.2 unblocks our test suite with Flask 3.0 which should fix the breakages in the last several months. In that window, our PyPy 3.8 build has broken on Windows due to https://github.com/pyca/cryptography/issues/10371. PyPy has dropped upstream support for both 3.7 and 3.8, so it seems more straight forward to follow them than try to patch around the cryptography issue.

We'll plan to deprecate both EoS PyPy runtimes with the next Requests release alongside CPython 3.7.