### PR TITLE
Clear *_PROXY env vars during test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,15 @@ def prepare_url(value):
     return inner
 
 
+@pytest.fixture(autouse=True)
+def clean_proxy_environ(monkeypatch):
+    """Remove proxy related environment variables for every test."""
+    proxy_vars = ("http_proxy", "https_proxy", "no_proxy", "ftp_proxy", "all_proxy")
+    for var in proxy_vars:
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(var.upper(), raising=False)
+
+
 @pytest.fixture
 def httpbin(httpbin):
     return prepare_url(httpbin)


### PR DESCRIPTION
This PR will make sure we're testing on a clean slate with each run test run. It looks like there have been some previous attempts to clean this up but they've done it by placing overrides in every test. This fixture should hopefully future proof the test suite from the environment so we don't get false positives on tests.