### PR TITLE
docs(exceptions): Add ConnectTimeout and ReadTimeout to documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,6 +37,8 @@ Exceptions
 .. autoexception:: requests.ReadTimeout
 .. autoexception:: requests.Timeout
 .. autoexception:: requests.JSONDecodeError
+.. autoexception:: requests.ConnectTimeout
+.. autoexception:: requests.ReadTimeout
 
 
 Request Sessions


### PR DESCRIPTION
Comparing `__init__.py` exported exceptions with the documentation revealed that two exceptions were missing from the docs. This commit updates the documentation to include these previously unlisted exceptions, ensuring consistency between the code and the docs.