### PR TITLE
Fix incorrect Content-Length for StringIO with multi-byte characters

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -195,6 +195,18 @@ def super_len(o):
                     # seek back to current position to support
                     # partially read file-like objects
                     o.seek(current_position or 0)
+
+                    # Handle StringIO with multi-byte characters by correctly measuring UTF-8 byte length
+                    if isinstance(o, io.StringIO):
+                        # Save current position
+                        current_pos = o.tell()
+                        # Get entire content and calculate byte length after UTF-8 encoding
+                        o.seek(0)
+                        content = o.read()
+                        # Restore original position
+                        o.seek(current_pos)
+                        # Set total_length to the byte length, not character count
+                        total_length = len(content.encode("utf-8"))
                 except OSError:
                     total_length = 0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import copy
 import filecmp
+import io
 import os
 import tarfile
 import zipfile
@@ -150,6 +151,13 @@ class TestSuperLen:
     def test_super_len_with_no_matches(self):
         """Ensure that objects without any length methods default to 0"""
         assert super_len(object()) == 0
+
+    def test_super_len_with_stringio_containing_multibyte_chars(self):
+        """Ensure StringIO with multi-byte characters reports correct byte length"""
+        # emoji takes 4 bytes in UTF-8 but is 1 character
+        s = io.StringIO("💩")
+        # Super len should return 4 (byte length) not 1 (character length)
+        assert super_len(s) == 4
 
 
 class TestToKeyValList:


### PR DESCRIPTION
This PR fixes issue #6917 where `io.StringIO` objects containing multi-byte characters report incorrect Content-Length headers.

## The issue
When using `io.StringIO` objects with multi-byte characters (like emoji), the Content-Length header is incorrectly set to the character count instead of the byte count. This happens because `StringIO.tell()` reports character positions, not byte positions.

For example, the emoji "💩" is 1 character but 4 bytes in UTF-8. With the current implementation, the Content-Length header incorrectly shows 1 instead of 4.

## The fix
The solution ensures that `io.StringIO` objects correctly report their UTF-8 encoded byte length by:
1. Detecting when the object is an `io.StringIO` instance
2. Reading the entire content and calculating its UTF-8 encoded length
3. Restoring the original position to maintain the object's state

I've added a test case that reproduces the issue and verifies the fix works with emoji characters.