### PR TITLE
Adds json.JSONDecodeError from standard library to requests.JSONDecodeError

### DIFF
--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -7,7 +7,7 @@ This module contains the set of Requests' exceptions.
 from json import JSONDecodeError as StandardJSONDecodeError
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
-from .compat import JSONDecodeError as CompatJSONDecodeError
+from .compat import JSONDecodeError as BaseCompatJSONDecodeError
 
 
 class RequestException(IOError):
@@ -28,10 +28,10 @@ class RequestException(IOError):
 class InvalidJSONError(RequestException):
     """A JSON error occurred."""
 
-class CompatJSONDecodeError(CompatJSONDecodeError, StandardJSONDecodeError):
+class CompatJSONDecodeError(BaseCompatJSONDecodeError, StandardJSONDecodeError):
     """
     A JSON decoding error occurred.
-    Ensures CompatJSONDecodeError is a subclass of standard JSONDecodeError.
+    CompatJSONDecodeError is a subclass of json.JSONDecodeError and simplejson.JSONDecodeError.
     """
 
 class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):

--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -4,7 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
-import json
+from json import JSONDecodeError as StandardJSONDecodeError
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from .compat import JSONDecodeError as CompatJSONDecodeError
@@ -28,8 +28,13 @@ class RequestException(IOError):
 class InvalidJSONError(RequestException):
     """A JSON error occurred."""
 
+class CompatJSONDecodeError(CompatJSONDecodeError, StandardJSONDecodeError):
+    """
+    A JSON decoding error occurred.
+    Ensures CompatJSONDecodeError is a subclass of standard JSONDecodeError.
+    """
 
-class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError, json.JSONDecodeError):
+class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):
     """Couldn't decode the text into json"""
 
     def __init__(self, *args, **kwargs):

--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -4,6 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
+import json
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from .compat import JSONDecodeError as CompatJSONDecodeError
@@ -28,7 +29,7 @@ class InvalidJSONError(RequestException):
     """A JSON error occurred."""
 
 
-class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):
+class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError, json.JSONDecodeError):
     """Couldn't decode the text into json"""
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2807,6 +2807,7 @@ class TestPreparingURLs:
             r.json()
         assert isinstance(excinfo.value, RequestException)
         assert isinstance(excinfo.value, JSONDecodeError)
+        assert isinstance(excinfo.value, json.JSONDecodeError)
         assert r.text not in str(excinfo.value)
 
     def test_json_decode_persists_doc_attr(self, httpbin):


### PR DESCRIPTION
Below is a suggestion for slightly enhancing the `JSONDecodeError` behavior.

### Background
The [comments](https://github.com/psf/requests/blob/main/src/requests/models.py#L972) for the `json()` method of `Response` say that `requests.JSONDecodeError` should alias the JSONDecodeError from the standard `json` library (`json.JSONDecodeError`) and `simplejson.JSONDecodeError`. 

### Problem
When `simplejson` is installed, `requests.JSONDecodeError` is not an instance of `json.JSONDecodeError`

### How to reproduce
1. Install `simplejson` in a virtual environment
```
pip install simplejson
```
2. Without the proposed change, [this test](https://github.com/psf/requests/compare/main...jon-behnken:requests:main#diff-05180dda5cdc530f95d400932961d6152bd515a6447af23d22c7f335b390b9d8R2810) should fail:
```
pytest tests/test_requests.py -k test_json_decode_compatibility 
```

### Why
Implementations like this should behave as expected:
```
try:
    response = requests.get("https://www.example.com/data").json()
except json.JSONDecodeError:
    # do something
```
but this exception does not get caught. Currently you must use `requests.exceptions.JSONDecodeError` which is a bit unintuitive. 