### PR TITLE
Add !r to error messages for improved clarity on file paths

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -327,7 +327,7 @@ class HTTPAdapter(BaseAdapter):
                 if not os.path.exists(cert_loc):
                     raise OSError(
                         f"Could not find a suitable TLS CA certificate bundle, "
-                        f"invalid path: {cert_loc}"
+                        f"invalid path: {cert_loc!r}"
                     )
 
                 if not os.path.isdir(cert_loc):
@@ -349,11 +349,11 @@ class HTTPAdapter(BaseAdapter):
             if conn.cert_file and not os.path.exists(conn.cert_file):
                 raise OSError(
                     f"Could not find the TLS certificate file, "
-                    f"invalid path: {conn.cert_file}"
+                    f"invalid path: {conn.cert_file!r}"
                 )
             if conn.key_file and not os.path.exists(conn.key_file):
                 raise OSError(
-                    f"Could not find the TLS key file, invalid path: {conn.key_file}"
+                    f"Could not find the TLS key file, invalid path: {conn.key_file!r}"
                 )
 
     def build_response(self, req, resp):


### PR DESCRIPTION
If leading and/or trailing spaces are included in the file path, they are clearly shown in the error messages because the file path is shown within quotes. If the file path is not shown within quotes, it may be difficult to identify that leading and/or trailing spaces are the cause of the problem.