### PR TITLE
Add HTTP status group properties for response objects

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -783,28 +783,28 @@ class Response:
 
     @property
     def is_1xx_informational(self):
-        """True if the status code is an informational (1xx)"""
-        return self.get_status_group() == HttpStatus.INFORMATIONAL
+        """True if the status code is an informational (1xx)."""
+        return 100 <= self.status_code < 200
 
     @property
     def is_2xx_successful(self):
-        """True if the status code is a successful (2xx) response."""
-        return self.get_status_group() == HttpStatus.SUCCESSFUL
+        """True if the status code is a successful (2xx)."""
+        return 200 <= self.status_code < 300
 
     @property
     def is_3xx_redirection(self):
         """True if the status code is a redirection (3xx)."""
-        return self.get_status_group() == HttpStatus.REDIRECTION
+        return 300 <= self.status_code < 400
 
     @property
     def is_4xx_client_error(self):
         """True if the status code is a client error (4xx)."""
-        return self.get_status_group() == HttpStatus.CLIENT_ERROR
+        return 400 <= self.status_code < 500
 
     @property
     def is_5xx_server_error(self):
         """True if the status code is a server error (5xx)."""
-        return self.get_status_group() == HttpStatus.SERVER_ERROR
+        return 500 <= self.status_code < 600
 
     @property
     def next(self):
@@ -1047,17 +1047,6 @@ class Response:
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)
-
-    def get_status_group(self) -> HttpStatus:
-        """
-        Determine the HTTP status group (1xx, 2xx, 3xx, 4xx, 5xx) based on the status code.
-
-        This method divides the status code by 100 to extract the group (e.g., 2xx, 3xx, etc.)
-        and returns the corresponding HttpStatus enum.
-
-        :return: The HttpStatus group (Informational, Successful, Redirection, Client Error, or Server Error).
-        """
-        return http_status_map.get(self.status_code // 100)
 
     def close(self):
         """Releases the connection back to the pool. Once this method has been

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -51,7 +51,7 @@ from .exceptions import MissingSchema
 from .exceptions import SSLError as RequestsSSLError
 from .exceptions import StreamConsumedError
 from .hooks import default_hooks
-from .status_codes import codes, http_status_map, HttpStatus
+from .status_codes import codes
 from .structures import CaseInsensitiveDict
 from .utils import (
     check_header_validity,

--- a/src/requests/status_codes.py
+++ b/src/requests/status_codes.py
@@ -19,6 +19,16 @@ the names are allowed. For example, ``codes.ok``, ``codes.OK``, and
 """
 
 from .structures import LookupDict
+from enum import Enum
+
+
+class HttpStatus(Enum):
+    INFORMATIONAL = 1
+    SUCCESSFUL = 2
+    REDIRECTION = 3
+    CLIENT_ERROR = 4
+    SERVER_ERROR = 5
+
 
 _codes = {
     # Informational.
@@ -101,6 +111,15 @@ _codes = {
     509: ("bandwidth_limit_exceeded", "bandwidth"),
     510: ("not_extended",),
     511: ("network_authentication_required", "network_auth", "network_authentication"),
+}
+
+# Precomputed mapping of status code groups to corresponding HttpStatus categories
+http_status_map = {
+    HttpStatus.INFORMATIONAL.value: HttpStatus.INFORMATIONAL,
+    HttpStatus.SUCCESSFUL.value: HttpStatus.SUCCESSFUL,
+    HttpStatus.REDIRECTION.value: HttpStatus.REDIRECTION,
+    HttpStatus.CLIENT_ERROR.value: HttpStatus.CLIENT_ERROR,
+    HttpStatus.SERVER_ERROR.value: HttpStatus.SERVER_ERROR,
 }
 
 codes = LookupDict(name="status_codes")

--- a/src/requests/status_codes.py
+++ b/src/requests/status_codes.py
@@ -19,16 +19,6 @@ the names are allowed. For example, ``codes.ok``, ``codes.OK``, and
 """
 
 from .structures import LookupDict
-from enum import Enum
-
-
-class HttpStatus(Enum):
-    INFORMATIONAL = 1
-    SUCCESSFUL = 2
-    REDIRECTION = 3
-    CLIENT_ERROR = 4
-    SERVER_ERROR = 5
-
 
 _codes = {
     # Informational.
@@ -111,15 +101,6 @@ _codes = {
     509: ("bandwidth_limit_exceeded", "bandwidth"),
     510: ("not_extended",),
     511: ("network_authentication_required", "network_auth", "network_authentication"),
-}
-
-# Precomputed mapping of status code groups to corresponding HttpStatus categories
-http_status_map = {
-    HttpStatus.INFORMATIONAL.value: HttpStatus.INFORMATIONAL,
-    HttpStatus.SUCCESSFUL.value: HttpStatus.SUCCESSFUL,
-    HttpStatus.REDIRECTION.value: HttpStatus.REDIRECTION,
-    HttpStatus.CLIENT_ERROR.value: HttpStatus.CLIENT_ERROR,
-    HttpStatus.SERVER_ERROR.value: HttpStatus.SERVER_ERROR,
 }
 
 codes = LookupDict(name="status_codes")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -306,6 +306,21 @@ class TestRequests:
         assert r.history[0].status_code == 303
         assert r.history[0].is_redirect
 
+    def test_HTTP_2xx_successful(self, httpbin):
+        response = requests.get(httpbin("/status/200"))
+        assert response.status_code == 200
+        assert response.is_2xx_successful
+
+    def test_HTTP_4xx_client_error(self, httpbin):
+        response = requests.get(httpbin("/status/404"))
+        assert response.status_code == 404
+        assert response.is_4xx_client_error
+
+    def test_HTTP_5xx_server_error(self, httpbin):
+        response = requests.get(httpbin("/status/503"))
+        assert response.status_code == 503
+        assert response.is_5xx_server_error
+
     def test_header_and_body_removal_on_redirect(self, httpbin):
         purged_headers = ("Content-Length", "Content-Type")
         ses = requests.Session()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -307,19 +307,19 @@ class TestRequests:
         assert r.history[0].is_redirect
 
     def test_HTTP_2xx_successful(self, httpbin):
-        response = requests.get(httpbin("/status/200"))
-        assert response.status_code == 200
-        assert response.is_2xx_successful
+        r = requests.get(httpbin("/status/200"))
+        assert r.status_code == 200
+        assert r.is_2xx_successful
 
     def test_HTTP_4xx_client_error(self, httpbin):
-        response = requests.get(httpbin("/status/404"))
-        assert response.status_code == 404
-        assert response.is_4xx_client_error
+        r = requests.get(httpbin("/status/404"))
+        assert r.status_code == 404
+        assert r.is_4xx_client_error
 
     def test_HTTP_5xx_server_error(self, httpbin):
-        response = requests.get(httpbin("/status/503"))
-        assert response.status_code == 503
-        assert response.is_5xx_server_error
+        r = requests.get(httpbin("/status/503"))
+        assert r.status_code == 503
+        assert r.is_5xx_server_error
 
     def test_header_and_body_removal_on_redirect(self, httpbin):
         purged_headers = ("Content-Length", "Content-Type")


### PR DESCRIPTION
## PR Description:

This PR adds properties (`is_2xx_successful`, `is_5xx_server_error`, etc.) to the HTTP response class for easy classification of HTTP status codes, improving code readability.

## Justification:
- **Improved readability**: Using direct range comparisons like `100 <= self.status_code < 200` makes the code clear and intuitive.
- **Maintaining performance**: The range comparison is efficient and keeps the performance trade-offs minimal while avoiding unnecessary complexity.
