### PR TITLE
Fix typos

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -401,7 +401,7 @@ class HTTPAdapter(BaseAdapter):
         alter the other keys to ensure the desired behaviour.
 
         :param request:
-            The PreparedReqest being sent over the connection.
+            The PreparedRequest being sent over the connection.
         :type request:
             :class:`~requests.models.PreparedRequest`
         :param verify:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -586,7 +586,7 @@ class TestRequests:
             ("http://doesnotexist.google.com", ConnectionError),
             # Connecting to an invalid port should raise a ConnectionError
             ("http://localhost:1", ConnectionError),
-            # Inputing a URL that cannot be parsed should raise an InvalidURL error
+            # Inputting a URL that cannot be parsed should raise an InvalidURL error
             ("http://fe80::5054:ff:fe5a:fc0", InvalidURL),
         ),
     )


### PR DESCRIPTION
Fix typos found by [typos](https://github.com/crate-ci/typos).

Also, the plural of **status** is **status** or **statuses** - not [**stati**](https://www.oed.com/search/dictionary/?q=stati):
https://github.com/psf/requests/blob/f43f750ee10addbaa13901c1017631b4d70fd6e3/src/requests/models.py#L71-L73
I'd like to fix this too, but isn't `REDIRECT_STATI` pat of the API?