### PR TITLE
Use EmailMessage for response headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	python -m pytest tests
 
 ci:
-	python -m pytest tests --junitxml=report.xml
+	python -m pytest tests --junitxml=report.xml --tb=long
 
 test-readme:
 	python setup.py check --restructuredtext --strict && ([ $$? -eq 0 ] && echo "README.rst and HISTORY.rst ok") || echo "Invalid markup in README.rst or HISTORY.rst!"

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -6,6 +6,8 @@ This module contains the primary objects that power Requests.
 """
 
 import datetime
+import email
+import email.policy
 
 # Import encoding now, to avoid implicit import later.
 # Implicit import within threads may cause LookupError when standard library is in a ZIP,
@@ -663,10 +665,10 @@ class Response:
         #: Integer Code of responded HTTP Status, e.g. 404 or 200.
         self.status_code = None
 
-        #: Case-insensitive Dictionary of Response Headers.
+        #: Case-insensitive Dictionary (email.EmailMessage) of Response Headers.
         #: For example, ``headers['content-encoding']`` will return the
         #: value of a ``'Content-Encoding'`` response header.
-        self.headers = CaseInsensitiveDict()
+        self.headers = email.message.EmailMessage(policy=email.policy.HTTP)
 
         #: File-like object representation of response (for advanced usage).
         #: Use of ``raw`` requires that ``stream=True`` be set on the request.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1235,6 +1235,18 @@ class TestRequests:
         )
         assert resp.cookies.get("cookie") == "value"
 
+    def test_multi_cookie(self, httpbin):
+        s = requests.Session()
+        resp = s.request(
+            "GET",
+            httpbin("cookies/set?cookie=value&anothercookie=anothervalue"),
+            allow_redirects=False,
+            headers={"Host": b"httpbin.org"},
+        )
+        assert resp.cookies.get("cookie") == "value"
+        assert resp.cookies.get("anothercookie") == "anothervalue"
+        assert len(resp.headers.get_all("set-cookie")) == 2
+
     def test_links(self):
         r = requests.Response()
         r.headers = {


### PR DESCRIPTION
MockResponse requires EmailMessage for http.CookieJar to be able to
extract cookies from headers but CaseInsensitiveDict is provided.

Use EmailMessage and special-case Set-Cookie per note in
https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2

Fixes: #7014
