### PR TITLE
security: update publish workflow to use `artifact-id` instead of `name`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
       name: "publish"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
+      artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -25,6 +26,8 @@ jobs:
 
       - name: "Checkout repository"
         uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
+        with:
+          persist-credentials: false
 
       - name: "Setup Python"
         uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
@@ -46,6 +49,7 @@ jobs:
 
       - name: "Upload dists"
         uses: "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        id: upload-artifact
         with:
           name: "dist"
           path: "dist/"
@@ -80,9 +84,9 @@ jobs:
         egress-policy: audit
 
     - name: "Download dists"
-      uses: "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
+      uses: "actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0" # v5.0.0
       with:
-        name: "dist"
+        artifact-ids: ${{ needs.build.outputs.artifact-id }}
         path: "dist/"
 
     - name: "Publish dists to PyPI"


### PR DESCRIPTION
## Use `artifact-id` instead of `name` with Actions Artifacts 🔒 

This pull updates the **publish** workflow to use `artifact-id` instead of `name` when downloading artifacts that have been previously published in prior workflow steps. This is important because artifacts produced by GitHub Actions can be completely overwritten by other workflow runs if they use the same `name` under very unique circumstances (like passing the `run-id` value to the download-artifact action to point to an entirely different workflow run - don't do that). To avoid potential TOCTOU issues/vulnerabilities where an artifact might be replaced between upload and download, the new `artifact-ids` input allows you to download artifacts by their specific ID rather than by name. This is safer but also helps lead to more deterministic workflow builds by referencing the artifact you wish to download by its _exact id_.

This PR also hardens the workflow a bit by adding `persist-credentials: false` to the checkout step.

---

I recently did some work to land these exact changes in the [urllib3/urllib3](https://github.com/urllib3/urllib3/pulls?q=is%3Apr+is%3Aclosed+author%3AGrantBirki) and wanted to contribute those same changes here as well!