### PR TITLE
Minor quirk: more straightforward __iter__ impl. for CaseInsensitiveDict

### DIFF
--- a/src/requests/structures.py
+++ b/src/requests/structures.py
@@ -55,7 +55,7 @@ class CaseInsensitiveDict(MutableMapping):
         del self._store[key.lower()]
 
     def __iter__(self):
-        return (casedkey for casedkey, mappedvalue in self._store.values())
+        return (casedkey for casedkey in self._store)
 
     def __len__(self):
         return len(self._store)


### PR DESCRIPTION
With the actual `CaseInsensitiveDict.__iter__` method, both the key and value are extracted but only the key is used. With this minor change, we would loop directly over the internal dict's keys (which is the default for the dict's `__iter__`). The difference is minimal, just 4 less bytecode instructions: [https://godbolt.org/z/saT7Me3vb](https://godbolt.org/z/saT7Me3vb) (uncomment either `__iter__` implementation).