### PR TITLE
Enhance raise_for_status() to include response content

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -1012,12 +1012,12 @@ class Response:
 
         if 400 <= self.status_code < 500:
             http_error_msg = (
-                f"{self.status_code} Client Error: {reason} for url: {self.url}"
+                f"{self.status_code} Client Error: {reason} for url: {self.url}\nResponse: {self.text}"
             )
 
         elif 500 <= self.status_code < 600:
             http_error_msg = (
-                f"{self.status_code} Server Error: {reason} for url: {self.url}"
+                f"{self.status_code} Server Error: {reason} for url: {self.url}\nResponse: {self.text}"
             )
 
         if http_error_msg:


### PR DESCRIPTION
#  Improve raise_for_status() to Include Response Content

## Description:
Currently, the `raise_for_status()` method in `requests.models.Response` raises an `HTTPError` but does not include the response content in the exception message. This can make debugging difficult, especially when APIs return meaningful error messages in the response body.

## Proposed Change  
Modify `raise_for_status()` to append a snippet of the response content (if available) to the exception message. Example:  

## Why This Matters:

- Helps developers quickly understand API errors without manually inspecting the response body.

- Aligns with common practices in other HTTP client libraries.


## Example Use Case
_**Before :**_ 
requests.exceptions.HTTPError: 403 Client Error: Bad Request for url: https://api.example.com

_**After :**_
requests.exceptions.HTTPError: 403 Client Error: Bad Request for url: https://api.example.com
Response: {"error": "Invalid token"}


