### PR TITLE
Clarify response comparison in Quickstart documentation (fixes #6949)

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -271,7 +271,13 @@ use the same key::
       },
       ...
     }
+
+    # Note: httpbin.org adds a changing header ("X-Amzn-Trace-Id") to each response,
+    # so r1.text == r2.text may be False even if the form data matches.
+    # Instead, compare the form data in the JSON response:
     >>> r1.text == r2.text
+    False
+    >>> r1.json()['form'] == r2.json()['form']
     True
 
 There are times that you may want to send data that is not form-encoded. If


### PR DESCRIPTION
Updated the Quickstart documentation to clarify that r1.text == r2.text may be False due to changing headers (like X-Amzn-Trace-Id), and recommend comparing r1.json()['form'] == r2.json()['form'] instead.
This resolves confusion for users following the example and aligns the documentation with actual behavior.
Fixes #6949