### PR TITLE
Consider urllib3 version has 3 numbers at most (#7375)

### DIFF
--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -56,7 +56,7 @@ except ImportError:
 
 
 def check_compatibility(urllib3_version, chardet_version, charset_normalizer_version):
-    urllib3_version = urllib3_version.split(".")
+    urllib3_version = urllib3_version.split(".")[:3]
     assert urllib3_version != ["dev"]  # Verify urllib3 isn't installed from git.
 
     # Sometimes, urllib3 only reports its version as 16.1.


### PR DESCRIPTION
Handle the urllib3 string version the same way it is done for chardet or charset-normalizer.

It avoids the version check from failing if the split generates a list of size > 3.

Fixes #7375