### PR TITLE
Fix PreparedRequest.copy() sharing hooks reference with original

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -388,7 +388,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         p.headers = self.headers.copy() if self.headers is not None else None
         p._cookies = _copy_cookie_jar(self._cookies)
         p.body = self.body
-        p.hooks = self.hooks
+        p.hooks = {event: list(callbacks) for event, callbacks in self.hooks.items()}
         p._body_position = self._body_position
         return p
 


### PR DESCRIPTION
`PreparedRequest.copy()` currently assigns `p.hooks = self.hooks` which means the copy shares the same hooks dictionary and callback lists with the original request. Modifying hooks on the copy (e.g., registering a new response hook) will unintentionally affect the original as well.

This is inconsistent with how the method handles other mutable attributes — `headers` and `_cookies` are both properly copied via `.copy()` and `_copy_cookie_jar()`, respectively.

```python
import requests

req = requests.Request("GET", "https://example.com").prepare()
copy = req.copy()

copy.hooks["response"].append(lambda r, **kw: print("hook fired"))
print(req.hooks["response"])  # ['<lambda>'] — original was modified
```

The fix creates a new dict with shallow-copied callback lists so that adding or removing hooks on a copy does not affect the original.
