### PR TITLE
docs: Fix missing hook output in hook example

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -467,6 +467,7 @@ Let's print some request method arguments at runtime::
 You can add multiple hooks to a single request.  Let's call two hooks at once::
 
     >>> r = requests.get('https://httpbin.org/', hooks={'response': [print_url, record_hook]})
+    https://httpbin.org/
     >>> r.hook_called
     True
 


### PR DESCRIPTION
The REPL example for multiple hooks is missing the stdout from response hook `print_url`.
I added the missing line to demonstrate that both hooks are called.