### PR TITLE
Trim excess leading path separators

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -390,6 +390,9 @@ class HTTPAdapter(BaseAdapter):
             using_socks_proxy = proxy_scheme.startswith("socks")
 
         url = request.path_url
+        if url.startswith("//"):  # Don't confuse urllib3
+            url = f"/{url.lstrip('/')}"
+
         if is_proxied_http_request and not using_socks_proxy:
             url = urldefragauth(request.url)
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,8 @@
+import requests.adapters
+
+
+def test_request_url_trims_leading_path_separators():
+    """See also https://github.com/psf/requests/issues/6643."""
+    a = requests.adapters.HTTPAdapter()
+    p = requests.Request(method="GET", url="http://127.0.0.1:10000//v:h").prepare()
+    assert "/v:h" == a.request_url(p, {})


### PR DESCRIPTION
A URL with excess leading / (path-separator)s would cause urllib3 to attempt to reparse the request-uri as a full URI with a host and port. This bypasses that logic in ConnectionPool.urlopen by replacing these leading /s with just a single /.

Closes #6643