### PR TITLE
[Bugfix] Fix incorrectly overwriting Content-Type header when passing JSON body

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -564,7 +564,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             self.prepare_content_length(body)
 
             # Add content-type if it wasn't explicitly provided.
-            if content_type and ("content-type" not in self.headers):
+            if content_type and ("Content-Type" not in self.headers):
                 self.headers["Content-Type"] = content_type
 
         self.body = body


### PR DESCRIPTION
Checks for when to set the Content-Type header currently are using the wrong casing to check if the value has already been set before
This is causing the header to be overwritten from what it may have already been set as

![image](https://github.com/user-attachments/assets/7de66c24-f6d3-4b8e-9d5d-f85d0c735c7f)
