### PR TITLE
fix CVE 2024 47081: manual url parsing leads to netloc credentials leak

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -219,14 +219,7 @@ def get_netrc_auth(url, raise_errors=False):
         netrc_path = None
 
         for f in netrc_locations:
-            try:
-                loc = os.path.expanduser(f)
-            except KeyError:
-                # os.path.expanduser can fail when $HOME is undefined and
-                # getpwuid fails. See https://bugs.python.org/issue20164 &
-                # https://github.com/psf/requests/issues/1846
-                return
-
+            loc = os.path.expanduser(f)
             if os.path.exists(loc):
                 netrc_path = loc
                 break

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -236,16 +236,8 @@ def get_netrc_auth(url, raise_errors=False):
             return
 
         ri = urlparse(url)
-
-        # Strip port numbers from netloc. This weird `if...encode`` dance is
-        # used for Python 3.2, which doesn't support unicode literals.
-        splitstr = b":"
-        if isinstance(url, str):
-            splitstr = splitstr.decode("ascii")
-        host = ri.netloc.split(splitstr)[0]
-
         try:
-            _netrc = netrc(netrc_path).authenticators(host)
+            _netrc = netrc(netrc_path).authenticators(ri.hostname)
             if _netrc:
                 # Return with login / password
                 login_i = 0 if _netrc[0] else 1


### PR DESCRIPTION
https://seclists.org/fulldisclosure/2025/Jun/2

Honestly I have no idea why this lib used `netloc` + manual parsing instead of `hostname` as I can see references to `hostname` as early as from [the python 2.6 docs](https://docs.python.org/2.6/library/urlparse.html).