### PR TITLE
Update floors for certifi and urllib3 to something more reasonable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ requires-python = ">=3.10"
 dependencies = [
     "charset_normalizer>=2,<4",
     "idna>=2.5,<4",
-    "urllib3>=1.21.1,<3",
-    "certifi>=2017.4.17"
+    "urllib3>=1.26,<3",
+    "certifi>=2023.5.7"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
We have left the floors for both certifi and urllib3 low for several years to facilitate installations on older versions of Linux distros where the issues have been patched in an effort to allow maximum compatibility. After reviewing the current floors, we've decided to bring them into a more reasonable range.

urllib3 1.26.0 was released on November 10th, 2020. The 1.26.x branch of urllib3 _is no longer supported by the urllib3 team_. We'd strongly recommend users move to urllib3 2.x if they have not already. We will be dropping support for 1.26.x releases in a future release.

certifi 2023.5.7 was released May 7th, 2023. We've chosen this release as the earliest release for today - 3 years. We'd again strongly recommend users remain up to date with their version of certifi as this controls the default certificate bundle used with Requests.