### PR TITLE
docs: clarify Session.request verify defaults to Session's verify value

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -551,10 +551,10 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
-            ``False``, requests will accept any TLS certificate presented by
-            the server, and will ignore hostname mismatches and/or expired
-            certificates, which will make your application vulnerable to
+            to a CA bundle to use. Defaults to the Session's verify value, which itself
+            defaults to ``True``. When set to ``False``, requests will accept any TLS
+            certificate presented by the server, and will ignore hostname mismatches and/or
+            expired certificates, which will make your application vulnerable to
             man-in-the-middle (MitM) attacks. Setting verify to ``False``
             may be useful during local development or testing.
         :param cert: (optional) if String, path to ssl client cert file (.pem).


### PR DESCRIPTION
## Summary

Clarify that Session.request's verify parameter defaults to the Session's own verify value (which itself defaults to True), rather than saying it simply 'Defaults to True'.

This matches the actual behavior where an explicit per-request verify overrides the session setting, which in turn overrides the default of True.

Fixes #7399.

## Maintainer feedback

@nateprewitt said:
> If we changed it, it would probably be to convey it 'defaults to the Session value, True by default'.

## Changelog

- Updated verify parameter docstring in Session.request() to reflect actual inheritance behavior