### PR TITLE
docs: fix FAQ contraction

### DIFF
--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -9,7 +9,7 @@ Encoded Data?
 -------------
 
 Requests automatically decompresses gzip-encoded responses, and does
-its best to decode response content to unicode when possible.
+it's best to decode response content to unicode when possible.
 
 When either the `brotli <https://pypi.org/project/Brotli/>`_ or `brotlicffi <https://pypi.org/project/brotlicffi/>`_
 package is installed, requests also decodes Brotli-encoded responses.


### PR DESCRIPTION
## Summary
- Fix the contraction in the FAQ guidance about decoding response content.

## Related issue
- N/A

## Guideline alignment
- Kept this to one focused docs-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this docs-only change.
