### PR TITLE
Don't hide navigation on mobile webpage

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -7,7 +7,6 @@ div.document {width: 1008px;}
 div.highlight pre {padding: 11px 14px;}
 
 @media screen and (max-width: 1008px) {
-  div.sphinxsidebar {display: none;}
   div.document {width: 100%!important;}
   div.highlight pre {margin-right: -30px;}
 }


### PR DESCRIPTION
This PR should address #7359. Navigation was completely disabled on mobile. This readds the default alabaster theme nav to the bottom of the page. It gets a bit out of control as you move deeper into the site tree, but it's probably better than no navigation.