### PR TITLE
chore(charset issue): Resolution for issue 6102 

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -202,7 +202,7 @@ class HTTPDigestAuth(AuthBase):
         realm = self.encode_to_bytes(realm)
         password = self.encode_to_bytes(self.password)
 
-        A1 = f"{username}:{realm}:{password}"
+        A1 = b':'.join([username, realm, password])
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)

--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -123,6 +123,18 @@ class HTTPDigestAuth(AuthBase):
             self._thread_local.pos = None
             self._thread_local.num_401_calls = None
 
+    @staticmethod
+    def encode_to_bytes(data, encoding="latin-1"):
+        """
+        This function encodes input data to bytes using the specified
+        encoding (default is Latin-1). It returns the encoded data as bytes.
+        :rtype: bytes
+        """
+        if type(data) == bytes:
+            return data
+        str_data = str(data)
+        return str_data.encode(encoding)
+
     def build_digest_header(self, method, url):
         """
         :rtype: str
@@ -186,7 +198,11 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        username = self.encode_to_bytes(self.username)
+        realm = self.encode_to_bytes(realm)
+        password = self.encode_to_bytes(self.password)
+
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)


### PR DESCRIPTION
Resolution for the issue https://github.com/psf/requests/issues/6102

Now, If a username and password are passed already encoded, they will not be affected by being expected as a string. In this case, the function will encode the string-formatted attributes into bytes using the latin-1 charset by default due to convention.