### PR TITLE
docs: clarify timeout parameter is per-phase, not total deadline

### DIFF
--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -31,7 +31,9 @@ def request(method, url, **kwargs):
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How many seconds to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read
-        timeout) <timeouts>` tuple.
+        timeout) <timeouts>` tuple. A single value is applied to both the
+        connect and read timeouts; this is *not* a total/wall-clock deadline
+        for the whole request. Pass ``None`` to wait forever.
     :type timeout: float or tuple
     :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
     :type allow_redirects: bool

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -539,7 +539,9 @@ class Session(SessionRedirectMixin):
             Basic/Digest/Custom HTTP Auth.
         :param timeout: (optional) How many seconds to wait for the server to send
             data before giving up, as a float, or a :ref:`(connect timeout,
-            read timeout) <timeouts>` tuple.
+            read timeout) <timeouts>` tuple. A single value is applied to both
+            the connect and read timeouts; this is *not* a total/wall-clock
+            deadline for the whole request. Pass ``None`` to wait forever.
         :type timeout: float or tuple
         :param allow_redirects: (optional) Set to True by default.
         :type allow_redirects: bool


### PR DESCRIPTION

**Repo:** psf/requests (⭐ 52000)
**Type:** docs
**Files changed:** 2
**Lines:** +6/-2

## What
Expands the docstring for the `timeout` parameter on `requests.api.request()` and
`Session.request()` to spell out that a single float value is applied to both
the connect and read phases independently, that it is *not* a wall-clock
deadline for the whole request, and that `None` means wait forever.

## Why
Issue #7350 reports that the docstring for `timeout` is confusing: users
expect a single value to be a total request deadline. The longer-form docs
(`docs/user/advanced.rst`) already explain this, but the API docstrings —
which are what most users read via `help()` / IDE tooltips — did not. This
keeps the change small and aligns the inline docs with the existing prose
documentation.

## Testing
Pure docstring change, no behavior change. Verified rendering keeps reST
indentation valid (matches surrounding `:param:` blocks). No tests added or
needed.

## Risk
Low — documentation only, no code paths touched.
