### PR TITLE
Fix typo in documentation for verify

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -410,7 +410,7 @@ class HTTPAdapter(BaseAdapter):
           ``"cert_reqs"`` will be set
         * If ``verify`` is a string, (i.e., it is a user-specified trust bundle)
           ``"ca_certs"`` will be set if the string is not a directory recognized
-          by :py:func:`os.path.isdir`, otherwise ``"ca_certs_dir"`` will be
+          by :py:func:`os.path.isdir`, otherwise ``"ca_cert_dir"`` will be
           set.
         * If ``"cert"`` is specified, ``"cert_file"`` will always be set. If
           ``"cert"`` is a tuple with a second item, ``"key_file"`` will also


### PR DESCRIPTION
The code for reference: https://github.com/psf/requests/blob/7335bbf480adc8e6aa88feb2022797a549a00aa3/src/requests/adapters.py#L336
