### PR TITLE
Fix utils functions with invalid ip/cidr inputs

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -9,6 +9,7 @@ that are also useful for external consumption.
 import codecs
 import contextlib
 import io
+import ipaddress
 import os
 import re
 import socket
@@ -677,11 +678,12 @@ def address_in_network(ip, net):
 
     :rtype: bool
     """
-    ipaddr = struct.unpack("=L", socket.inet_aton(ip))[0]
-    netaddr, bits = net.split("/")
-    netmask = struct.unpack("=L", socket.inet_aton(dotted_netmask(int(bits))))[0]
-    network = struct.unpack("=L", socket.inet_aton(netaddr))[0] & netmask
-    return (ipaddr & netmask) == (network & netmask)
+    try:
+        ip_address = ipaddress.ip_address(ip)
+        network = ipaddress.ip_network(net)
+        return ip_address in network
+    except (ipaddress.AddressValueError, ValueError):
+        return False
 
 
 def dotted_netmask(mask):

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -702,8 +702,8 @@ def is_ipv4_address(string_ip):
     :rtype: bool
     """
     try:
-        socket.inet_aton(string_ip)
-    except OSError:
+        ipaddress.IPv4Address(string_ip)
+    except ipaddress.AddressValueError:
         return False
     return True
 

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -714,22 +714,11 @@ def is_valid_cidr(string_network):
 
     :rtype: bool
     """
-    if string_network.count("/") == 1:
-        try:
-            mask = int(string_network.split("/")[1])
-        except ValueError:
-            return False
-
-        if mask < 1 or mask > 32:
-            return False
-
-        try:
-            socket.inet_aton(string_network.split("/")[0])
-        except OSError:
-            return False
-    else:
+    try:
+        interface = ipaddress.ip_interface(string_network)
+    except (ipaddress.AddressValueError, ValueError):
         return False
-    return True
+    return string_network in (interface.compressed, interface.exploded)
 
 
 @contextlib.contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,6 +300,7 @@ class TestIsValidCIDR:
             "192.168.1.0/128",
             "192.168.1.0/-1",
             "192.168.1.999/24",
+            "1.1.1.1 something/24",
         ),
     )
     def test_invalid(self, value):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -303,8 +303,17 @@ class TestAddressInNetwork:
     def test_valid(self):
         assert address_in_network("192.168.1.1", "192.168.1.0/24")
 
-    def test_invalid(self):
-        assert not address_in_network("172.16.0.1", "192.168.1.0/24")
+    @pytest.mark.parametrize(
+        "ip, net",
+        (
+            ("172.16.0.1", "192.168.1.0/24"),
+            ("1.1.1.1", "1.1.1.1/24"),
+            ("1.1.1.1wtf", "1.1.1.1/24"),
+            ("1.1.1.1 wtf", "1.1.1.1/24"),
+        ),
+    )
+    def test_invalid(self, ip, net):
+        assert not address_in_network(ip, net)
 
 
 class TestGuessFilename:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -276,7 +276,14 @@ class TestIsIPv4Address:
     def test_valid(self):
         assert is_ipv4_address("8.8.8.8")
 
-    @pytest.mark.parametrize("value", ("8.8.8.8.8", "localhost.localdomain"))
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "8.8.8.8.8",
+            "1.1.1.1 someone was here...",
+            "localhost.localdomain",
+        ),
+    )
     def test_invalid(self, value):
         assert not is_ipv4_address(value)
 


### PR DESCRIPTION
- add test cases reported in #5131
- fix utils functions `address_in_network`, `is_ipv4_address` and `is_valid_cidr`
- replace socket with `ipaddress` module
- prepare ipv6 support

Fixes #5131