### PR TITLE
docs(exceptions): Remove unused exception URLRequired from documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,7 +31,6 @@ Exceptions
 .. autoexception:: requests.RequestException
 .. autoexception:: requests.ConnectionError
 .. autoexception:: requests.HTTPError
-.. autoexception:: requests.URLRequired
 .. autoexception:: requests.TooManyRedirects
 .. autoexception:: requests.ConnectTimeout
 .. autoexception:: requests.ReadTimeout


### PR DESCRIPTION
The documentation previously listed `requests.URLRequired` as a valid exception, suggesting it would be raised for invalid URLs. However, this exception has been dead code since commit ab27027 (2012) and is never actually raised.

Instead, invalid URLs raise `MissingSchema`, `InvalidSchema`, or `InvalidURL`, none of which were documented. This commit removes `URLRequired` from the documentation to reflect the actual behavior and prevent confusion.