### PR TITLE
test: add two more tests exercising the adapter

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1662,10 +1662,10 @@ class TestRequests:
         s.mount(mixed_case_prefix, my_adapter)
 
         assert s.get_adapter(url_matching_prefix_with_different_case) is my_adapter
-    
+
     def test_session_get_adapter_prefix_with_trailing_slash(self):
         # from issue #6935
-        prefix = "https://example.com/" # trailing slash
+        prefix = "https://example.com/"  # trailing slash
         url_matching_prefix = "https://example.com/some/path"
         url_not_matching_prefix = "https://example.com.other.com/some/path"
 
@@ -1677,7 +1677,7 @@ class TestRequests:
         assert s.get_adapter(url_not_matching_prefix) is not adapter
 
     def test_session_get_adapter_prefix_without_trailing_slash(self):
-         # from issue #6935
+        # from issue #6935
         prefix = "https://example.com"  # no trailing slash
         url_matching_prefix = "https://example.com/some/path"
         url_extended_hostname = "https://example.com.other.com/some/path"

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1662,6 +1662,32 @@ class TestRequests:
         s.mount(mixed_case_prefix, my_adapter)
 
         assert s.get_adapter(url_matching_prefix_with_different_case) is my_adapter
+    
+    def test_session_get_adapter_prefix_with_trailing_slash(self):
+        # from issue #6935
+        prefix = "https://example.com/" # trailing slash
+        url_matching_prefix = "https://example.com/some/path"
+        url_not_matching_prefix = "https://example.com.other.com/some/path"
+
+        s = requests.Session()
+        adapter = HTTPAdapter()
+        s.mount(prefix, adapter)
+
+        assert s.get_adapter(url_matching_prefix) is adapter
+        assert s.get_adapter(url_not_matching_prefix) is not adapter
+
+    def test_session_get_adapter_prefix_without_trailing_slash(self):
+         # from issue #6935
+        prefix = "https://example.com"  # no trailing slash
+        url_matching_prefix = "https://example.com/some/path"
+        url_extended_hostname = "https://example.com.other.com/some/path"
+
+        s = requests.Session()
+        adapter = HTTPAdapter()
+        s.mount(prefix, adapter)
+
+        assert s.get_adapter(url_matching_prefix) is adapter
+        assert s.get_adapter(url_extended_hostname) is adapter
 
     def test_header_remove_is_case_insensitive(self, httpbin):
         # From issue #1321


### PR DESCRIPTION
This PR adds two test cases for `Session.mount()` to cover the documentation's recommendation about trailing slashes in prefixes (see #6935). 

The first test `test_session_get_adapter_prefix_with_trailing_slash` verifies that prefixes with a trailing / (e.g., https://example.com/) match only the intended hostname. 

The second test `test_session_get_adapter_prefix_without_trailing_slash` verifies that prefixes without a trailing / (e.g., https://example.com) match both the intended hostname and extended hostnames (e.g., https://example.com.other.com), as warned in the docs. 

Together, these tests ensure the longest prefix match behavior is well-documented and stable.