### PR TITLE
Ruff rule UP038 has been removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ select = [
     "UP",     # pyupgrade
     "T10",    # flake8-debugger (replaces debug-statements hook)
 ]
-ignore = ["E203", "E501", "UP038", "UP031"]
+ignore = ["E203", "E501", "UP031"]
 per-file-ignores = {"src/requests/__init__.py" = ["E402", "F401"], "src/requests/compat.py" = ["E402", "F401"], "tests/compat.py" = ["F401"]}
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
[Removed since 0.13.0](https://docs.astral.sh/ruff/rules/non-pep604-isinstance/)

Fixes this warning while running ruff:
```
warning: The following rules have been removed and ignoring them has no effect:
    - UP038
```