### PR TITLE
docs: clarify Session.request verify inherits from session

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -551,7 +551,8 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
+            to a CA bundle to use. Defaults to the Session's ``verify`` value,
+            which itself defaults to ``True``. When set to
             ``False``, requests will accept any TLS certificate presented by
             the server, and will ignore hostname mismatches and/or expired
             certificates, which will make your application vulnerable to


### PR DESCRIPTION
## Summary

Clarify that Session.request's verify parameter defaults to the Session's own verify value (which itself defaults to True), rather than saying it simply 'Defaults to True'.

This matches the actual behavior where an explicit per-request verify overrides the session setting, which in turn overrides the default of True.

Fixes #7399.

## Maintainer feedback

@nateprepout said:
> If we changed it, it would probably be to convey it 'defaults to the Session value, True by default'.

## Changes

- src/requests/sessions.py: Updated docstring for verify parameter in Session.request()

## Testing

No code changes — only docstring. The existing behavior is unchanged.