### PR TITLE
Add support for Python 3.14 and drop support for Python 3.8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev", "pypy-3.10", "pypy-3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev", "pypy-3.10", "pypy-3.11"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
         # Pypy-3.11 can't install openssl-sys with rust
         # which prevents us from testing in GHA.
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-      - name: 'Set up Python 3.8'
+      - name: 'Set up Python 3.9'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           make
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-      - name: 'Set up Python 3.8'
+      - name: 'Set up Python 3.9'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           make

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14-dev", "pypy-3.10", "pypy-3.11"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
         # Pypy-3.11 can't install openssl-sys with rust
         # which prevents us from testing in GHA.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+**Deprecations**
+- Added support for Python 3.14.
+- Dropped support for Python 3.8 following its end of support.
+
 2.32.4 (2025-06-10)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Requests is available on PyPI:
 $ python -m pip install requests
 ```
 
-Requests officially supports Python 3.8+.
+Requests officially supports Python 3.9+.
 
 ## Supported Features & Best–Practices
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -55,7 +55,8 @@ Chris Adams gave an excellent summary on
 Python 3 Support?
 -----------------
 
-Yes! Requests officially supports Python 3.8+ and PyPy.
+Yes! Requests supports all `officially supported versions of Python <https://devguide.python.org/versions/>`_
+and recent releases of PyPy.
 
 Python 2 Support?
 -----------------
@@ -64,8 +65,8 @@ No! As of Requests 2.28.0, Requests no longer supports Python 2.7. Users who
 have been unable to migrate should pin to `requests<2.28`. Full information
 can be found in `psf/requests#6023 <https://github.com/psf/requests/issues/6023>`_.
 
-It is *highly* recommended users migrate to Python 3.8+ now since Python
-2.7 is no longer receiving bug fixes or security updates as of January 1, 2020.
+It is *highly* recommended users migrate to a supported Python 3.x version now since
+Python 2.7 is no longer receiving bug fixes or security updates as of January 1, 2020.
 
 What are "hostname doesn't match" errors?
 -----------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - ``.netrc`` Support
 
-Requests officially supports Python 3.8+, and runs great on PyPy.
+Requests officially supports Python 3.9+, and runs great on PyPy.
 
 
 The User Guide

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from codecs import open
 from setuptools import setup
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 8)
+REQUIRED_PYTHON = (3, 9)
 
 if CURRENT_PYTHON < REQUIRED_PYTHON:
     sys.stderr.write(
@@ -69,7 +69,7 @@ setup(
     package_data={"": ["LICENSE", "NOTICE"]},
     package_dir={"": "src"},
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requires,
     license=about["__license__"],
     zip_safe=False,
@@ -82,7 +82,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313,314}-{default, use_chardet_on_py3}
+envlist = py{39,310,311,312,313,314}-{default, use_chardet_on_py3}
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313}-{default, use_chardet_on_py3}
+envlist = py{38,39,310,311,312,313,314}-{default, use_chardet_on_py3}
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This PR will start testing Python 3.14 to make sure we're ready for the October release. Assuming tests run, I'll add trove classifiers and change log notes. We'll also drop Python 3.8 support as we're now almost a year past its [official end of support](https://devguide.python.org/versions/).