### PR TITLE
Simplify from_key_val_list doctest to work across all Python 3.8+ versions

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -326,13 +326,13 @@ def from_key_val_list(value):
     ::
 
         >>> from_key_val_list([('key', 'val')])
-        OrderedDict([('key', 'val')])
+        OrderedDict({'key': 'val'})
         >>> from_key_val_list('string')
         Traceback (most recent call last):
         ...
         ValueError: cannot encode objects that are not 2-tuples
         >>> from_key_val_list({'key': 'val'})
-        OrderedDict([('key', 'val')])
+        OrderedDict({'key': 'val'})
 
     :rtype: OrderedDict
     """


### PR DESCRIPTION
Simplifies the doctest for the `from_key_val_list` function to ensure compatibility across all Python 3.8+ versions, particularly addressing the inconsistency in how `OrderedDict` is represented in Python 3.8+ versus earlier versions.

### Representation Differences:
Starting from Python 3.8, the string representation of an OrderedDict has changed slightly.
In earlier versions, OrderedDict objects were represented as:
```python
OrderedDict([('key', 'val')])
```
In Python 3.8 and later, the `OrderedDict` has a more streamlined string representation, shown as:
```python
OrderedDict({'key': 'val'})
```

The Python 3.8 and lower versions are [already considered End of Life by Python](https://devguide.python.org/versions/), so there is no need to build the test around the older representation for OrderedDict.