### PR TITLE
docs: fix JSONDecodeError comment grammar

### DIFF
--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -35,7 +35,7 @@ class JSONDecodeError(InvalidJSONError, CompatJSONDecodeError):
     def __init__(self, *args, **kwargs):
         """
         Construct the JSONDecodeError instance first with all
-        args. Then use it's args to construct the IOError so that
+        args. Then use its args to construct the IOError so that
         the json specific args aren't used as IOError specific args
         and the error message from JSONDecodeError is preserved.
         """


### PR DESCRIPTION
## Summary
- Change `it's args` to `its args` in the `JSONDecodeError` comment.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.
