### PR TITLE
Make the SSL version more human-readable

### DIFF
--- a/src/requests/help.py
+++ b/src/requests/help.py
@@ -93,9 +93,10 @@ def info():
         "openssl_version": "",
     }
     if OpenSSL:
+        openssl_version = OpenSSL.SSL.SSLeay_version(OpenSSL.SSL.SSLEAY_VERSION).decode("utf-8")
         pyopenssl_info = {
             "version": OpenSSL.__version__,
-            "openssl_version": f"{OpenSSL.SSL.OPENSSL_VERSION_NUMBER:x}",
+            "openssl_version": f"{openssl_version}",
         }
     cryptography_info = {
         "version": getattr(cryptography, "__version__", ""),
@@ -104,8 +105,8 @@ def info():
         "version": getattr(idna, "__version__", ""),
     }
 
-    system_ssl = ssl.OPENSSL_VERSION_NUMBER
-    system_ssl_info = {"version": f"{system_ssl:x}" if system_ssl is not None else ""}
+    system_ssl = ssl.OPENSSL_VERSION
+    system_ssl_info = {"version": f"{system_ssl}"}
 
     return {
         "platform": platform_info,


### PR DESCRIPTION
When executing `python -m requests.help`, the previous format looked like:
```json
{
  "chardet": {
    "version": null
  },
  "charset_normalizer": {
    "version": "2.0.12"
  },
  "cryptography": {
    "version": "40.0.2"
  },
  "idna": {
    "version": "3.7"
  },
  "implementation": {
    "name": "CPython",
    "version": "3.6.8"
  },
  "platform": {
    "release": "3.10.0-1160.119.1.el7.x86_64",
    "system": "Linux"
  },
  "pyOpenSSL": {
    "openssl_version": "30100000",
    "version": "23.2.0"
  },
  "requests": {
    "version": "2.27.1"
  },
  "system_ssl": {
    "version": "100020bf"
  },
  "urllib3": {
    "version": "1.26.19"
  },
  "using_charset_normalizer": true,
  "using_pyopenssl": true
}
```

The current format looks like:
```json
{
  "chardet": {
    "version": null
  },
  "charset_normalizer": {
    "version": "2.0.12"
  },
  "cryptography": {
    "version": "40.0.2"
  },
  "idna": {
    "version": "3.7"
  },
  "implementation": {
    "name": "CPython",
    "version": "3.6.8"
  },
  "platform": {
    "release": "3.10.0-1160.119.1.el7.x86_64",
    "system": "Linux"
  },
  "pyOpenSSL": {
    "openssl_version": "OpenSSL 3.1.0 14 Mar 2023", 
    "version": "23.2.0"
  },
  "requests": {
    "version": "2.27.1"
  },
  "system_ssl": {
    "version": "OpenSSL 1.0.2k-fips  26 Jan 2017" 
  },
  "urllib3": {
    "version": "1.26.19"
  },
  "using_charset_normalizer": true,
  "using_pyopenssl": true
}

```