### PR TITLE
Drop support for CPython 3.7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Requests is available on PyPI:
 $ python -m pip install requests
 ```
 
-Requests officially supports Python 3.7+.
+Requests officially supports Python 3.8+.
 
 ## Supported Features & Best–Practices
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -55,7 +55,7 @@ Chris Adams gave an excellent summary on
 Python 3 Support?
 -----------------
 
-Yes! Requests officially supports Python 3.7+ and PyPy.
+Yes! Requests officially supports Python 3.8+ and PyPy.
 
 Python 2 Support?
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 3.7+, and runs great on PyPy.
+Requests officially supports Python 3.8+, and runs great on PyPy.
 
 
 The User Guide

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,3 @@ pytest-httpbin==2.0.0
 httpbin~=0.10.0
 trustme
 wheel
-cryptography<40.0.0; python_version <= '3.7' and platform_python_implementation == 'PyPy'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 7)
+REQUIRED_PYTHON = (3, 8)
 
 if CURRENT_PYTHON < REQUIRED_PYTHON:
     sys.stderr.write(
@@ -20,7 +20,7 @@ you're trying to install it on Python {}.{}. To resolve this,
 consider upgrading to a supported Python version.
 
 If you can't upgrade your Python version, you'll need to
-pin to an older version of Requests (<2.28).
+pin to an older version of Requests (<2.32.0).
 """.format(
             *(REQUIRED_PYTHON + CURRENT_PYTHON)
         )
@@ -94,7 +94,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"]},
     package_dir={"": "src"},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requires,
     license=about["__license__"],
     zip_safe=False,
@@ -107,7 +107,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-{default, use_chardet_on_py3}
+envlist = py{38,39,310,311,312}-{default, use_chardet_on_py3}
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Now that pip has dropped support for Python 3.7 in https://github.com/pypa/pip/pull/11944, we should be set to follow. This PR will remove support for Python 3.7 from requests starting in the next minor release 2.32.0.