### PR TITLE
Handle None-valued method cookies as removals

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -533,6 +533,10 @@ def cookiejar_from_dict(cookie_dict, cookiejar=None, overwrite=True):
     if cookie_dict is not None:
         names_from_jar = [cookie.name for cookie in cookiejar]
         for name in cookie_dict:
+            if cookie_dict[name] is None:
+                remove_cookie_by_name(cookiejar, name)
+                continue
+
             if overwrite or (name not in names_from_jar):
                 cookiejar.set_cookie(create_cookie(name, cookie_dict[name]))
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -21,6 +21,7 @@ from .cookies import (
     cookiejar_from_dict,
     extract_cookies_to_jar,
     merge_cookies,
+    remove_cookie_by_name,
 )
 from .exceptions import (
     ChunkedEncodingError,
@@ -467,15 +468,21 @@ class Session(SessionRedirectMixin):
         :rtype: requests.PreparedRequest
         """
         cookies = request.cookies or {}
+        cookies_to_remove = []
 
         # Bootstrap CookieJar.
         if not isinstance(cookies, cookielib.CookieJar):
+            cookies_to_remove = [
+                name for name, value in cookies.items() if value is None
+            ]
             cookies = cookiejar_from_dict(cookies)
 
         # Merge with session cookies
         merged_cookies = merge_cookies(
             merge_cookies(RequestsCookieJar(), self.cookies), cookies
         )
+        for name in cookies_to_remove:
+            remove_cookie_by_name(merged_cookies, name)
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -428,6 +428,23 @@ class TestRequests:
         # Sending a request with cookies should not add cookies to the session
         assert not s.cookies
 
+    def test_none_request_cookie_removes_session_cookie(self):
+        s = requests.session()
+        s.cookies = cookiejar_from_dict({"from-my": "browser"})
+
+        req = requests.Request(
+            "GET",
+            "https://example.com",
+            cookies={"another": "cookie", "from-my": None},
+        )
+        prep = s.prepare_request(req)
+
+        assert prep.headers["Cookie"] == "another=cookie"
+        assert [(cookie.name, cookie.value) for cookie in prep._cookies] == [
+            ("another", "cookie")
+        ]
+        assert s.cookies["from-my"] == "browser"
+
     def test_generic_cookiejar_works(self, httpbin):
         cj = cookielib.CookieJar()
         cookiejar_from_dict({"foo": "bar"}, cj)
@@ -500,6 +517,13 @@ class TestRequests:
         req = requests.Request("GET", httpbin("get"))
         prep = ses.prepare_request(req)
         assert "Accept-Encoding" not in prep.headers
+
+    def test_cookiejar_from_dict_omits_none_values(self):
+        jar = cookiejar_from_dict({"keep": "value"})
+
+        cookiejar_from_dict({"keep": None, "empty": ""}, jar)
+
+        assert [(cookie.name, cookie.value) for cookie in jar] == [("empty", "")]
 
     def test_headers_preserve_order(self, httpbin):
         """Preserve order when headers provided as OrderedDict."""


### PR DESCRIPTION
## Summary
- treat None values in cookie dicts as removals instead of serializing invalid cookies
- remove session cookies that are explicitly unset by request-level cookie dictionaries
- add regression coverage for both the helper and the session merge path

Closes #2716.

## Testing
- .venv/bin/python -m pytest tests/test_requests.py -k "none_request_cookie_removes_session_cookie or cookiejar_from_dict_omits_none_values or request_cookies_not_persisted or generic_cookiejar_works or param_cookiejar_works" -q
- .venv/bin/python -m pytest tests/test_requests.py -k "headers_on_session_with_None_are_not_sent" -q
- .venv/bin/python -m pytest tests/test_requests.py -k "cookie" -q
- python3 -m compileall src/requests tests/test_requests.py
