### PR TITLE
docs: Clarify timeout parameter behavior in quickstart guide

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -548,6 +548,21 @@ to hang indefinitely::
     received on the underlying socket for ``timeout`` seconds). If no timeout is specified explicitly, requests do
     not time out.
 
+**Timeout values:**
+
+- A single float value applies to both the **connect** and **read** timeouts::
+
+    >>> requests.get('https://github.com/', timeout=5)
+
+- A tuple can be used to specify separate connect and read timeouts::
+
+    >>> requests.get('https://github.com/', timeout=(3.05, 27))
+
+The first value is the connect timeout (time to establish a connection),
+and the second is the read timeout (time to wait for a response).
+
+See :ref:`timeouts` in the advanced section for more details.
+
 
 Errors and Exceptions
 ---------------------


### PR DESCRIPTION
## Summary

This PR adds explicit clarification to the quickstart guide about the `timeout` parameter behavior:

- A single float value applies to both the **connect** and **read** timeouts
- A tuple can be used to specify separate connect and read timeouts

The current documentation does not clearly explain that a single float applies to both timeouts, which can confuse users who expect it to behave as a total request timeout.

## Changes

Added a new section in `docs/user/quickstart.rst` under the "Timeouts" section that:
1. Explains that a single float applies to both connect and read timeouts
2. Shows an example of using a tuple to specify separate timeouts
3. Links to the advanced section for more detailed information

## Test Plan

- [ ] Verified RST syntax is valid (Sphinx-specific directives are expected)
- [ ] Local unit tests pass (tests that don't require network)
- [ ] Documentation change only - no code changes required

Fixes #7350

🤖 Generated with [Claude Code](https://claude.com/claude-code)