### PR TITLE
fix: session.verify=False should take precedence over REQUESTS_CA_BUNDLE

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -766,11 +766,13 @@ class Session(SessionRedirectMixin):
             # Look for requests environment configuration
             # and be compatible with cURL.
             if verify is True or verify is None:
-                verify = (
-                    os.environ.get("REQUESTS_CA_BUNDLE")
-                    or os.environ.get("CURL_CA_BUNDLE")
-                    or verify
-                )
+                # Don't override an explicit session.verify=False with env vars
+                if self.verify is not False:
+                    verify = (
+                        os.environ.get("REQUESTS_CA_BUNDLE")
+                        or os.environ.get("CURL_CA_BUNDLE")
+                        or verify
+                    )
 
         # Merge all the kwargs.
         proxies = merge_setting(proxies, self.proxies)


### PR DESCRIPTION
Fixes #3829

**Problem:** When `session.verify = False` is explicitly set, calling `session.get(url)` (without passing verify) still picks up `REQUESTS_CA_BUNDLE` from the environment, causing SSL verification to fail with a self-signed or untrusted cert.

**Root cause:** In `merge_environment_settings()`, when `verify` parameter is `None` (not passed by caller), the environment variable lookup runs unconditionally and sets verify to the CA bundle path. Then `merge_setting(env_path, self.verify=False)` returns the env path because neither arg is None — request_setting takes priority over session_setting for non-dict values.

**Fix:** Skip the environment CA bundle lookup when `self.verify is False`. This preserves the user's explicit intent to disable verification, while keeping the existing behavior for all other cases (default sessions, explicit `verify=True`, etc.).

**Behavior after fix:**
- `session.verify = False; session.get(url)` → verify stays `False` ✅
- Default session with REQUESTS_CA_BUNDLE set → uses env bundle ✅ (unchanged)
- Explicit `verify=True` in request → uses env bundle ✅ (unchanged)
- Explicit `verify=False` in request → `False` ✅ (unchanged)