### PR TITLE
fix: reject None values in auth tuple

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -45,6 +45,7 @@ from .exceptions import (
     ConnectionError,
     ContentDecodingError,
     HTTPError,
+    InvalidHeader,
     InvalidJSONError,
     InvalidURL,
     MissingSchema,
@@ -598,6 +599,12 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         if auth:
             if isinstance(auth, tuple) and len(auth) == 2:
                 # special-case basic HTTP auth
+                if auth[0] is None or auth[1] is None:
+                    raise InvalidHeader(
+                        f"Invalid auth tuple: "
+                        f"username and password must be strings, got "
+                        f"{type(auth[0]).__name__} and {type(auth[1]).__name__}"
+                    )
                 auth = HTTPBasicAuth(*auth)
 
             # Allow auth to make its changes.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -557,7 +557,6 @@ class TestRequests:
             ("user", "pass"),
             ("имя".encode(), "пароль".encode()),
             (42, 42),
-            (None, None),
         ),
     )
     def test_set_basicauth(self, httpbin, username, password):
@@ -568,6 +567,21 @@ class TestRequests:
         p = r.prepare()
 
         assert p.headers["Authorization"] == _basic_auth_str(username, password)
+
+    @pytest.mark.parametrize(
+        "username, password",
+        (
+            (None, None),
+            ("user", None),
+            (None, "pass"),
+        ),
+    )
+    def test_set_basicauth_none_rejected(self, username, password):
+        """Auth tuples with None values should raise InvalidHeader."""
+        auth = (username, password)
+        r = requests.Request("GET", "http://localhost", auth=auth)
+        with pytest.raises(InvalidHeader):
+            r.prepare()
 
     def test_basicauth_encodes_byte_strings(self):
         """Ensure b'test' formats as the byte string "test" rather


### PR DESCRIPTION
When `auth` is a 2-tuple containing `None` values, `prepare_auth` passes it to `HTTPBasicAuth` because `(None, None)` is truthy. This sends `"None:None"` as Basic Auth credentials instead of being rejected.

```python
from requests.models import PreparedRequest
pr = PreparedRequest()
pr.prepare(method="GET", url="http://example.com/", auth=(None, None))
# Sends: Authorization: Basic Tm9uZTpOb25l (decodes to "None:None")
```

Raised `InvalidHeader` when either username or password is `None`, so the error is caught at preparation time rather than silently sending garbage credentials.