### PR TITLE
v2.32.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,12 +6,14 @@ dev
 
 - \[Short description of non-trivial change.\]
 
-2.32.3 (2024-05-24)
+2.32.3 (2024-05-29)
 -------------------
 
 **Bugfixes**
-- Fix bug breaking the ability to specify custom SSLContexts in sub-classes of
+- Fixed bug breaking the ability to specify custom SSLContexts in sub-classes of
   HTTPAdapter. (#6716)
+- Fixed issue where Requests started failing to run on Python versions compiled
+  without the `ssl` module. (#6724)
 
 2.32.2 (2024-05-21)
 -------------------

--- a/src/requests/__version__.py
+++ b/src/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.32.2"
-__build__ = 0x023202
+__version__ = "2.32.3"
+__build__ = 0x023203
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
2.32.3 (2024-05-29)
-------------------

**Bugfixes**
- Fixed bug breaking the ability to specify custom SSLContexts in sub-classes of
  HTTPAdapter. (#6716)
- Fixed issue where Requests started failing to run on Python versions compiled
  without the `ssl` module. (#6724)