### PR TITLE
Update conf.py footer line to reflect correct Roman numeral notation date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"Requests"
-copyright = u'MMXVIX. A Kenneth Reitz Project'
+copyright = u'MMXXIV. A Kenneth Reitz Project'
 author = u"Kenneth Reitz"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This commit updates the 2024 date in Roman numeral notation from the incorrect "MMXVIX" to the correct "MMXXIV".

Specifically MMXVIX is invalid because “VIX” is not an allowed subtractive combination in Roman numerals, moreover the "MXXIV" is the established notation for 1024, which we can use as a starting point for 2024 by prefixing it with just "M", thus obtaining MMXXIV