### PR TITLE
Don't let REQUESTS_CA_BUNDLE override an explicit session.verify=False

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -765,12 +765,16 @@ class Session(SessionRedirectMixin):
 
             # Look for requests environment configuration
             # and be compatible with cURL.
+            # Only consult env vars when the session-level verify has not been
+            # explicitly set to False; otherwise REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE
+            # would silently override an intentional session.verify = False.
             if verify is True or verify is None:
-                verify = (
-                    os.environ.get("REQUESTS_CA_BUNDLE")
-                    or os.environ.get("CURL_CA_BUNDLE")
-                    or verify
-                )
+                if self.verify is not False:
+                    verify = (
+                        os.environ.get("REQUESTS_CA_BUNDLE")
+                        or os.environ.get("CURL_CA_BUNDLE")
+                        or verify
+                    )
 
         # Merge all the kwargs.
         proxies = merge_setting(proxies, self.proxies)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1023,6 +1023,23 @@ class TestRequests:
             )
         assert settings["verify"] == expected
 
+    def test_session_verify_false_not_overridden_by_env(self):
+        """session.verify=False must not be overridden by REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE."""
+        s = requests.Session()
+        s.verify = False
+        for env in (
+            {"REQUESTS_CA_BUNDLE": "/some/path"},
+            {"CURL_CA_BUNDLE": "/curl/path"},
+            {"REQUESTS_CA_BUNDLE": "/some/path", "CURL_CA_BUNDLE": "/curl/path"},
+        ):
+            with mock.patch("os.environ", env):
+                settings = s.merge_environment_settings(
+                    url="https://example.com/", proxies={}, stream=False, verify=None, cert=None
+                )
+            assert settings["verify"] is False, (
+                f"Expected verify=False with session.verify=False, env={env}, got {settings['verify']!r}"
+            )
+
     def test_http_with_certificate(self, httpbin):
         r = requests.get(httpbin(), cert=".")
         assert r.status_code == 200


### PR DESCRIPTION
## Problem

When a session is configured with `verify=False` and the `REQUESTS_CA_BUNDLE`
(or `CURL_CA_BUNDLE`) environment variable is set, the environment variable
silently wins and TLS verification still happens:

```python
import os
os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"

s = requests.Session()
s.verify = False
r = s.get("https://self-signed.example.com/")  # still raises SSLError
```

This has been open since 2015: #3829

## Root cause

`merge_environment_settings` checks the *per-request* `verify` argument
(which is `None` when no per-request override is given) and promotes it to
the CA bundle path if either env var is set.  The `merge_setting` call that
follows merges that promoted value with `self.verify`, but since the env-var
path is a non-`None` string it takes priority over `False`.

## Fix

Before consulting the env vars, check whether the session-level `verify` has
been explicitly set to `False`.  If it has, skip the env-var lookup entirely.

```python
if verify is True or verify is None:
    if self.verify is not False:
        verify = (
            os.environ.get("REQUESTS_CA_BUNDLE")
            or os.environ.get("CURL_CA_BUNDLE")
            or verify
        )
```

A targeted regression test is included.

## Behaviour unchanged for

- `session.verify = True` (default) — env vars continue to work as before
- `session.verify = "/path/to/bundle"` — custom bundle continues to work
- per-request `verify=False` — already skipped the env-var block (value is
  not `True` or `None`), behaviour unchanged

Fixes #3829