### PR TITLE
Removes simplejson

### DIFF
--- a/src/requests/compat.py
+++ b/src/requests/compat.py
@@ -54,19 +54,7 @@ is_py2 = _ver[0] == 2
 #: Python 3.x?
 is_py3 = _ver[0] == 3
 
-# json/simplejson module import resolution
-has_simplejson = False
-try:
-    import simplejson as json
-
-    has_simplejson = True
-except ImportError:
-    import json
-
-if has_simplejson:
-    from simplejson import JSONDecodeError
-else:
-    from json import JSONDecodeError
+import json
 
 # Keep OrderedDict for backwards compatibility.
 from collections import OrderedDict
@@ -74,6 +62,7 @@ from collections.abc import Callable, Mapping, MutableMapping
 from http import cookiejar as cookielib
 from http.cookies import Morsel
 from io import StringIO
+from json import JSONDecodeError
 
 # --------------
 # Legacy Imports


### PR DESCRIPTION
I don't see a need to keep `simplejson` around, when `json` is builtin to python since 2.6.