### PR TITLE
Only use hostname to do netrc lookup instead of netloc

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -236,13 +236,7 @@ def get_netrc_auth(url, raise_errors=False):
             return
 
         ri = urlparse(url)
-
-        # Strip port numbers from netloc. This weird `if...encode`` dance is
-        # used for Python 3.2, which doesn't support unicode literals.
-        splitstr = b":"
-        if isinstance(url, str):
-            splitstr = splitstr.decode("ascii")
-        host = ri.netloc.split(splitstr)[0]
+        host = ri.hostname
 
         try:
             _netrc = netrc(netrc_path).authenticators(host)


### PR DESCRIPTION
Applies the patch generated from the GHSA which we couldn't merge as no one on the team had sufficient permissions.