### PR TITLE
Wrapped _preloaded_ssl_context with function to speed up package import

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -74,17 +74,28 @@ DEFAULT_RETRIES = 0
 DEFAULT_POOL_TIMEOUT = None
 
 
-try:
-    import ssl  # noqa: F401
+def _default_ssl_context():
+    """
+    Initializes and returns default SSL context.
+    Performed the first time it is actually needed to speed up "import requests" time.
+    """
+    if '_preloaded_ssl_context' in globals():
+        return globals()['_preloaded_ssl_context']
 
-    _preloaded_ssl_context = create_urllib3_context()
-    _preloaded_ssl_context.load_verify_locations(
-        extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
-    )
-except ImportError:
-    # Bypass default SSLContext creation when Python
-    # interpreter isn't built with the ssl module.
-    _preloaded_ssl_context = None
+    global _preloaded_ssl_context
+    try:
+        import ssl  # noqa: F401
+
+        _preloaded_ssl_context = create_urllib3_context()
+        _preloaded_ssl_context.load_verify_locations(
+            extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
+        )
+    except ImportError:
+        # Bypass default SSLContext creation when Python
+        # interpreter isn't built with the ssl module.
+        _preloaded_ssl_context = None
+
+    return _preloaded_ssl_context
 
 
 def _urllib3_request_context(
@@ -104,14 +115,14 @@ def _urllib3_request_context(
     poolmanager_kwargs = getattr(poolmanager, "connection_pool_kw", {})
     has_poolmanager_ssl_context = poolmanager_kwargs.get("ssl_context")
     should_use_default_ssl_context = (
-        _preloaded_ssl_context is not None and not has_poolmanager_ssl_context
+        _default_ssl_context() is not None and not has_poolmanager_ssl_context
     )
 
     cert_reqs = "CERT_REQUIRED"
     if verify is False:
         cert_reqs = "CERT_NONE"
     elif verify is True and should_use_default_ssl_context:
-        pool_kwargs["ssl_context"] = _preloaded_ssl_context
+        pool_kwargs["ssl_context"] = _default_ssl_context()
     elif isinstance(verify, str):
         if not os.path.isdir(verify):
             pool_kwargs["ca_certs"] = verify


### PR DESCRIPTION
Wrapped around default SSL context initialization to potentially speed up "import requests" time.

Measurements:

# original
$ time python -c "import requests"
real    0m0.936s
user    0m0.000s
sys     0m0.047s

# modified:
$ time python -c "import requests"
real    0m0.351s
user    0m0.000s
sys     0m0.047s
