### PR TITLE
Add tests for hasattr/getattr usage on LookupDict

### DIFF
--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -76,3 +76,16 @@ class TestLookupDict:
     @get_item_parameters
     def test_get(self, key, value):
         assert self.lookup_dict.get(key) == value
+
+    def test_hasattr(self):
+        assert hasattr(self.lookup_dict, "bad_gateway") is True
+        assert hasattr(self.lookup_dict, "not_a_key") is False
+
+    def test_getattr(self):
+        assert getattr(self.lookup_dict, "bad_gateway") == 502
+        with pytest.raises(AttributeError):
+            getattr(self.lookup_dict, "not_a_key")
+
+    @get_item_parameters
+    def test_getattr_default(self, key, value):
+        assert getattr(self.lookup_dict, key, None) == value


### PR DESCRIPTION
This PR codifies a few behaviors on LookupDict that weren't immediately clear when making changes for #7272. Because both dict keys and attributes are intended to operate interchangeably they typically behave identically.

The one exception to that is dict access through `["missing_key"]` is treated as `None` but `.missing_key` raises an AttributeError. That has implications on `hasattr`/`getattr` checks for key presence.