### PR TITLE
fix: handle non-ASCII (Unicode) credentials in HTTPDigestAuth

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -186,7 +186,16 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        # Normalize username/password: decode bytes to str so non-ASCII
+        # credentials are handled correctly in both the hash and the header.
+        username = self.username
+        password = self.password
+        if isinstance(username, bytes):
+            username = username.decode("utf-8")
+        if isinstance(password, bytes):
+            password = password.decode("utf-8")
+
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -218,8 +227,18 @@ class HTTPDigestAuth(AuthBase):
         self._thread_local.last_nonce = nonce
 
         # XXX should the partial digests be encoded too?
+        # Build username header field: use RFC 7616 / RFC 5987 encoding for
+        # non-ASCII usernames so that the header stays valid HTTP.
+        try:
+            username.encode("ascii")
+            username_field = f'username="{username}"'
+        except UnicodeEncodeError:
+            from urllib.parse import quote as urlquote
+
+            username_field = f"username*=UTF-8''{urlquote(username, safe='')}"
+
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'{username_field}, realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
## Problem

`HTTPDigestAuth` mishandles non-ASCII usernames and passwords in two ways:

**1. Unicode str → invalid HTTP header**
```python
HTTPDigestAuth('Ondřej', 'heslíčko')
# produces: Digest username="Ondřej", ...
# → non-ASCII bytes in a header field; invalid per HTTP spec
```

**2. Pre-encoded bytes → bytes repr in header**
The previously suggested workaround of passing pre-encoded bytes produces:
```python
HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko')
# produces: Digest username="b'Ond\xc5\x99ej'", ...
# → Python bytes repr embedded in header; completely wrong
```

Closes #6102

## Solution

Two targeted changes to `build_digest_header`:

### 1. Normalize bytes → str early
```python
if isinstance(username, bytes):
    username = username.decode("utf-8")
if isinstance(password, bytes):
    password = password.decode("utf-8")
```
This ensures both the hash computation and header construction always work with `str`.

### 2. RFC 5987 encoding for non-ASCII usernames
Per [RFC 7616 §3.4](https://datatracker.ietf.org/doc/html/rfc7616#section-3.4), when a username cannot be represented as a quoted ASCII string, the `username*` parameter with RFC 5987 encoding must be used:

```python
try:
    username.encode("ascii")
    username_field = f'username="{username}"'
except UnicodeEncodeError:
    username_field = f"username*=UTF-8''{urlquote(username, safe='')}"
```

ASCII usernames produce the same output as before. Non-ASCII usernames produce:
```
Digest username*=UTF-8''Ond%C5%99ej, realm="...", ...
```

The hash computation (`A1 = username:realm:password`) already uses UTF-8 encoding via `hash_utf8`, which is correct per RFC 7616 §6.1.