### PR TITLE
Remove quotes on qop and algorithm values for Digest auth

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -225,11 +225,11 @@ class HTTPDigestAuth(AuthBase):
         if opaque:
             base += f', opaque="{opaque}"'
         if algorithm:
-            base += f', algorithm="{algorithm}"'
+            base += f', algorithm={algorithm}'
         if entdig:
             base += f', digest="{entdig}"'
         if qop:
-            base += f', qop="auth", nc={ncvalue}, cnonce="{cnonce}"'
+            base += f', qop=auth, nc={ncvalue}, cnonce="{cnonce}"'
 
         return f"Digest {base}"
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -797,13 +797,19 @@ class TestRequests:
             r = s.get(url)
             assert r.status_code == 401
 
-    def test_DIGESTAUTH_QUOTES_QOP_VALUE(self, httpbin):
+    def test_DIGESTAUTH_NO_QUOTES_QOP_ALGORITHM_NC_VALUES(self, httpbin):
+        """RFC7616 states the following for the Authentication header:
+        "For historical reasons, a sender MUST NOT generate the quoted string
+        syntax for the following parameters: algorithm, qop, and nc."
+        """
         for authtype in self.digest_auth_algo:
             auth = HTTPDigestAuth("user", "pass")
             url = httpbin("digest-auth", "auth", "user", "pass", authtype)
 
             r = requests.get(url, auth=auth)
-            assert '"auth"' in r.request.headers["Authorization"]
+            assert ' qop=auth,' in r.request.headers["Authorization"]
+            assert f' algorithm={authtype},' in r.request.headers["Authorization"]
+            assert re.search(r' nc=[0-9]+,', r.request.headers["Authorization"])
 
     def test_POSTBIN_GET_POST_FILES(self, httpbin):
         url = httpbin("post")


### PR DESCRIPTION
This fixes https://github.com/psf/requests/issues/5745

## Motivation
The [RFC7616](https://datatracker.ietf.org/doc/html/rfc7616) states the following for the Authorization header:
"For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc."

The examples provided in the RFC also show that those parameters are unquoted.

## Project history
I also found PR #1765 that intentionally quoted the `qop` parameter but I believe the RFC was misinterpreted:
[RFC2617](https://datatracker.ietf.org/doc/html/rfc2617) defines the grammar for the Authorization header in chapter 3.2.2 as `message-qop      = "qop" "=" qop-value` and the `qop-value` is defined in chapter 3.2.1 as `qop-value         = "auth" | "auth-int" | token`.
Quotes in the grammar are used to indicate a raw string and should not be part of the final message.

The quoted part of the RFC in the linked PR is an extract from chapter 3.2.1 for the definition of `qop-options` which only affect the `WWW-Authenticate` header sent by the server, not the client-sent response in the `Authorization` header.