### PR TITLE
fix: handle bytes username/password in HTTPDigestAuth

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -133,6 +133,14 @@ class HTTPDigestAuth(AuthBase):
         qop = self._thread_local.chal.get("qop")
         algorithm = self._thread_local.chal.get("algorithm")
         opaque = self._thread_local.chal.get("opaque")
+
+        # Ensure username and password are strings for header formatting
+        # and consistent hash computation
+        if isinstance(self.username, bytes):
+            self.username = self.username.decode("utf-8")
+        if isinstance(self.password, bytes):
+            self.password = self.password.decode("utf-8")
+
         hash_utf8 = None
 
         if algorithm is None:


### PR DESCRIPTION
## Summary

When `username` or `password` is passed as bytes to `HTTPDigestAuth` (e.g. users following the workaround for non-ASCII credentials from issue #5089), `build_digest_header` would include the bytes repr (`b'...'`) in the Authorization header value, producing an invalid header like:

```
Digest username="b'Ond\xc5\x99ej'", realm="..."
```

## Fix

Decode bytes to UTF-8 strings at the start of `build_digest_header`, before they are used in both hash computation (A1 string) and header formatting. This matches the pattern already used by the inner hash functions (`md5_utf8`, etc.) which accept both str and bytes.

Fixes #6102