### PR TITLE
Header-based auth class

### DIFF
--- a/docs/user/authentication.rst
+++ b/docs/user/authentication.rst
@@ -32,6 +32,27 @@ for using it::
 Providing the credentials in a tuple like this is exactly the same as the
 ``HTTPBasicAuth`` example above.
 
+Header Authentication
+--------------------
+
+Some services require authentication data in the header of the request.
+Multiple headers can be added to an authentication object to keep them separate
+from request data::
+
+    >>> from requests.auth import HTTPHeaderAuth
+    >>> auth = HTTPHeaderAuth({'Api-Key': '1234567890ABCDEF'}})
+    >>> response = requests.get('https://httpbin.org/headers', auth=auth)
+    >>> response.json()['headers']['Api-Key']
+    '1234567890abcdef'
+
+Be aware that keys in the authentication object will override headers set by
+the current request or session parameters::
+
+    >>> from requests.auth import HTTPHeaderAuth
+    >>> auth = HTTPHeaderAuth({'Api-Key': '1234567890ABCDEF'}})
+    >>> response = requests.get('https://httpbin.org/headers', headers={'Api-Key': '0000000000'}, auth=auth)
+    >>> response.json()['headers']['Api-Key']
+    '1234567890ABCDEF'
 
 netrc Authentication
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -104,6 +104,17 @@ class HTTPProxyAuth(HTTPBasicAuth):
         return r
 
 
+class HTTPHeaderAuth(AuthBase):
+    """Attaches authentication headers to the given Request object."""
+
+    def __init__(self, headers):
+        self.headers = headers
+
+    def __call__(self, r):
+        r.headers.update(self.headers)
+        return r
+
+
 class HTTPDigestAuth(AuthBase):
     """Attaches HTTP Digest Authentication to the given Request object."""
 


### PR DESCRIPTION
This adds a short and simple header-based auth backend (and tests!). This allows greater flexibility in auth mechanisms out of the box.

For example, I'm working on on an internal library to interface with OGC services and three providers use three different auth mechanisms. Being able to consolidate this via the auth parameter seems like the correct solution.

It's worth noting that because of when this executes, auth objects override the headers provided both by the session and request call. This has been appropriately documented, and I don't believe any other option would be preferable.

Looks like someone proposed this in 2018 (#4823) but was rejected because of a feature freeze at the time.

If this is acceptable, would the team be interested in something similar like HTTPParamAuth that uses a dict of parameters in a similar fashion? Going back to my library example, one provider uses oauth, which requests supports, one uses headers, and one uses a custom api key parameter. Totally willing to add it to this PR if it simplifies approval :)