### PR TITLE
Update setup.py in order to fix CVE-2023-37920

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ requires = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
     "urllib3>=1.21.1,<3",
-    "certifi>=2017.4.17",
+    "certifi>=2023.07.22",
 ]
 test_requirements = [
     "pytest-httpbin==2.0.0",


### PR DESCRIPTION
CVE-2023-37920 link:
https://nvd.nist.gov/vuln/detail/CVE-2023-37920

Certifi is a curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. Certifi prior to version 2023.07.22 recognizes "e-Tugra" root certificates. e-Tugra's root certificates were subject to an investigation prompted by reporting of security issues in their systems. Certifi 2023.07.22 removes root certificates from "e-Tugra" from the root store.