### PR TITLE
Add content to raise for status method

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -1030,3 +1030,4 @@ class Response:
         release_conn = getattr(self.raw, "release_conn", None)
         if release_conn is not None:
             release_conn()
+# scratch

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -1030,4 +1030,3 @@ class Response:
         release_conn = getattr(self.raw, "release_conn", None)
         if release_conn is not None:
             release_conn()
-# scratch

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -1007,12 +1007,12 @@ class Response:
 
         if 400 <= self.status_code < 500:
             http_error_msg = (
-                f"{self.status_code} Client Error: {reason} for url: {self.url}"
+                f"{self.status_code} Client Error: {reason} for url: {self.url} content: {self.content}"
             )
 
         elif 500 <= self.status_code < 600:
             http_error_msg = (
-                f"{self.status_code} Server Error: {reason} for url: {self.url}"
+                f"{self.status_code} Server Error: {reason} for url: {self.url} content: {self.content}"
             )
 
         if http_error_msg:

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -1006,14 +1006,10 @@ class Response:
             reason = self.reason
 
         if 400 <= self.status_code < 500:
-            http_error_msg = (
-                f"{self.status_code} Client Error: {reason} for url: {self.url} content: {self.content}"
-            )
+            http_error_msg = f"{self.status_code} Client Error: {reason} for url: {self.url} content: {self.content}"
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = (
-                f"{self.status_code} Server Error: {reason} for url: {self.url} content: {self.content}"
-            )
+            http_error_msg = f"{self.status_code} Server Error: {reason} for url: {self.url} content: {self.content}"
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)


### PR DESCRIPTION
added self.content to http_error_msg for helping debugging
Sometimes response content has information that helping debugging.

following is the code I tested.

## Test code
### 402
```
import requests

response = requests.get('https://httpbin.org/status/402')
print(f'status_cod: {response.status_code}')
print(f'content: {response.content}')
print(f'reason: {response.reason}')
response.raise_for_status()
```

### 406
```
import requests

response = requests.get('https://httpbin.org/status/406')
print(f'status_cod: {response.status_code}')
print(f'content: {response.content}')
print(f'reason: {response.reason}')
response.raise_for_status()
```

## Before
### 402
```
status_cod: 402
content: b'Fuck you, pay me!'
reason: PAYMENT REQUIRED
Traceback (most recent call last):
  File "/private/tmp/playground.py", line 7, in <module>
    response.raise_for_status()
  File "/opt/homebrew/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 402 Client Error: PAYMENT REQUIRED for url: https://httpbin.org/status/402
```

### 406
```
status_cod: 406
content: b'{"message": "Client did not request a supported media type.", "accept": ["image/webp", "image/svg+xml", "image/jpeg", "image/png", "image/*"]}'
reason: NOT ACCEPTABLE
Traceback (most recent call last):
  File "/private/tmp/playground.py", line 7, in <module>
    response.raise_for_status()
  File "/opt/homebrew/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 406 Client Error: NOT ACCEPTABLE for url: https://httpbin.org/status/406
```

## After
### 402
```
status_cod: 402
content: b'Fuck you, pay me!'
reason: PAYMENT REQUIRED
Traceback (most recent call last):
  File "/private/tmp/playground.py", line 7, in <module>
    response.raise_for_status()
  File "/opt/homebrew/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 402 Client Error: PAYMENT REQUIRED for url: https://httpbin.org/status/402 content: b'Fuck you, pay me!'
```

### 406
```
status_cod: 406
content: b'{"message": "Client did not request a supported media type.", "accept": ["image/webp", "image/svg+xml", "image/jpeg", "image/png", "image/*"]}'
reason: NOT ACCEPTABLE
Traceback (most recent call last):
  File "/private/tmp/playground.py", line 7, in <module>
    response.raise_for_status()
  File "/opt/homebrew/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 406 Client Error: NOT ACCEPTABLE for url: https://httpbin.org/status/406 content: b'{"message": "Client did not request a supported media type.", "accept": ["image/webp", "image/svg+xml", "image/jpeg", "image/png", "image/*"]}'
```