### PR TITLE
v2.32.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,20 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+2.32.2 (2024-05-21)
+-------------------
+
+**Deprecations**
+- To provide a more stable migration for custom HTTPAdapters impacted
+  by the CVE changes in 2.32.0, we've renamed `_get_connection` to
+  a new public API, `get_connection_with_tls_context`. Existing custom
+  HTTPAdapters will need to migrate their code to use this new API.
+  `get_connection` is considered deprecated in all versions of Requests>=2.32.0.
+
+  A minimal (2-line) example has been provided in the linked PR to ease
+  migration, but we strongly urge users to evaluate if their custom adapter
+  is subject to the same issue described in CVE-2024-35195. (#6710)
+
 2.32.1 (2024-05-20)
 -------------------
 

--- a/src/requests/__version__.py
+++ b/src/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.32.1"
-__build__ = 0x023201
+__version__ = "2.32.2"
+__build__ = 0x023202
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
2.32.2 (2024-05-21)
-------------------

**Deprecations**
- To provide a more stable migration for custom HTTPAdapters impacted
  by the CVE changes in 2.32.0, we've renamed `_get_connection` to
  a new public API, `get_connection_with_tls_context`. Existing custom
  HTTPAdapters will need to migrate their code to use this new API with
  Requests>2.32.0.

  A minimal (2-line) example has been provided in the linked PR to ease
  migration, but we strongly urge users to evaluate if their custom adapter
  is subject to the same issue described in CVE-2024-35195. (#6710)