### PR TITLE
docs(exceptions): clarify ChunkedEncodingError can result from transient network issues

### DIFF
--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -118,7 +118,12 @@ class InvalidProxyURL(InvalidURL):
 
 
 class ChunkedEncodingError(RequestException):
-    """The server declared chunked encoding but sent an invalid chunk."""
+    """The server declared chunked encoding but sent an invalid chunk.
+
+    This may also be raised when the connection is interrupted mid-stream,
+    resulting in an incomplete chunked response. Retrying the request may
+    succeed in cases where the error is caused by a transient network issue.
+    """
 
 
 class ContentDecodingError(RequestException, BaseHTTPError):


### PR DESCRIPTION
The docstring for `ChunkedEncodingError` only mentions "server sent an invalid chunk" but this exception is also raised when the connection drops mid-stream during a chunked transfer (e.g. transient network interruption). The underlying `ProtocolError` from urllib3 covers both cases.

Added a clarifying note to the docstring so users know this error can result from transient issues and that retrying may succeed. This aligns with the discussion in #7341 and #4771.

Fixes #7341