### PR TITLE
Address certificate loading regression

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -118,15 +118,23 @@ def _urllib3_request_context(
     poolmanager_kwargs = getattr(poolmanager, "connection_pool_kw", {})
 
     cert_reqs = "CERT_REQUIRED"
+    cert_loc = None
     if verify is False:
         cert_reqs = "CERT_NONE"
     elif _should_use_default_context(verify, client_cert, poolmanager_kwargs):
         pool_kwargs["ssl_context"] = _preloaded_ssl_context
+    elif verify is True:
+        # Set default ca cert location if none provided
+        cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
     elif isinstance(verify, str):
-        if not os.path.isdir(verify):
-            pool_kwargs["ca_certs"] = verify
+        cert_loc = verify
+
+    if cert_loc is not None:
+        if not os.path.isdir(cert_loc):
+            pool_kwargs["ca_certs"] = cert_loc
         else:
-            pool_kwargs["ca_cert_dir"] = verify
+            pool_kwargs["ca_cert_dir"] = cert_loc
+
     pool_kwargs["cert_reqs"] = cert_reqs
     if client_cert is not None:
         if isinstance(client_cert, tuple) and len(client_cert) == 2:

--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -334,10 +334,8 @@ class HTTPAdapter(BaseAdapter):
         if url.lower().startswith("https") and verify:
             conn.cert_reqs = "CERT_REQUIRED"
 
-            # Only load the CA certificates if 'verify' is a string indicating the CA bundle to use.
-            # Otherwise, if verify is a boolean, we don't load anything since
-            # the connection will be using a context with the default certificates already loaded,
-            # and this avoids a call to the slow load_verify_locations()
+            # Only load the CA certificates if `verify` is a
+            # string indicating the CA bundle to use.
             if verify is not True:
                 # `verify` must be a str with a path then
                 cert_loc = verify


### PR DESCRIPTION
## Overview
This PR is intended to address two distinct issues introduced with the default cert optimizations originally introduced in 2.32.0. While we continue to refine the settings considered when opting into our optimized context, we'll no longer use the new default if any custom cert values are supplied. This addresses the concurrency issues raised in #6726.

The second piece of this will be ensuring that when opting out of the default SSLContext, we're still supplying to the default CA Cert bundle correctly. This addresses the problems noticed in https://github.com/psf/requests/pull/6710#issuecomment-2137802782 and #6730.

## Considerations

We're now duplicating a decent chunk of the [logic from cert_verify](https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/src/requests/adapters.py#L324-L357) inside [_urllib3_request_context](https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/src/requests/adapters.py#L115-L128) but without our validation exceptions. That's a potential vector for behavioral shifts in the future. We _could_ consolidate some of this behavior in one place but it's going to require constructing a dict and using `setattr` on our `conn` in `cert_verify` while setting `pool_kwargs` in `_urllib3_request_context`. I started writing that up but it feels clunky. This is probably going to be a tradeoff of risking drift like we have with Session settings and binding the two behaviors together too tightly.

## Testing
I'd like to codify the issues we've encountered through the whole 2.32.x saga in tests to hopefully avoid this in the future. Doing it cleanly without relying on external endpoints is proving to be a bit more involved than I'd like. I think we can harness some of the infrastructure added in #6662, but I haven't had a chance to really dig into that.