### PR TITLE
Preserve IPv6 zone identifier in prepared URLs (#6735)

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -480,6 +480,16 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 query = enc_params
 
         url = requote_uri(urlunparse([scheme, netloc, path, None, query, fragment]))
+
+        # Preserve the IPv6 zone identifier separator ('%') inside a bracketed
+        # host. ``requote_uri`` percent-encodes a literal '%' to '%25', but
+        # ``urllib3`` forwards the (already-parsed) host to ``getaddrinfo()``
+        # verbatim, so an encoded zone identifier like ``%25eth0`` cannot be
+        # resolved by the OS. See https://github.com/psf/requests/issues/6735.
+        if host and "%" in host:
+            encoded_host = host.replace("%", "%25", 1)
+            url = url.replace(encoded_host, host, 1)
+
         self.url = url
 
     def prepare_headers(self, headers):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -151,6 +151,39 @@ class TestRequests:
         "url, expected",
         (
             (
+                # Literal '%' zone-id separator must be preserved, otherwise
+                # urllib3 will forward '%25ens192' to getaddrinfo() which the
+                # OS cannot resolve. Regression test for #6735.
+                "https://[fe80::1%ens192]/redfish/v1",
+                "https://[fe80::1%ens192]/redfish/v1",
+            ),
+            (
+                # RFC 6874 form ('%25') must be normalized back to the literal
+                # form expected by getaddrinfo() / urllib3.
+                "https://[fe80::1%25ens192]/redfish/v1",
+                "https://[fe80::1%ens192]/redfish/v1",
+            ),
+            (
+                # Zone-id preserved alongside port/query/fragment.
+                "https://[fe80::5eed:8cff:fe00:0da4%ens192]:8443/api?x=1#f",
+                "https://[fe80::5eed:8cff:fe00:0da4%ens192]:8443/api?x=1#f",
+            ),
+            (
+                # Plain IPv6 (no zone id) must be unaffected.
+                "https://[::1]/",
+                "https://[::1]/",
+            ),
+        ),
+    )
+    def test_ipv6_zone_id_is_preserved(self, url, expected):
+        """See: https://github.com/psf/requests/issues/6735"""
+        request = requests.Request("GET", url).prepare()
+        assert request.url == expected
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        (
+            (
                 "http://example.com/path#fragment",
                 "http://example.com/path?a=b#fragment",
             ),


### PR DESCRIPTION
Fixes #6735.
 
## Problem
 
Since requests 2.32.0, requesting a link-local IPv6 URL such as
 
```python
requests.get("https://[fe80::1%ens192]/redfish/v1", verify=False)

fails with [Errno -2] Name or service not known. The same URL works against urllib3 directly, and worked with requests 2.31.0.

**Root cause**
In PreparedRequest.prepare_url:

urllib3.util.parse_url normalizes both %ens192 and %25ens192 forms of the IPv6 zone identifier to the literal form, giving us host = '[fe80::1%ens192]' with a literal %.
The assembled URL is passed through requote_uri, whose unquote_unreserved helper treats %en as a malformed percent- escape ('en'.isalnum() is true but int('en', 16) raises ValueError), raises InvalidURL, and requote_uri falls back to quote(uri, safe=safe_without_percent) which percent-encodes the
literal % to %25. 3. urllib3 then hands the host fe80::1%25ens192 straight to getaddrinfo(), which cannot resolve a zone literally named %25ens192.

urllib3 alone works because the literal %ens192 survives all the way to getaddrinfo(), which accepts it per RFC 4007.

Fix
After requote_uri runs, restore the literal % inside the bracketed host. Because parse_url guarantees that host only ever contains a % inside a bracketed IPv6 authority (never in the path/query/ fragment), the replacement is anchored to the authority and cannot accidentally undo an intentional %25 elsewhere in the URL.

python
url = requote_uri(urlunparse([scheme, netloc, path, None, query, fragment]))
 
if host and "%" in host:
    encoded_host = host.replace("%", "%25", 1)
    url = url.replace(encoded_host, host, 1)
 
self.url = url
10 lines of production code, no new helpers, no regex, no changes to requote_uri / unquote_unreserved semantics (their existing tests continue to pass unchanged).

Tests
tests/test_requests.py::TestRequests::test_ipv6_zone_id_is_preserved adds four parametrized cases:

- literal %ens192 form preserved end-to-end;
- RFC 6874 %25ens192 form normalized to literal form;
- zone id preserved alongside port, query, and fragment;
- plain IPv6 (no zone id) unaffected.

The existing test_requote_uri_with_unquoted_percents and test_unquote_unreserved cases continue to pass, confirming that percent handling outside the authority is unchanged.

**Relation to prior attempts**
Aware of prior attempts at this bug (#5257, #7065, #7088, #7111, #7193). This PR differs by:

- being localized to prepare_url only — no new helpers in utils.py / adapters.py, no regex, no behavior changes to the existing quoting utilities;
- using the already-parsed host variable as the anchor for the fix-up, so the scope is provably limited to the bracketed IPv6 authority;
- including a parametrized regression test directly tied to the reported failure case in #6735.