### PR TITLE
Clarify decode_unicode behaviour in iter_{content,lines} docstrings

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -811,8 +811,10 @@ class Response:
         chunks are received. If stream=False, data is returned as
         a single chunk.
 
-        If decode_unicode is True, content will be decoded using the best
-        available encoding based on the response.
+        If decode_unicode is True, content will be decoded using encoding
+        information from the response. If no encoding information is available,
+        bytes will be returned. This can be bypassed by manually setting
+        `encoding` on the response.
         """
 
         def generate():
@@ -862,6 +864,9 @@ class Response:
         """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the
         content at once into memory for large responses.
+
+        The decode_unicode param works the same as in `iter_content`, with the
+        same caveats.
 
         .. note:: This method is not reentrant safe.
         """


### PR DESCRIPTION
This corner case around automatic encoding detection is already mentioned in the "Advanced Usage" documentation, but deserves to be in the docstring too.

---

This is the documentation-only version of #7349, as requested.