### PR TITLE
Start testing on 3.13 beta

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
         # Python 3.8 and 3.9 do not run on macOS-latest which
         # is now using arm64 hardware.


### PR DESCRIPTION
It looks like we're currently blocked on wheels for a few testing dependencies so this isn't mergable currently but we'll use this PR to monitor upstream support from other projects. Once those blockers are moved, we can merge this into our CI to prepare for the upcoming release candidates.

Currently it looks like `flsgger` and `greenlet` are having issues from httpbin. I think we have an open proposal/request to make `flsgger` optional which seems fine. `greenlet` currently has a proposed patch from Victor Stinner so I would assume that's resolved sooner than later.