### PR TITLE
docs: clarify gzip decompression behavior when using stream=True

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -321,6 +321,17 @@ Alternatively, you can read the undecoded body from the underlying
 urllib3 :class:`urllib3.HTTPResponse <urllib3.response.HTTPResponse>` at
 :attr:`Response.raw <requests.Response.raw>`.
 
+.. note::
+
+    When using ``stream=True``, Requests does not automatically decompress
+    responses with ``Content-Encoding: gzip`` when accessing
+    :attr:`Response.raw <requests.Response.raw>`. This is intentional.
+
+    If you need decompression while streaming, enable it manually::
+
+        r = requests.get(url, stream=True)
+        r.raw.decode_content = True
+
 If you set ``stream`` to ``True`` when making a request, Requests cannot
 release the connection back to the pool unless you consume all the data or call
 :meth:`Response.close <requests.Response.close>`. This can lead to


### PR DESCRIPTION
When using stream=True, Requests does not automatically decompress gzip-encoded
responses when accessing Response.raw. This behavior is intentional but not
clearly documented and has caused repeated confusion.

This PR adds a note in the advanced documentation explaining the behavior and
shows how to enable decompression manually:

    r.raw.decode_content = True

This documents the intended behavior discussed in #2155 and related issues.
