### PR TITLE
Fix raise for status #6683

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -989,7 +989,7 @@ class Response:
 
         return resolved_links
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> "Response":
         """Raises :class:`HTTPError`, if one occurred."""
 
         http_error_msg = ""
@@ -1017,6 +1017,8 @@ class Response:
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)
+        else:
+            return self
 
     def close(self):
         """Releases the connection back to the pool. Once this method has been

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -989,7 +989,7 @@ class Response:
 
         return resolved_links
 
-    def raise_for_status(self) -> "Response":
+    def raise_for_status(self):
         """Raises :class:`HTTPError`, if one occurred."""
 
         http_error_msg = ""

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -897,10 +897,10 @@ class TestRequests:
 
     def test_raise_for_status_chainability(self, httpbin):
         for status_code in (200, 299, 300, 399):
-            response = requests.get(httpbin("status", str(status_code)))
-            out = response.raise_for_status()
+            r = requests.get(httpbin("status", str(status_code)))
+            out = r.raise_for_status()
             assert isinstance(out, requests.Response)
-            assert out is response
+            assert out is r
 
     def test_decompress_gzip(self, httpbin):
         r = requests.get(httpbin("gzip"))

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -889,13 +889,18 @@ class TestRequests:
         r = requests.get(httpbin("status", "404"))
         assert not r.ok
 
-    def test_status_raising(self, httpbin):
-        r = requests.get(httpbin("status", "404"))
-        with pytest.raises(requests.exceptions.HTTPError):
-            r.raise_for_status()
+    def test_raise_for_status_not_ok(self, httpbin):
+        for status_code in (400, 404, 499, 500, 599):
+            r = requests.get(httpbin("status", str(status_code)))
+            with pytest.raises(requests.exceptions.HTTPError):
+                r.raise_for_status()
 
-        r = requests.get(httpbin("status", "500"))
-        assert not r.ok
+    def test_raise_for_status_chainability(self, httpbin):
+        for status_code in (200, 299, 300, 399):
+            response = requests.get(httpbin("status", str(status_code)))
+            out = response.raise_for_status()
+            assert isinstance(out, requests.Response)
+            assert out is response
 
     def test_decompress_gzip(self, httpbin):
         r = requests.get(httpbin("gzip"))


### PR DESCRIPTION
Fix `raise_for_status()` behaviour to comply with documentation as per [issue #6683](https://github.com/psf/requests/issues/6683). In particular, makes it return the response to ease chaining in trivial cases.