### PR TITLE
feat:add chunked parameter for request method

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -92,7 +92,7 @@ def _urllib3_request_context(
     verify: "bool | str | None",
     client_cert: "typing.Tuple[str, str] | str | None",
     poolmanager: "PoolManager",
-) -> "(typing.Dict[str, typing.Any], typing.Dict[str, typing.Any])":
+) -> "typing.Tuple[typing.Dict[str, typing.Any], typing.Dict[str, typing.Any]]":
     host_params = {}
     pool_kwargs = {}
     parsed_request_url = urlparse(request.url)
@@ -611,7 +611,14 @@ class HTTPAdapter(BaseAdapter):
         return headers
 
     def send(
-        self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
+        self,
+        request,
+        stream=False,
+        timeout=None,
+        verify=True,
+        cert=None,
+        proxies=None,
+        chunked=None,
     ):
         """Sends PreparedRequest object. Returns Response object.
 
@@ -626,6 +633,10 @@ class HTTPAdapter(BaseAdapter):
             must be a path to a CA bundle to use
         :param cert: (optional) Any user-provided SSL certificate to be trusted.
         :param proxies: (optional) The proxies dictionary to apply to the request.
+        :param chunked: (optional) If True, requests will send the body using 
+            chunked transfer encoding. If False, requests will send the body using 
+            the standard content-length form. Defaults to None which will auto choose.
+        :type chunked: bool, optional
         :rtype: requests.Response
         """
 
@@ -647,7 +658,8 @@ class HTTPAdapter(BaseAdapter):
             proxies=proxies,
         )
 
-        chunked = not (request.body is None or "Content-Length" in request.headers)
+        if chunked is None:
+            chunked = not (request.body is None or "Content-Length" in request.headers)
 
         if isinstance(timeout, tuple):
             try:

--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -41,6 +41,10 @@ def request(method, url, **kwargs):
             to a CA bundle to use. Defaults to ``True``.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
     :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
+    :param chunked: (optional) If True, requests will send the body using 
+        chunked transfer encoding. If False, requests will send the body using 
+        the standard content-length form. Defaults to None which will auto choose.
+    :type chunked: bool, optional
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -515,6 +515,7 @@ class Session(SessionRedirectMixin):
         verify=None,
         cert=None,
         json=None,
+        chunked=None,
     ):
         """Constructs a :class:`Request <Request>`, prepares it and sends it.
         Returns :class:`Response <Response>` object.
@@ -557,6 +558,10 @@ class Session(SessionRedirectMixin):
             may be useful during local development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
+        :param chunked: (optional) If True, requests will send the body using 
+            chunked transfer encoding. If False, requests will send the body using 
+            the standard content-length form. Defaults to None which will auto choose.
+        :type chunked: bool, optional
         :rtype: requests.Response
         """
         # Create the Request.
@@ -584,6 +589,7 @@ class Session(SessionRedirectMixin):
         send_kwargs = {
             "timeout": timeout,
             "allow_redirects": allow_redirects,
+            "chunked": chunked,
         }
         send_kwargs.update(settings)
         resp = self.send(prep, **send_kwargs)


### PR DESCRIPTION
I need `chunked` parameter for uploading big size files, because header `Transfer-Encoding: chunked` is not work.