### PR TITLE
Fix HTTPDigestAuth non-latin credentials encoding

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -218,7 +218,16 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        if isinstance(self.username, bytes):
+            username = self.username.decode("utf-8")
+        else:
+            username = self.username
+        if isinstance(self.password, bytes):
+            password = self.password.decode("utf-8")
+        else:
+            password = self.password
+
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -250,8 +259,12 @@ class HTTPDigestAuth(AuthBase):
         self._thread_local.last_nonce = nonce
 
         # XXX should the partial digests be encoded too?
+        if isinstance(self.username, bytes):
+            username_header = self.username.decode("utf-8")
+        else:
+            username_header = self.username
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{username_header}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
When HTTPDigestAuth credentials are passed as bytes (e.g. encoded UTF-8), they were being used directly in the digest header without decoding, resulting in headers like `Digest username="b'Ond\xc5\x99ej'"`.

This fix decodes bytes username/password to strings before using them in the digest A1 computation and the username header field.

Fixes #6102