### PR TITLE
Install tox and flake8 dependency to run make test and make flake8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-httpbin==2.1.0
 httpbin~=0.10.0
 trustme
 wheel
+tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ httpbin~=0.10.0
 trustme
 wheel
 tox
+flake8


### PR DESCRIPTION
I see that setting up this project as per the Makefile needs `tox` to run `make test` and `flake8` to run `make flake8`. I do not see these mentioned anywhere in the project installation steps that people need to install the pip package first before running the commands. This MR adds the `tox` and `flake8` dependency to dev requirements. 