### PR TITLE
Fix SSL verification error

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -277,27 +277,30 @@ class HTTPAdapter(BaseAdapter):
         """
         if proxy in self.proxy_manager:
             manager = self.proxy_manager[proxy]
-        elif proxy.lower().startswith("socks"):
-            username, password = get_auth_from_url(proxy)
-            manager = self.proxy_manager[proxy] = SOCKSProxyManager(
-                proxy,
-                username=username,
-                password=password,
-                num_pools=self._pool_connections,
-                maxsize=self._pool_maxsize,
-                block=self._pool_block,
-                **proxy_kwargs,
-            )
         else:
-            proxy_headers = self.proxy_headers(proxy)
-            manager = self.proxy_manager[proxy] = proxy_from_url(
-                proxy,
-                proxy_headers=proxy_headers,
-                num_pools=self._pool_connections,
-                maxsize=self._pool_maxsize,
-                block=self._pool_block,
-                **proxy_kwargs,
-            )
+            if proxy.lower().startswith("socks"):
+                username, password = get_auth_from_url(proxy)
+                manager = self.proxy_manager[proxy] = SOCKSProxyManager(
+                    proxy,
+                    username=username,
+                    password=password,
+                    num_pools=self._pool_connections,
+                    maxsize=self._pool_maxsize,
+                    block=self._pool_block,
+                    **proxy_kwargs,
+                )
+            else:
+                proxy_headers = self.proxy_headers(proxy)
+                manager = self.proxy_manager[proxy] = proxy_from_url(
+                    proxy,
+                    proxy_headers=proxy_headers,
+                    num_pools=self._pool_connections,
+                    maxsize=self._pool_maxsize,
+                    block=self._pool_block,
+                    **proxy_kwargs,
+                )
+            # Copy `connection_pool_kw` from the current poolmanager
+            manager.connection_pool_kw = self.poolmanager.connection_pool_kw
 
         return manager
 


### PR DESCRIPTION
This a dedicated PR to fix [#6900](https://github.com/psf/requests/issues/6900).

As I said in the issue, this looks like a bug of `requests_toolbelt` but turns out that it belongs to the `requests` itself.
Basically, what `HostHeaderSSLAdapter` does is quite simple:
```python
    def send(self, request, **kwargs):
        # HTTP headers are case-insensitive (RFC 7230)
        host_header = None
        for header in request.headers:
            if header.lower() == "host":
                host_header = request.headers[header]
                break

        connection_pool_kwargs = self.poolmanager.connection_pool_kw

        if host_header:
            connection_pool_kwargs["assert_hostname"] = host_header
        elif "assert_hostname" in connection_pool_kwargs:
            # an assert_hostname from a previous request may have been left
            connection_pool_kwargs.pop("assert_hostname", None)

        return super(HostHeaderSSLAdapter, self).send(request, **kwargs)
```
As you can see, it simply set `assert_hostname` to the custom SNI for the `urllib3.poolmanager.connection_pool_kw`.

When the proxy is set, the function `adapters.py!proxy_manager_for()` forgets to copy the `connection_pool_kwargs` property from the current `poolmanager`, which will cause the SSL verification exception when the user is doing the request with the custom SNI and self-signed certificate.