### PR TITLE
Add default timeout

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+**Security**
+- Add a default timeout value to Requests. The default connect timeout is 10.0
+  seconds and the default read timeout is 30.0 seconds. (#3070)
+
 2.32.1 (2024-05-20)
 -------------------
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -58,6 +58,10 @@ else:
     preferred_clock = time.time
 
 
+# (connect timeout, read timeout)
+_DEFAULT_TIMEOUT = (10.0, 30.0)
+
+
 def merge_setting(request_setting, session_setting, dict_class=OrderedDict):
     """Determines appropriate setting for a given request, taking into account
     the explicit setting on that request, and the setting in the session. If a
@@ -582,7 +586,7 @@ class Session(SessionRedirectMixin):
 
         # Send the request.
         send_kwargs = {
-            "timeout": timeout,
+            "timeout": timeout if timeout is not None else _DEFAULT_TIMEOUT,
             "allow_redirects": allow_redirects,
         }
         send_kwargs.update(settings)


### PR DESCRIPTION
This adds a default connect and read timeout value for all usage of Requests. This is to solve a long-standing issue where some systems do not have a sufficiently low default value.

Personally, I'd want these values to be much lower, but a 10 second connection timeout and a 30 second read timeout seem like they should be enough to avoid problems for the edge cases of users while also not being so large that they're basically ineffective.

Closes #3070