### PR TITLE
Create groups for GHA and pre-commit dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,17 @@ updates:
         update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR consolidates our dependabot PRs into groups so GHA updates and pre-commit updates can be bundled respectively.