### PR TITLE
Formalize 3.15 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,6 @@ permissions:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
We've been testing on 3.15 for a few months and now that the feature freeze is finalized for beta1, I think we should be good to start advertising support. Downstream should be free to start testing with the next release.

The only remaining action is removing the PyO3 forward ABI flag which is currently pending pyo3/pyo3#6012. Once that's merged, we should be ready to do final cleanup. The flag is only used for testing infra and shouldn't affect any direct dependencies.