### PR TITLE
docs: clarify file-like object comment

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -496,7 +496,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
     def prepare_body(self, data, files, json=None):
         """Prepares the given HTTP body data."""
 
-        # Check if file, fo, generator, iterator.
+        # Check if data is a file, file-like object, generator, or iterator.
         # If not, run through normal process.
 
         # Nottin' on you.


### PR DESCRIPTION
## Summary
- Replace the ambiguous `fo` shorthand with `file-like object` in the body preparation comment.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.
