### PR TITLE
Update docstring for Session.verify to include string support (#6859)

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -420,6 +420,8 @@ class Session(SessionRedirectMixin):
         #: presented by the server, and will ignore hostname mismatches and/or
         #: expired certificates, which will make your application vulnerable to
         #: man-in-the-middle (MitM) attacks.
+        #: If verify is set to a string, it must be the path to a CA bundle file
+        #: that will be used to verify the TLS certificate.
         #: Only set this to `False` for testing.
         self.verify = True
 


### PR DESCRIPTION
This pull request updates the docstring for the `Session.verify` attribute to clarify that it supports a string value for custom CA bundle paths.

Closes #6859.
