### PR TITLE
docs: clarify timeout parameter uses seconds in Session.request

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -535,7 +535,7 @@ class Session(SessionRedirectMixin):
             for multipart encoding upload.
         :param auth: (optional) Auth tuple or callable to enable
             Basic/Digest/Custom HTTP Auth.
-        :param timeout: (optional) How long to wait for the server to send
+        :param timeout: (optional) How many seconds to wait for the server to send
             data before giving up, as a float, or a :ref:`(connect timeout,
             read timeout) <timeouts>` tuple.
         :type timeout: float or tuple


### PR DESCRIPTION
- Updated Session.request() docstring to match requests.request()
- Changed 'How long to wait' to 'How many seconds to wait'
- Fixes inconsistency in timeout documentation

Fixes #6813