### PR TITLE
v2.32.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,16 @@ dev
 
 - \[Short description of non-trivial change.\]
 
+2.32.5 (2025-08-18)
+-------------------
+
+**Bugfixes**
+
+- The SSLContext caching feature originally introduced in 2.32.0 has created
+  a new class of issues in Requests that have had negative impact across a number
+  of use cases. The Requests team has decided to revert this feature as long term
+  maintenance of it is proving to be unsustainable in its current iteration.
+
 **Deprecations**
 - Added support for Python 3.14.
 - Dropped support for Python 3.8 following its end of support.

--- a/src/requests/__version__.py
+++ b/src/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.32.4"
-__build__ = 0x023204
+__version__ = "2.32.5"
+__build__ = 0x023205
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache-2.0"


### PR DESCRIPTION
2.32.5 (2025-08-18)
-------------------

**Bugfixes**

- The SSLContext caching feature originally introduced in 2.32.0 has created
  a new class of issues in Requests that have had negative impact across a number
  of use cases. The Requests team has decided to revert this feature as long term
  maintenance of it is proving to be unsustainable in its current iteration.

**Deprecations**
- Added support for Python 3.14.
- Dropped support for Python 3.8 following its end of support.