### PR TITLE
Fix-#7003: RequestsCookieJar cannot correctly retrieve zero value

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -408,7 +408,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
                         # we will eventually return this as long as no cookie conflict
                         toReturn = cookie.value
 
-        if toReturn:
+        if toReturn is not None:
             return toReturn
         raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
 


### PR DESCRIPTION
When using RequestsCookieJar to set a cookie with an empty string ('') or 0 as the value, it cannot be retrieved properly afterward.  (Fix #7003)