### PR TITLE
Prefer charset_normalizer for char detection

### DIFF
--- a/src/requests/compat.py
+++ b/src/requests/compat.py
@@ -18,7 +18,7 @@ import sys
 def _resolve_char_detection():
     """Find supported character detection libraries."""
     chardet = None
-    for lib in ("chardet", "charset_normalizer"):
+    for lib in ("charset_normalizer", "chardet"):
         if chardet is None:
             try:
                 chardet = importlib.import_module(lib)


### PR DESCRIPTION
`charset_normalizer` is a dependency for requests, while `chardet` is not, so it is more likely to be found.

For vendored requests this would still load whatever is available.

The reason I noticed this memory profiling in case both libraries are present and `charset_normalizer` has way lower memory footprint than `chardet`.