### PR TITLE
Fix compatibility with pytest 8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .[socks]
-pytest>=2.8.0,<=6.2.5
+pytest>=2.8.0,<9
 pytest-cov
 pytest-httpbin==2.0.0
 httpbin~=0.10.0

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1003,7 +1003,7 @@ class TestRequests:
                 "SubjectAltNameWarning",
             )
 
-        with pytest.warns(None) as warning_records:
+        with pytest.warns() as warning_records:
             warnings.simplefilter("always")
             requests.get(f"https://localhost:{port}/", verify=ca_bundle)
 


### PR DESCRIPTION
`pytest.warns(None)` has been deprecated in pytest 7.0.0 and it's no longer working in pytest 8.

Resolves: https://github.com/psf/requests/issues/6679