### PR TITLE
remove setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import sys
 from codecs import open
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 8)
@@ -26,30 +25,6 @@ pin to an older version of Requests (<2.32.0).
         )
     )
     sys.exit(1)
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass into py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        try:
-            from multiprocessing import cpu_count
-
-            self.pytest_args = ["-n", str(cpu_count()), "--boxed"]
-        except (ImportError, NotImplementedError):
-            self.pytest_args = ["-n", "1", "--boxed"]
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 # 'setup.py publish' shortcut.
@@ -118,7 +93,6 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries",
     ],
-    cmdclass={"test": PyTest},
     tests_require=test_requirements,
     extras_require={
         "security": [],


### PR DESCRIPTION
`setuptools==72.0.0` just [removed their test command](https://github.com/pypa/setuptools/blob/main/NEWS.rst#deprecations-and-removals) so this import now fails