### PR TITLE
Adding host details in proxy headers

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -290,6 +290,8 @@ class HTTPAdapter(BaseAdapter):
             )
         else:
             proxy_headers = self.proxy_headers(proxy)
+            if 'host' in proxy_kwargs and proxy_kwargs['host']:
+                proxy_headers['host'] = f"{proxy_kwargs['host']}"
             manager = self.proxy_manager[proxy] = proxy_from_url(
                 proxy,
                 proxy_headers=proxy_headers,
@@ -480,7 +482,9 @@ class HTTPAdapter(BaseAdapter):
                     "Please check proxy URL. It is malformed "
                     "and could be missing the host."
                 )
-            proxy_manager = self.proxy_manager_for(proxy)
+            u = parse_url(request.url)
+            host=u.host
+            proxy_manager = self.proxy_manager_for(proxy, host=host)
             conn = proxy_manager.connection_from_host(
                 **host_params, pool_kwargs=pool_kwargs
             )


### PR DESCRIPTION
**Issue:**
The connect request does not include host details when operating in a proxy environment. This can lead to failures in establishing a proper connection, as the host information is essential for routing the request through the proxy.

**Code Explanation:**
To address this issue, the following approach is used:

Check for Host in Proxy Settings:
If the proxy_kwargs dictionary contains a host key, it indicates that host details are available.

Add Host to Proxy Headers:
These host details are added to the proxy_headers dictionary under the Host key. By doing so, the host information is explicitly included in the proxy headers, ensuring that the connect request incorporates the correct routing details.

Impact:
Including the host details in the proxy_headers ensures that the connect request is properly formed and able to route through the proxy environment without any missing information. This resolves the issue and enhances connectivity reliability