### PR TITLE
docs: clarify timeout parameter in requests.get()

### DIFF
--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -30,8 +30,9 @@ def request(method, url, **kwargs):
         to add for the file.
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How many seconds to wait for the server to send data
-        before giving up, as a float, or a :ref:`(connect timeout, read
-        timeout) <timeouts>` tuple.
+        before giving up. If a float is provided, it is applied to both the
+        connect and read timeouts. Use a :ref:`(connect timeout, read
+        timeout) <timeouts>` tuple to set them separately.
     :type timeout: float or tuple
     :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
     :type allow_redirects: bool


### PR DESCRIPTION
Clarifies that timeout accepts both float (applied to both connect and read) and tuple (separate values). Fixes #6575