### PR TITLE
fix: allow empty string and zero values to be retrieved from RequestsCookieJar

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -408,7 +408,7 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
                         # we will eventually return this as long as no cookie conflict
                         toReturn = cookie.value
 
-        if toReturn:
+        if toReturn is not None:
             return toReturn
         raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,9 @@
+from requests.cookies import RequestsCookieJar
+
+def test_cookiejar_allows_empty_and_zero_values():
+    jar = RequestsCookieJar()
+    jar.set('empty', '', domain='example.com')
+    assert jar.get('empty') == ''
+    jar.set('zero', 0, domain='example.com')
+    # Requests stores values as strings
+    assert jar.get('zero') == '0'


### PR DESCRIPTION
### Summary
Fixes an issue (#7003) where cookies with an empty string ('') or zero (0) value were treated as missing.

### Changes
- Updated _find_no_duplicates to check `is not None` instead of truthiness.
- Added unit test to verify behavior.

Fixes #7003 