### PR TITLE
docs(quickstart): add practical timeout example

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -532,7 +532,13 @@ Timeouts
 You can tell Requests to stop waiting for a response after a given number of
 seconds with the ``timeout`` parameter. Nearly all production code should use
 this parameter in nearly all requests. Failure to do so can cause your program
-to hang indefinitely::
+to hang indefinitely.
+
+For example, this request uses a 10-second timeout::
+
+    >>> requests.get('https://github.com/', timeout=10)
+
+If the server takes too long to respond, Requests raises ``Timeout``::
 
     >>> requests.get('https://github.com/', timeout=0.001)
     Traceback (most recent call last):


### PR DESCRIPTION
## What changed

This updates the Quickstart timeout section to add:

- a practical example using a normal timeout value
- clearer wording before the failure example
- explicit mention that Requests raises `Timeout`

## Why

The section recommends using timeouts in production, so adding a normal usage example makes the guidance easier for readers to apply in real code.