### PR TITLE
docs: fix dead links to kenreitz.org

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Requests"
-copyright = u'MMXVIX. A <a href="https://kenreitz.org/projects">Kenneth Reitz</a> Project'
+copyright = u'MMXVIX. A <a href="https://kennethreitz.org/software/">Kenneth Reitz</a> Project'
 author = u"Kenneth Reitz"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Requests"
-copyright = u'MMXVIX. A <a href="https://kennethreitz.org/software/">Kenneth Reitz</a> Project'
+copyright = u'MMXVIX. A Kenneth Reitz Project'
 author = u"Kenneth Reitz"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -22,19 +22,17 @@ The guide is split into sections based on the type of contribution you're
 thinking of making, with a section that covers general guidelines for all
 contributors.
 
-Be Cordial
-----------
+Code of Conduct
+---------------
 
-    **Be cordial or be on your way**. *—Kenneth Reitz*
+The Python community is made up of members from around the globe with a diverse
+set of skills, personalities, and experiences. It is through these differences
+that our community experiences great successes and continued growth. When you're
+working with members of the community, follow the
+`Python Software Foundation Code of Conduct`_ to help steer your interactions
+and keep Python a positive, successful, and growing community.
 
-Requests has one very important rule governing all forms of contribution,
-including reporting bugs or requesting features. This golden rule is
-"`be cordial or be on your way`_".
-
-**All contributions are welcome**, as long as
-everyone involved is treated with respect.
-
-.. _be cordial or be on your way: https://kennethreitz.org/essays/2013/be_cordial_or_be_on_your_way
+.. _Python Software Foundation Code of Conduct: https://policies.python.org/python.org/code-of-conduct/
 
 .. _early-feedback:
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -34,7 +34,7 @@ including reporting bugs or requesting features. This golden rule is
 **All contributions are welcome**, as long as
 everyone involved is treated with respect.
 
-.. _be cordial or be on your way: https://kenreitz.org/essays/2013/01/27/be-cordial-or-be-on-your-way
+.. _be cordial or be on your way: https://kennethreitz.org/essays/2013/be_cordial_or_be_on_your_way
 
 .. _early-feedback:
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -969,11 +969,9 @@ Requests will automatically parse these link headers and make them easily consum
 Transport Adapters
 ------------------
 
-As of v1.0.0, Requests has moved to a modular internal design. Part of the
-reason this was done was to implement Transport Adapters, originally
-`described here`_. Transport Adapters provide a mechanism to define interaction
-methods for an HTTP service. In particular, they allow you to apply per-service
-configuration.
+As of v1.0.0, Requests has moved to a modular internal design using Transport
+Adapters. These objects provide a mechanism to define interaction methods for an
+HTTP service. In particular, they allow you to apply per-service configuration.
 
 Requests ships with a single Transport Adapter, the :class:`HTTPAdapter
 <requests.adapters.HTTPAdapter>`. This adapter provides the default Requests
@@ -1053,7 +1051,6 @@ backoff, within a Requests :class:`Session <requests.Session>` using the
     )
     s.mount('https://', HTTPAdapter(max_retries=retries))
 
-.. _`described here`: https://kennethreitz.org/essays/2012/the_future_of_python_http
 .. _`urllib3`: https://github.com/urllib3/urllib3
 .. _`urllib3.util.Retry`: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1053,7 +1053,7 @@ backoff, within a Requests :class:`Session <requests.Session>` using the
     )
     s.mount('https://', HTTPAdapter(max_retries=retries))
 
-.. _`described here`: https://kenreitz.org/essays/2012/06/14/the-future-of-python-http
+.. _`described here`: https://kennethreitz.org/essays/2012/the_future_of_python_http
 .. _`urllib3`: https://github.com/urllib3/urllib3
 .. _`urllib3.util.Retry`: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry
 


### PR DESCRIPTION
I noticed a few dead links. Looking back through the [wayback machine](https://web.archive.org/web/20220203091232/https://kenreitz.org/essays/2012/06/14/the-future-of-python-http), I was able to find the new location of these articles.