### PR TITLE
Add 3.14t support to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev", "pypy-3.11"]
         os: [ubuntu-22.04, macOS-latest, windows-latest]
         # Pypy-3.11 can't install openssl-sys with rust
         # which prevents us from testing in GHA.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries"
 ]


### PR DESCRIPTION
This PR will start testing Requests on 3.14 free-threaded builds to make sure we don't have any obvious issues.