### PR TITLE
Move _get_connection to get_connection_with_tls_context

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -9,6 +9,7 @@ and maintain connections.
 import os.path
 import socket  # noqa: F401
 import typing
+import warnings
 
 from urllib3.exceptions import ClosedPoolError, ConnectTimeoutError
 from urllib3.exceptions import HTTPError as _HTTPError
@@ -425,6 +426,15 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: (optional) A Requests-style dictionary of proxies used on this request.
         :rtype: urllib3.ConnectionPool
         """
+        warnings.warn(
+            (
+                "`get_connection` has been deprecated in favor of "
+                "`get_connection_with_tls_context`. Custom HTTPAdapter subclasses "
+                "will need to migrate for Requests>=2.32.2. Please see "
+                "https://github.com/psf/requests/pull/6710 for more details."
+            ),
+            DeprecationWarning,
+        )
         proxy = select_proxy(url, proxies)
 
         if proxy:

--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -374,10 +374,20 @@ class HTTPAdapter(BaseAdapter):
 
         return response
 
-    def _get_connection(self, request, verify, proxies=None, cert=None):
-        # Replace the existing get_connection without breaking things and
-        # ensure that TLS settings are considered when we interact with
-        # urllib3 HTTP Pools
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        """Returns a urllib3 connection for the given request and TLS settings.
+        This should not be called from user code, and is only exposed for use
+        when subclassing the :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
+
+        :param request: The :class:`PreparedRequest <PreparedRequest>` object
+            to be sent over the connection.
+        :param verify: Either a boolean, in which case it controls whether
+            we verify the server's TLS certificate, or a string, in which case it
+            must be a path to a CA bundle to use.
+        :param proxies: (optional) The proxies dictionary to apply to the request.
+        :param cert: (optional) Any user-provided SSL certificate to be trusted.
+        :rtype: urllib3.ConnectionPool
+        """
         proxy = select_proxy(request.url, proxies)
         try:
             host_params, pool_kwargs = _urllib3_request_context(request, verify, cert)
@@ -404,7 +414,10 @@ class HTTPAdapter(BaseAdapter):
         return conn
 
     def get_connection(self, url, proxies=None):
-        """Returns a urllib3 connection for the given URL. This should not be
+        """DEPRECATED: Users should move to `get_connection_with_tls_context`
+        for all subclasses of HTTPAdapter using Requests>=2.32.2.
+
+        Returns a urllib3 connection for the given URL. This should not be
         called from user code, and is only exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 
@@ -529,7 +542,9 @@ class HTTPAdapter(BaseAdapter):
         """
 
         try:
-            conn = self._get_connection(request, verify, proxies=proxies, cert=cert)
+            conn = self.get_connection_with_tls_context(
+                request, verify, proxies=proxies, cert=cert
+            )
         except LocationValueError as e:
             raise InvalidURL(e, request=request)
 


### PR DESCRIPTION
This PR is meant to provide a new publicly supported api `get_connection_with_tls_context` to better facilitate custom adapters with our recent fix for CVE-2024-35195.

As described [here](https://github.com/psf/requests/issues/6707#issuecomment-2122490651), we will be deprecating the existing `get_connection` API, and custom adapters will need to migrate their existing `get_connection` implementations to use `get_connection_with_tls_context`. Below is a very simple implementation that will get projects relying on a custom `get_connection` implementation unblocked.

However, we _strongly_ recommend maintainers evaluate if their custom `get_connection` is subject to the same issues as the CVE above and make appropriate changes as needed.

**Minimum new code to work as a pass-through**
This will be backwards compatible between versions of Requests.
```python
def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
    self.get_connection(request.url, proxies)
```