### PR TITLE
Use a more intuitive PySocks version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ test_requirements = [
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
-    "PySocks>=1.5.6, !=1.5.7",
+    "PySocks>=1.6.0",
     "pytest>=3",
 ]
 
@@ -97,7 +97,7 @@ setup(
     tests_require=test_requirements,
     extras_require={
         "security": [],
-        "socks": ["PySocks>=1.5.6, !=1.5.7"],
+        "socks": ["PySocks>=1.6.0"],
         "use_chardet_on_py3": ["chardet>=3.0.2,<6"],
     },
     project_urls={


### PR DESCRIPTION
I accidentally found this in the pip log: `Collecting PySocks!=1.5.7,>=1.5.6 (from requests[socks]`

This seems odd; I'm not sure if it's worth changing to a more intuitive version **at the cost of removing 1.5.6 from compatible version list**.

`!=1.5.7` was introduced in https://github.com/psf/requests/pull/3552
pysocks release history: https://pypi.org/project/PySocks/#history