### PR TITLE
ci: update to ubuntu-24.04 in workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
### Related issue
https://github.com/actions/runner-images/issues/11101

### What does this PR do?
Update workflow OS versions to ubuntu-24.04, version 20.04 is no longer allowed on GitHub action making ci lint broke e.g.:
https://github.com/psf/requests/actions/runs/14607511655/job/40981665101?pr=6936