### PR TITLE
Drop pypy 3.9 and add pypy 3.11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
+        # Pypy-3.11 can't install openssl-sys with rust
+        # which prevents us from testing in GHA.
+        exclude:
+        - { python-version: "pypy-3.11", os: "windows-latest" }
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+**Deprecations**
+- Added support for pypy 3.11 for Linux and macOS.
+- Dropped support for pypy 3.9 following its end of support.
+
+
 2.32.3 (2024-05-29)
 -------------------
 


### PR DESCRIPTION
This PR drops support for Pypy 3.9 and adds it for Pypy 3.11 on Linux and macOS. The Windows test runner for Pypy 3.11 is failing because it's unable to install Openssl-sys with the rust bindings for Cryptography. It looks like this may have been an oversight according to https://github.com/pyca/cryptography/issues/12592 and will be released in an upcoming release.