### PR TITLE
Move pytest pin to support 9.x series

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .[socks]
-pytest>=2.8.0,<9
+pytest>=2.8.0,<10
 pytest-cov
 pytest-httpbin==2.1.0
 httpbin~=0.10.0


### PR DESCRIPTION
This PR allows us to pull in the latest major version of pytest along with any fixes. Dependabot for some reason was unable to move the pin.