### PR TITLE
Use an invalid URI that will not cause httpbin to throw 500

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2721,7 +2721,7 @@ class TestPreparingURLs:
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()
 
-    @pytest.mark.parametrize("url, exception", (("http://localhost:-1", InvalidURL),))
+    @pytest.mark.parametrize("url, exception", (("http://:1", InvalidURL),))
     def test_redirecting_to_bad_url(self, httpbin, url, exception):
         with pytest.raises(exception):
             requests.get(httpbin("redirect-to"), params={"url": url})


### PR DESCRIPTION
Context in https://github.com/urllib3/urllib3/issues/3392

Urllib3's CI started failing due to the requests `test_redirecting_to_bad_url` failing. The test started failing, beacuse httpbin started returning 500 on initial request, instead of a 302. I think this would break requests CI as well if it were run now.

Modified the redirect to URI to something that will not cause httpbin to throw a 500, but is still an invalid URI.