### PR TITLE
Port bpo-39057 to Requests

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -851,9 +851,11 @@ def should_bypass_proxies(url: str, no_proxy: str | None) -> bool:
                 host_with_port += f":{parsed.port}"
 
             for host in no_proxy_hosts:
+                host = host.lstrip(".")
+                if hostname == host or host_with_port == host:
+                    return True
+                host = "." + host
                 if hostname.endswith(host) or host_with_port.endswith(host):
-                    # The URL does match something in no_proxy, so we don't want
-                    # to apply the proxies on this URL.
                     return True
 
     with set_environ("no_proxy", no_proxy_arg):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -844,6 +844,29 @@ def test_should_bypass_proxies_no_proxy(url, expected, monkeypatch):
     assert should_bypass_proxies(url, no_proxy=no_proxy) == expected
 
 
+@pytest.mark.parametrize(
+    "url, expected",
+    (
+        ("http://localhost/", True),
+        ("http://anotherdomain.com:8888/", True),
+        ("http://newdomain.com:1234/", True),
+        ("http://www.newdomain.com:1234/", True),
+        ("http://foo.d.o.t/", True),
+        ("http://d.o.t/", True),
+        ("http://prelocalhost/", False),
+        ("http://newdomain.com/", False),
+        ("http://newdomain.com:1235/", False),
+    ),
+)
+def test_should_bypass_proxies_no_proxy_domain_boundary(url, expected):
+    """Ensure no_proxy matching respects domain boundaries and does not
+    greedily match domains that merely endswith the no_proxy entry.
+    See CPython bpo-39057.
+    """
+    no_proxy = "localhost, anotherdomain.com, newdomain.com:1234, .d.o.t"
+    assert should_bypass_proxies(url, no_proxy=no_proxy) == expected
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Test only on Windows")
 @pytest.mark.parametrize(
     "url, expected, override",


### PR DESCRIPTION
This PR ports a [fix](https://bugs.python.org/issue39057) from CPython to constrain no_proxy behavior to domain boundaries. This was originally undefined behavior when Requests implemented `no_proxy` support but has since had bug fixes released in both CPython and Curl. We'll follow suit to conform with ecosystem expectations and resolve long standing issue #4795.