### PR TITLE
Parameterize SupportsItems to handle Mapping key invariance

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -20,6 +20,8 @@ from typing import (
 )
 
 _T_co = TypeVar("_T_co", covariant=True)
+_KT_co = TypeVar("_KT_co", covariant=True)
+_VT_co = TypeVar("_VT_co", covariant=True)
 
 
 @runtime_checkable
@@ -28,8 +30,8 @@ class SupportsRead(Protocol[_T_co]):
 
 
 @runtime_checkable
-class SupportsItems(Protocol):
-    def items(self) -> Iterable[tuple[Any, Any]]: ...
+class SupportsItems(Protocol[_KT_co, _VT_co]):
+    def items(self) -> Iterable[tuple[_KT_co, _VT_co]]: ...
 
 
 # These are needed at runtime for default_hooks() return type
@@ -79,7 +81,7 @@ if TYPE_CHECKING:
         str | bytes | int | float | Iterable[str | bytes | int | float] | None
     )
     ParamsType: TypeAlias = (
-        Mapping[_ParamsMappingKeyType, _ParamsMappingValueType]
+        SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType]
         | tuple[tuple[_ParamsMappingKeyType, _ParamsMappingValueType], ...]
         | Iterable[tuple[_ParamsMappingKeyType, _ParamsMappingValueType]]
         | str
@@ -87,7 +89,7 @@ if TYPE_CHECKING:
         | None
     )
 
-    KVDataType: TypeAlias = Iterable[tuple[Any, Any]] | Mapping[Any, Any]
+    KVDataType: TypeAlias = Iterable[tuple[Any, Any]] | SupportsItems[Any, Any]
 
     RawDataType: TypeAlias = KVDataType | str | bytes
     StreamDataType: TypeAlias = SupportsRead[str | bytes]

--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -147,7 +147,7 @@ if sys.platform == "win32":
 
 
 def dict_to_sequence(
-    d: _t.SupportsItems | Iterable[tuple[Any, Any]],
+    d: _t.SupportsItems[Any, Any] | Iterable[tuple[Any, Any]],
 ) -> Iterable[tuple[Any, Any]]:
     """Returns an internal sequence dictionary update."""
 
@@ -371,10 +371,10 @@ def from_key_val_list(
 def to_key_val_list(value: None) -> None: ...
 @overload
 def to_key_val_list(
-    value: Mapping[_KT, _VT] | Iterable[tuple[_KT, _VT]],
+    value: _t.SupportsItems[_KT, _VT] | Iterable[tuple[_KT, _VT]],
 ) -> list[tuple[_KT, _VT]]: ...
 def to_key_val_list(
-    value: Mapping[_KT, _VT] | Iterable[tuple[_KT, _VT]] | None,
+    value: _t.SupportsItems[_KT, _VT] | Iterable[tuple[_KT, _VT]] | None,
 ) -> list[tuple[_KT, _VT]] | None:
     """Take an object and test to see if it can be represented as a
     dictionary. If it can be, return a list of tuples, e.g.,


### PR DESCRIPTION
This PR parameterizes our `SupportsItems` class similar to what's done in Typeshed. This avoids issues with our current `Mapping[..., ...]` typing for params described in https://github.com/psf/requests/issues/7271#issuecomment-4421158751. It also better maps to how we're representing our Iterable definitions on the same parameters.