### PR TITLE
Add rfc9110 HTTP status code names

### DIFF
--- a/src/requests/status_codes.py
+++ b/src/requests/status_codes.py
@@ -24,7 +24,7 @@ _codes = {
     # Informational.
     100: ("continue",),
     101: ("switching_protocols",),
-    102: ("processing",),
+    102: ("processing", "early-hints"),
     103: ("checkpoint",),
     122: ("uri_too_long", "request_uri_too_long"),
     200: ("ok", "okay", "all_ok", "all_okay", "all_good", "\\o/", "✓"),
@@ -65,8 +65,8 @@ _codes = {
     410: ("gone",),
     411: ("length_required",),
     412: ("precondition_failed", "precondition"),
-    413: ("request_entity_too_large",),
-    414: ("request_uri_too_large",),
+    413: ("request_entity_too_large", "content_too_large"),
+    414: ("request_uri_too_large", "uri_too_long"),
     415: ("unsupported_media_type", "unsupported_media", "media_type"),
     416: (
         "requested_range_not_satisfiable",
@@ -76,7 +76,7 @@ _codes = {
     417: ("expectation_failed",),
     418: ("im_a_teapot", "teapot", "i_am_a_teapot"),
     421: ("misdirected_request",),
-    422: ("unprocessable_entity", "unprocessable"),
+    422: ("unprocessable_entity", "unprocessable", "unprocessable_content"),
     423: ("locked",),
     424: ("failed_dependency", "dependency"),
     425: ("unordered_collection", "unordered", "too_early"),


### PR DESCRIPTION
RFC 9110 _HTTP Semantics_ obsoletes some earlier RFCs which defined HTTP 1.1. It adds some status codes that were previously only used for WebDAV to HTTP _proper_ after making the names somewhat more generic.

See https://www.rfc-editor.org/rfc/rfc9110.html#name-changes-from-rfc-7231

This commit adds the http status code names from that RFC.

RFC 9110 has been accepted as Internet Standard in June 2022.

In https://github.com/psf/requests/blob/main/docs/user/advanced.rst#compliance  it states:

> Requests is intended to be compliant with all relevant specifications and RFCs where that compliance will not cause difficulties for users. 

So it seems only logical that the status code descriptions found in that RFC are also available in Requests