### PR TITLE
Handle multiple paths/cert files in 'REQUESTS_CA_BUNDLE' environment variable

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -325,6 +325,16 @@ class HTTPAdapter(BaseAdapter):
                 cert_loc = verify
 
                 if not os.path.exists(cert_loc):
+                    # Need to handle if multiple paths/cert files in 'REQUESTS_CA_BUNDLE' environment variable
+                    if ";" in cert_loc:
+                        # get non-empty path strings
+                        paths = [p for p in cert_loc.split(";") if p]
+                        if len(paths) > 1:
+                            raise OSError(
+                                f"Need to specify one global CA certificate file, "
+                                f"invalid paths: {"\n".join(paths)}"
+                            )
+                            
                     raise OSError(
                         f"Could not find a suitable TLS CA certificate bundle, "
                         f"invalid path: {cert_loc}"


### PR DESCRIPTION
An OSError just gets raised saying the cert_loc is an invalid path if you have several CA certificate paths 'REQUESTS_CA_BUNDLE' environment variable separated by the standard ";" delimiter. It should handle this by at the very least by returning an error telling the user to append the certificates to their global trust CA file and just use one certificate instead of saying it is an invalid path, if not support multiple CA certificate files in the environment variable.