### PR TITLE
docs: clarify Session.request verify inheritance

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -551,12 +551,13 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
-            ``False``, requests will accept any TLS certificate presented by
-            the server, and will ignore hostname mismatches and/or expired
-            certificates, which will make your application vulnerable to
-            man-in-the-middle (MitM) attacks. Setting verify to ``False``
-            may be useful during local development or testing.
+            to a CA bundle to use. When omitted, this request inherits the session-level
+            ``verify`` setting, which defaults to ``True``. Passing ``verify`` on the
+            request overrides the session-level value. When set to ``False``, requests
+            will accept any TLS certificate presented by the server, and will ignore
+            hostname mismatches and/or expired certificates, which will make your
+            application vulnerable to man-in-the-middle (MitM) attacks. Setting
+            verify to ``False`` may be useful during local development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2176,6 +2176,33 @@ class TestRequests:
             proxies["one"].clear.assert_called_once_with()
             proxies["two"].clear.assert_called_once_with()
 
+    def test_session_request_uses_session_verify_default(self):
+        session = requests.Session()
+        session.verify = False
+        response = requests.Response()
+        response.status_code = 200
+
+        with mock.patch.object(
+            requests.Session, "send", autospec=True, return_value=response
+        ) as send:
+            session.request("GET", "https://example.com")
+
+        assert send.call_args.kwargs["verify"] is False
+
+    def test_session_request_verify_overrides_session_default(self):
+        session = requests.Session()
+        session.verify = False
+        response = requests.Response()
+        response.status_code = 200
+        ca_bundle = "/tmp/custom-ca.pem"
+
+        with mock.patch.object(
+            requests.Session, "send", autospec=True, return_value=response
+        ) as send:
+            session.request("GET", "https://example.com", verify=ca_bundle)
+
+        assert send.call_args.kwargs["verify"] == ca_bundle
+
     def test_proxy_auth(self):
         adapter = HTTPAdapter()
         headers = adapter.proxy_headers("http://user:pass@httpbin.org")


### PR DESCRIPTION
## Summary
- clarify that `Session.request(..., verify=...)` inherits `session.verify` when omitted
- document that an explicit per-request `verify` value overrides the session-level setting
- add focused tests covering both behaviors

Closes #7399.

## Why
The current `Session.request` docstring says `verify` defaults to `True`, but the implementation actually defers to the session-level `verify` setting when the argument is omitted. That makes the generated API docs misleading for code like:

```python
session = requests.Session()
session.verify = False
session.request("GET", url)
```

## Testing
- `python -m pytest tests/test_requests.py -k "session_request_uses_session_verify_default or session_request_verify_overrides_session_default" -q`
- `python -m pytest tests/test_requests.py -q` still hits the same existing 194 fixture/environment errors on a clean checkout; this change adds 2 passing tests on top of that baseline
