### PR TITLE
Remove old macOS runners

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,15 +14,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
-        # Python 3.8 and 3.9 do not run on macOS-latest which
-        # is now using arm64 hardware.
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-        - { python-version: "3.8", os: "macos-latest" }
-        - { python-version: "3.9", os: "macos-latest" }
-        include:
-        - { python-version: "3.8", os: "macos-13" }
-        - { python-version: "3.9", os: "macos-13" }
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
Now that the upstream issue in setup-python is  resolved, we can move back to using `macos-latest` for everything.