### PR TITLE
Allow for overriding of specific pool key params

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+2.32.3 (2024-??-??)
+-------------------
+
+**Bugfixes**
+- Fix bug breaking the ability to specify custom SSLContexts in sub-classes of
+  HTTPAdapter. (#6655)
+
 2.32.2 (2024-05-21)
 -------------------
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,12 +6,12 @@ dev
 
 - \[Short description of non-trivial change.\]
 
-2.32.3 (2024-??-??)
+2.32.3 (2024-05-24)
 -------------------
 
 **Bugfixes**
 - Fix bug breaking the ability to specify custom SSLContexts in sub-classes of
-  HTTPAdapter. (#6655)
+  HTTPAdapter. (#6716)
 
 2.32.2 (2024-05-21)
 -------------------

--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -375,23 +375,83 @@ class HTTPAdapter(BaseAdapter):
 
         return response
 
+    def build_connection_pool_key_attributes(self, request, verify, cert=None):
+        """Build the PoolKey attributes used by urllib3 to return a connection.
+
+        This looks at the PreparedRequest, the user-specified verify value,
+        and the value of the cert parameter to determine what PoolKey values
+        to use to select a connection from a given urllib3 Connection Pool.
+
+        The SSL related pool key arguments are not consistently set. As of
+        this writing, use the following to determine what keys may be in that
+        dictionary:
+
+        * If ``verify`` is ``True``, ``"ssl_context"`` will be set and will be the
+          default Requests SSL Context
+        * If ``verify`` is ``False``, ``"ssl_context"`` will not be set but
+          ``"cert_reqs"`` will be set
+        * If ``verify`` is a string, (i.e., it is a user-specified trust bundle)
+          ``"ca_certs"`` will be set if the string is not a directory recognized
+          by :py:func:`os.path.isdir`, otherwise ``"ca_certs_dir"`` will be
+          set.
+        * If ``"cert"`` is specified, ``"cert_file"`` will always be set. If
+          ``"cert"`` is a tuple with a second item, ``"key_file"`` will also
+          be present
+
+        To override these settings, one may subclass this class, call this
+        method and use the above logic to change parameters as desired. For
+        example, if one wishes to use a custom :py:class:`ssl.SSLContext` one
+        must both set ``"ssl_context"`` and based on what else they require,
+        alter the other keys to ensure the desired behaviour.
+
+        :param request:
+            The PreparedReqest being sent over the connection.
+        :type request:
+            :class:`~requests.models.PreparedRequest`
+        :param verify:
+            Either a boolean, in which case it controls whether
+            we verify the server's TLS certificate, or a string, in which case it
+            must be a path to a CA bundle to use.
+        :param cert:
+            (optional) Any user-provided SSL certificate for client
+            authentication (a.k.a., mTLS). This may be a string (i.e., just
+            the path to a file which holds both certificate and key) or a
+            tuple of length 2 with the certificate file path and key file
+            path.
+        :returns:
+            A tuple of two dictionaries. The first is the "host parameters"
+            portion of the Pool Key including scheme, hostname, and port. The
+            second is a dictionary of SSLContext related parameters.
+        """
+        return _urllib3_request_context(request, verify, cert)
+
     def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
         """Returns a urllib3 connection for the given request and TLS settings.
         This should not be called from user code, and is only exposed for use
         when subclassing the :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 
-        :param request: The :class:`PreparedRequest <PreparedRequest>` object
-            to be sent over the connection.
-        :param verify: Either a boolean, in which case it controls whether
-            we verify the server's TLS certificate, or a string, in which case it
-            must be a path to a CA bundle to use.
-        :param proxies: (optional) The proxies dictionary to apply to the request.
-        :param cert: (optional) Any user-provided SSL certificate to be trusted.
-        :rtype: urllib3.ConnectionPool
+        :param request:
+            The :class:`PreparedRequest <PreparedRequest>` object to be sent
+            over the connection.
+        :param verify:
+            Either a boolean, in which case it controls whether we verify the
+            server's TLS certificate, or a string, in which case it must be a
+            path to a CA bundle to use.
+        :param proxies:
+            (optional) The proxies dictionary to apply to the request.
+        :param cert:
+            (optional) Any user-provided SSL certificate to be used for client
+            authentication (a.k.a., mTLS).
+        :rtype:
+            urllib3.ConnectionPool
         """
         proxy = select_proxy(request.url, proxies)
         try:
-            host_params, pool_kwargs = _urllib3_request_context(request, verify, cert)
+            host_params, pool_kwargs = self.build_connection_pool_key_attributes(
+                request,
+                verify,
+                cert,
+            )
         except ValueError as e:
             raise InvalidURL(e, request=request)
         if proxy:


### PR DESCRIPTION
This re-enables the use case of providing a custom SSLContext via a Transport Adapter as broken in #6655 and reported in #6715

Closes #6715