### PR TITLE
Fix handling of zero and empty cookie values in RequestsCookieJar

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -395,22 +395,22 @@ class RequestsCookieJar(cookielib.CookieJar, MutableMapping):
             that match name and optionally domain and path
         :return: cookie.value
         """
-        toReturn = None
+        foundCookie = None
         for cookie in iter(self):
             if cookie.name == name:
                 if domain is None or cookie.domain == domain:
                     if path is None or cookie.path == path:
-                        if toReturn is not None:
+                        if foundCookie is not None:
                             # if there are multiple cookies that meet passed in criteria
                             raise CookieConflictError(
                                 f"There are multiple cookies with name, {name!r}"
                             )
                         # we will eventually return this as long as no cookie conflict
-                        toReturn = cookie.value
+                        foundCookie = cookie
 
-        if toReturn:
-            return toReturn
-        raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
+        if foundCookie is None:
+            raise KeyError(f"name={name!r}, domain={domain!r}, path={path!r}")
+        return foundCookie.value
 
     def __getstate__(self):
         """Unlike a normal CookieJar, this class is pickleable."""

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,0 +1,62 @@
+from my_requests.cookies import RequestsCookieJar
+
+
+def test_cookie_empty_value_bug():
+    jar = RequestsCookieJar()
+    jar.set('token', 0, domain='example.com', path='/')
+
+    assert list(jar.items()) == [('token', 0)]
+    assert jar.get('token', domain='example.com', path='/') == 0
+
+
+def test_cookie_zero_value_among_others():
+    jar = RequestsCookieJar()
+    jar.set('token', 0, domain='example.com', path='/')
+    jar.set('session', 'abc', domain='example.com', path='/')
+
+    assert jar.get('token', domain='example.com', path='/') == 0
+
+
+def test_cookie_string_zero_value():
+    jar = RequestsCookieJar()
+    jar.set('code', '0', domain='example.com', path='/')
+
+    assert jar.get('code', domain='example.com', path='/') == '0'
+
+
+def test_cookie_empty_string_value():
+    jar = RequestsCookieJar()
+    jar.set('empty', '', domain='example.com', path='/')
+
+    assert jar.get('empty', domain='example.com', path='/') == ''
+
+
+def test_cookie_none_value():
+    jar = RequestsCookieJar()
+    jar.set('missing', None, domain='example.com', path='/')
+
+    assert jar.get('missing', domain='example.com', path='/') is None
+
+
+def test_cookie_zero_value_with_domain_and_path_matching():
+    jar = RequestsCookieJar()
+    jar.set('token', 0, domain='example.com', path='/api')
+
+    assert jar.get('token', domain='example.com', path='/api') == 0
+
+
+def test_cookie_overwrite_zero_value():
+    jar = RequestsCookieJar()
+    jar.set('token', 'old', domain='example.com', path='/')
+    jar.set('token', 0, domain='example.com', path='/')
+
+    assert jar.get('token', domain='example.com', path='/') == 0
+
+
+def test_cookie_zero_value_persists_after_update():
+    jar = RequestsCookieJar()
+    jar.set('token', 0, domain='example.com', path='/')
+
+    jar.update(jar)
+
+    assert jar.get('token', domain='example.com', path='/') == 0


### PR DESCRIPTION
Description:
This PR addresses a bug in the _find_no_duplicates method of RequestsCookieJar where cookies with values of 0 or empty strings ('') were not being returned correctly.

Changes included:
Updated _find_no_duplicates to correctly return cookie values that are 0 or ''.
Added and updated test cases in test_cookie.py to cover:
-Cookies with value 0
-Cookies with empty string value
-Cookies with None value
-Cookies with domain and path matching
-Overwriting cookies with zero values
-Persistence of zero values after update

These changes ensure that the get method and other functions depending on _find_no_duplicates behave correctly for all valid cookie values.

Impact:
Existing code that relies on _find_no_duplicates returning cookie.value is preserved.