### PR TITLE
Add netrc file search information to authentication documentation

### DIFF
--- a/docs/user/authentication.rst
+++ b/docs/user/authentication.rst
@@ -44,6 +44,16 @@ set with `headers=`.
 If credentials for the hostname are found, the request is sent with HTTP Basic
 Auth.
 
+Requests will search for the netrc file at `~/.netrc`, `~/_netrc`, or at the path
+specified by the `NETRC` environment variable. `~` denotes the user's home
+directory, which is `$HOME` on Unix based systems and `%USERPROFILE%` on Windows.
+
+Usage of netrc file can be disabled by setting `trust_env` to `False` in the
+Requests session::
+
+    >>> s = requests.Session()
+    >>> s.trust_env = False
+    >>> s.get('https://httpbin.org/basic-auth/user/pass')
 
 Digest Authentication
 ---------------------

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -222,6 +222,7 @@ Note: Custom headers are given less precedence than more specific sources of inf
   are specified in ``.netrc``, which in turn will be overridden by the  ``auth=``
   parameter. Requests will search for the netrc file at `~/.netrc`, `~/_netrc`,
   or at the path specified by the `NETRC` environment variable.
+  Check details in :ref:`netrc authentication <authentication>`.
 * Authorization headers will be removed if you get redirected off-host.
 * Proxy-Authorization headers will be overridden by proxy credentials provided in the URL.
 * Content-Length headers will be overridden when we can determine the length of the content.


### PR DESCRIPTION
Added paragraph (copied from `quickstart.rst`) with information where Requests search for `.netrc` file.

It should make it easier to find this information when somebody reads regular documentation (as opposite to quickstart documentation).