### PR TITLE
Clarify error description in cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Requests is ready for the demands of building robust and reliable HTTP–speakin
 ## Cloning the repository
 
 When cloning the Requests repository, you may need to add the `-c
-fetch.fsck.badTimezone=ignore` flag to avoid an error about a bad commit (see
+fetch.fsck.badTimezone=ignore` flag to avoid an error about a bad commit timestamp (see
 [this issue](https://github.com/psf/requests/issues/2690) for more background):
 
 ```shell


### PR DESCRIPTION
This clarifies the error description in the 'Cloning the repository' section of the README. The current wording mentions 'an error about a bad commit', which is somewhat vague. I've updated it to 'an error about a bad commit timestamp', which more accurately describes the nature of the error referenced in issue #2690. This small change improves the clarity of the documentation, helping users better understand the potential issue they might encounter when cloning the repository and why they need to use the specified Git flag.