### PR TITLE
sessions: fix hooks type

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -150,7 +150,7 @@ if TYPE_CHECKING:
         timeout: TimeoutType
         allow_redirects: bool
         proxies: dict[str, str] | None
-        hooks: HooksType
+        hooks: HooksInputType | None
         stream: bool | None
         verify: VerifyType | None
         cert: CertType

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -567,7 +567,7 @@ class Session(SessionRedirectMixin):
         timeout: _t.TimeoutType = None,
         allow_redirects: bool = True,
         proxies: dict[str, str] | None = None,
-        hooks: _t.HooksType = None,
+        hooks: _t.HooksInputType | None = None,
         stream: bool | None = None,
         verify: _t.VerifyType | None = None,
         cert: _t.CertType = None,


### PR DESCRIPTION
The `hook` keyword in `Session.request()` should be of type `HooksInputType | None`, not `HooksType`.

This is already correctly defined in `models.Request.__init__()`:
- https://github.com/psf/requests/blob/dc9dbdfb3434c6e58d48fd102f93e5342308817e/src/requests/models.py#L283-L333

But `sessions.Session.request()` and the associated `_types.BaseRequestKwargs` are wrong:
- https://github.com/psf/requests/blob/dc9dbdfb3434c6e58d48fd102f93e5342308817e/src/requests/sessions.py#L557-L618
- https://github.com/psf/requests/blob/dc9dbdfb3434c6e58d48fd102f93e5342308817e/src/requests/_types.py#L145-L156