### PR TITLE
feat(security): add SecurityWarning for verify=False with cert

### DIFF
--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -172,6 +172,7 @@ from .exceptions import (
     Timeout,
     TooManyRedirects,
     URLRequired,
+    SecurityWarning,
 )
 from .models import PreparedRequest, Request, Response
 from .sessions import Session, session

--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -44,6 +44,7 @@ from .exceptions import (
     ReadTimeout,
     RetryError,
     SSLError,
+    SecurityWarning,
 )
 from .models import Response
 from .structures import CaseInsensitiveDict
@@ -606,6 +607,15 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: (optional) The proxies dictionary to apply to the request.
         :rtype: requests.Response
         """
+
+        if verify is False and cert is not None:
+            warnings.warn(
+                "You are using verify=False (disable certificate verification)"
+                "together with a specified client certificate (cert)."
+                "This combination may be insecure in production environments.",
+                SecurityWarning,
+                stacklevel=2,
+            )
 
         try:
             conn = self.get_connection_with_tls_context(

--- a/src/requests/exceptions.py
+++ b/src/requests/exceptions.py
@@ -150,3 +150,7 @@ class FileModeWarning(RequestsWarning, DeprecationWarning):
 
 class RequestsDependencyWarning(RequestsWarning):
     """An imported dependency doesn't match the expected version range."""
+
+
+class SecurityWarning(RequestsWarning, UserWarning):
+    """A security-related warning for potentially insecure configurations."""

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1065,6 +1065,20 @@ class TestRequests:
             # fail if we use our default trust bundle.
             requests.get(httpbin_secure("status", "200"))
 
+    def test_verify_false_with_cert_emits_security_warning(self):
+        """Ensure a SecurityWarning is raised when verify=False is combined
+        with a specified client certificate. This combination disables server identity
+        verification while still sending client credentials, which may be
+        insecure in production environments.
+        """
+        with pytest.warns(requests.exceptions.SecurityWarning, match="verify=False"):
+            # We pass cert="." as a dummy value -> the warning must be emitted
+            try:
+                requests.get("https://httpbin.org/get", verify=False, cert=".")
+            except Exception:
+                # Network or cert errors are irrelevant
+                pass
+
     def test_urlencoded_get_query_multivalued_param(self, httpbin):
         r = requests.get(httpbin("get"), params={"test": ["foo", "baz"]})
         assert r.status_code == 200


### PR DESCRIPTION
Add a SecurityWarning when verify=False and cert are used together in
HTTPAdapter.send(). This combination disables server certificate
verification while still sending client credentials, which can be
misleading and insecure in production environments.

- Add SecurityWarning class to exceptions.py
- Emit the warning in adapters.py before any network activity
- Expose SecurityWarning in the public API via __init__.py

Add a test ensuring SecurityWarning is emitted when verify=False
and cert are used together in HTTPAdapter.send("http://...", verify=False, cert = ".").

No existing behavior is changed.