### PR TITLE
docs(quickstart): clarify timeout applies to connect and read separately

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -548,6 +548,11 @@ to hang indefinitely::
     received on the underlying socket for ``timeout`` seconds). If no timeout is specified explicitly, requests do
     not time out.
 
+    A single ``timeout`` value applies to both the **connect** and
+    **read** phases separately. To set them independently, pass a
+    ``(connect_timeout, read_timeout)`` tuple. See :ref:`timeouts`
+    for details.
+
 
 Errors and Exceptions
 ---------------------


### PR DESCRIPTION
The quickstart timeout note explains that `timeout` is not a time limit on the entire response download, but does not mention that a single float applies to both connect and read timeouts independently, or that a `(connect_timeout, read_timeout)` tuple can set them separately.

Added a brief clarification to the existing admonition block in `docs/user/quickstart.rst` with a cross-reference to the advanced timeouts section, which already documents this behavior in detail.

Fixes #7350