### PR TITLE
docs: warn about using Session across forked processes

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -72,6 +72,18 @@ Sessions can also be used as context managers::
 This will make sure the session is closed as soon as the ``with`` block is
 exited, even if unhandled exceptions occurred.
 
+.. warning:: Using Sessions with ``fork()`` / multiprocessing
+
+    If you create a :class:`~requests.Session` in a parent process and then
+    ``fork()`` (for example via the :mod:`multiprocessing` module, Celery, or a
+    pre-fork server model), the underlying connection pool may be shared across
+    processes. This can lead to surprising or unsafe behavior.
+
+    If you use Requests in a multi-process environment, prefer creating a
+    separate :class:`~requests.Session` per process *after* the fork, or avoid
+    sharing Session objects between processes.
+
+
 
 .. admonition:: Remove a Value From a Dict Parameter
 


### PR DESCRIPTION
Context: psf/requests#4323 notes that creating a Session before forking can lead to unsafe behavior because connection pools may be shared between processes.

This PR adds a short warning to the "Session Objects" section of the advanced usage docs to help users avoid this pitfall.

What changed
- Add a warning admonition about fork()/multiprocessing and Session connection pools

How to verify
- Docs build should succeed (RST-only change)

Risk
- Low; documentation-only change.