### PR TITLE
Fix invalid setuptools config in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,8 @@
 [metadata]
-license_file = LICENSE
-provides-extra =
-    socks
-    use_chardet_on_py3
-requires-dist =
+license_files = LICENSE
+
+[options]
+install_requires =
     certifi>=2017.4.17
     charset_normalizer>=2,<4
     idna>=2.5,<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,6 @@
 [metadata]
 license_files = LICENSE
 
-[options]
-install_requires =
-    certifi>=2017.4.17
-    charset_normalizer>=2,<4
-    idna>=2.5,<4
-    urllib3>=1.21.1,<3
-
 [flake8]
 ignore = E203, E501, W503
 per-file-ignores =


### PR DESCRIPTION
In version 78 of setuptools, the invalid configuration in `setup.cfg` will start to fail(there has been a deprecation warning since 3 Mar 2021).

I also noticed that most of the information provided to `setup.cfg` is repeated in `setup.py`, so I removed the duplicated copies.

Alternatively, I can also try to migrate the static configs to `pyproject.toml` if desired.