### PR TITLE
Don't create default SSLContext if CA bundle isn't present

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -81,9 +81,10 @@ try:
     _preloaded_ssl_context.load_verify_locations(
         extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
     )
-except ImportError:
+except (ImportError, FileNotFoundError):
     # Bypass default SSLContext creation when Python
-    # interpreter isn't built with the ssl module.
+    # interpreter isn't built with the ssl module, or
+    # DEFAULT_CA_BUNDLE_PATH isn't present
     _preloaded_ssl_context = None
 
 


### PR DESCRIPTION
Similar to e18879932287c2bf4bcee4ddf6ccb8a69b6fc656 , this also skips creation of the default SSLContext on FileNotFoundError, which is raised if DEFAULT_CA_BUNDLE_PATH does not exist.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2297632