### PR TITLE
Docs update: warn that Session.verify is ignored if REQUESTS_CA_BUNDLE is set

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -238,6 +238,9 @@ or persistent::
 This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` environment variable.
 If ``REQUESTS_CA_BUNDLE`` is not set, ``CURL_CA_BUNDLE`` will be used as fallback.
 
+.. warning:: Changes to ``session.verify`` will be ignored if either 
+  ``REQUESTS_CA_BUNDLE`` or ``CURL_CA_BUNDLE`` is set.
+
 Requests can also ignore verifying the SSL certificate if you set ``verify`` to False::
 
     >>> requests.get('https://kennethreitz.org', verify=False)


### PR DESCRIPTION
Issue #3829 tracks that Session.verify is ignored whenever `REQUESTS_CA_BUNDLES` or `CURL_CA_BUNDLES` is set. The underlying behavior will apparently be changed in 3.x, but in the meantime it would be helpful to call out the behavior in the docs to avoid catching people out (the issue has been locked due to a large number of comments).

I'm happy to rework this PR as needed, but it'd be great to get something in the docs about this in one form or another to help prevent people hitting this.

Thanks in advance for your thoughts!

---

# Change Details

* Added a `warning::` callout to the relevant section of the docs.

# Alternate Approaches Considered

I initially wrote out a longer section detailing the semantics for how the various options interact — but all the other interactions are very intuitive, so this felt like overkill. Let me know if you'd prefer that approach.

This section of the docs is also a bit callout heavy, so I'm happy to inline the text rather than put it in a callout, if you prefer.