### PR TITLE
Fix: Correct Content-Length for StringIO with multi-byte characters

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -142,6 +142,11 @@ def super_len(o):
         # of latin-1 (iso-8859-1) like http.client.
         o = o.encode("utf-8")
 
+    if isinstance(o, io.StringIO):
+        total_length = len(o.getvalue().encode("utf-8"))
+        current_position = len(o.getvalue()[: o.tell()].encode("utf-8"))
+        return max(0, total_length - current_position)
+
     if hasattr(o, "__len__"):
         total_length = len(o)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,6 +142,18 @@ class TestSuperLen:
         foo.read(2)
         assert super_len(foo) == 3
 
+    def test_super_len_stringio_multibyte(self):
+        # UTF-8: "👍" is 4 bytes
+        data = "👍"
+        s = StringIO.StringIO(data)
+        assert super_len(s) == 4
+        
+        # Test partial read
+        data_mixed = "abc👍"
+        s = StringIO.StringIO(data_mixed)
+        s.read(3)
+        assert super_len(s) == 4
+
     def test_super_len_with_fileno(self):
         with open(__file__, "rb") as f:
             length = super_len(f)


### PR DESCRIPTION
## Summary
Fixes a regression where `Content-Length` is incorrectly calculated for `io.StringIO` objects containing multi-byte characters (like emojis).

## The Issue
When `io.StringIO` is passed as `data`, [super_len](cci:1://file:///c:/Users/Harish/OneDrive/Desktop/webdev/sample%20project/requests_repo/src/requests/utils.py:135:0-203:50) uses character count via [__len__](cci:1://file:///c:/Users/Harish/OneDrive/Desktop/webdev/sample%20project/requests_repo/tests/test_utils.py:76:12-77:24) or [tell()](cci:1://file:///c:/Users/Harish/OneDrive/Desktop/webdev/sample%20project/requests_repo/tests/test_utils.py:89:12-90:29) instead of the UTF-8 encoded byte length. This mismatch causes server errors when the encoded body is larger than the reported length.

## The Fix
Updated [super_len](cci:1://file:///c:/Users/Harish/OneDrive/Desktop/webdev/sample%20project/requests_repo/src/requests/utils.py:135:0-203:50) in [utils.py](cci:7://file:///c:/Users/Harish/OneDrive/Desktop/webdev/sample%20project/requests_repo/tests/utils.py:0:0-0:0) to encode `StringIO` content to UTF-8 before calculating length, matching the behavior for standard strings and `urllib3` expectations.