### PR TITLE
fix(headers): content-length shouldnt be set to 0 for all body-less methods

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -578,12 +578,11 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 # to Transfer-Encoding: chunked.
                 self.headers["Content-Length"] = builtin_str(length)
         elif (
-            self.method not in ("CONNECT", "GET", "HEAD", "OPTIONS", "TRACE")
+            self.method in ("DELETE", "PATCH", "POST", "PUT")
             and self.headers.get("Content-Length") is None
         ):
             # Set Content-Length to 0 for methods that can have a body
-            # but don't provide one. (i.e. not CONNECT, GET, HEAD, OPTIONS
-            # or TRACE)
+            # but don't provide one. (i.e. DELETE, PATCH, POST, PUT)
             self.headers["Content-Length"] = "0"
 
     def prepare_auth(self, auth, url=""):

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -578,11 +578,12 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 # to Transfer-Encoding: chunked.
                 self.headers["Content-Length"] = builtin_str(length)
         elif (
-            self.method not in ("GET", "HEAD")
+            self.method not in ("CONNECT", "GET", "HEAD", "OPTIONS", "TRACE")
             and self.headers.get("Content-Length") is None
         ):
             # Set Content-Length to 0 for methods that can have a body
-            # but don't provide one. (i.e. not GET or HEAD)
+            # but don't provide one. (i.e. not CONNECT, GET, HEAD, OPTIONS
+            # or TRACE)
             self.headers["Content-Length"] = "0"
 
     def prepare_auth(self, auth, url=""):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -118,17 +118,17 @@ class TestRequests:
         assert pr.url == req.url
         assert pr.body == "life=42"
 
-    @pytest.mark.parametrize("method", ("GET", "HEAD"))
+    @pytest.mark.parametrize("method", ("CONNECT", "GET", "HEAD", "OPTIONS", "TRACE"))
     def test_no_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert "Content-Length" not in req.headers
 
-    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS"))
+    @pytest.mark.parametrize("method", ("DELETE", "PATCH", "POST", "PUT"))
     def test_no_body_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert req.headers["Content-Length"] == "0"
 
-    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS"))
+    @pytest.mark.parametrize("method", ("DELETE", "PATCH", "POST", "PUT"))
     def test_empty_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower()), data="").prepare()
         assert req.headers["Content-Length"] == "0"


### PR DESCRIPTION
Currently we use `self.method not in ("GET", "HEAD")` to determine "methods that can have a body but don't provide one"

However, there are other [HTTP methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods) that cannot have a body.
Servers can consider it an error if Content-Length=0 when no data is expected. For example, the [Sanic server's position](https://github.com/sanic-org/sanic/issues/2915#issuecomment-2029785788).

MUST have body: PATCH, POST, PUT
MUST NOT have body: GET, HEAD, [TRACE](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.8-4)
SHOULD NOT have body (no official use): [CONNECT](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6-13), [DELETE](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.5-6), [OPTIONS](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7-6)

Proposing that Content-Length be set to 0 when there's no data, only for PATCH, POST, PUT methods since those must have content. DELETE should not have content although it seems most common out of the "SHOULD NOT" category so we can grandfather it in.