### PR TITLE
v2.34.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,19 +6,31 @@ dev
 
 - \[Short description of non-trivial change.\]
 
-2.34.0 (2026-05-??)
+2.34.0 (2026-05-11)
 -------------------
 
-**Improvements**
-* Requests 2.34.0 introduces inline types, replacing those provided by
+**Announcements**
+- Requests 2.34.0 introduces inline types, replacing those provided by
   typeshed. Public API types should be fully compatible with mypy, pyright,
-  and ty. (#7272)
-* Digest Auth hashing algorithms have added `usedforsecurity=False` to clarify
+  and ty. We believe types are comprehensive but if you find issues, please
+  report them to the pinned tracking issue. (#7272)
+
+**Improvements**
+- Digest Auth hashing algorithms have added `usedforsecurity=False` to clarify
   security considerations. (#7310)
+- Requests added support for Python 3.15 based on beta1. Downstream projects
+  should be able to start testing prior to its release in October. (#7422)
+- Requests added support for Python 3.14t. (#7419)
 
 **Bugfixes**
-* ``Response.history`` no longer contains a reference to itself, preventing
+- ``Response.history`` no longer contains a reference to itself, preventing
   accidental looping when traversing the history list. (#7328)
+- Requests no longer performs greedy matching on no_proxy domains. The
+  proxy_bypass implementation has been updated with CPython's fix from
+  bpo-39057. (#7427)
+- Requests no longer incorrectly strips duplicate leading slashes in
+  URI paths. This should address user issues with specific presigned
+  URLs. Note the full fix requires urllib3 2.7.0+. (#7315)
 
 
 2.33.1 (2026-03-30)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,7 +13,10 @@ dev
 - Requests 2.34.0 introduces inline types, replacing those provided by
   typeshed. Public API types should be fully compatible with mypy, pyright,
   and ty. We believe types are comprehensive but if you find issues, please
-  report them to the pinned tracking issue. (#7272)
+  report them to the pinned tracking issue.
+
+  Special thanks to @bastimeyer, @cthoyt, @edgarrmondragon, and @srittau for
+  helping review and test the types ahead of the release. (#7272)
 
 **Improvements**
 - Digest Auth hashing algorithms have added `usedforsecurity=False` to clarify

--- a/src/requests/__version__.py
+++ b/src/requests/__version__.py
@@ -5,7 +5,7 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.34.0.dev1"
+__version__ = "2.34.0"
 __build__ = 0x023400
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"


### PR DESCRIPTION
2.34.0 (2026-05-11)
-------------------

**Announcements**
- Requests 2.34.0 introduces inline types, replacing those provided by
  typeshed. Public API types should be fully compatible with mypy, pyright,
  and ty. **We believe types are comprehensive but if you find issues, please
  report them to the [pinned tracking issue](https://github.com/psf/requests/issues/7271).**

  Special thanks to @bastimeyer, @cthoyt, @edgarrmondragon, and @srittau for
  helping review and test the types ahead of the release. (#7272)

**Improvements**
- Digest Auth hashing algorithms have added `usedforsecurity=False` to clarify
  security considerations. (#7310)
- Requests added support for Python 3.15 based on beta1. Downstream projects
  should be able to start testing prior to its release in October. (#7422)
- Requests added support for Python 3.14t. (#7419)

**Bugfixes**
- ``Response.history`` no longer contains a reference to itself, preventing
  accidental looping when traversing the history list. (#7328)
- Requests no longer performs greedy matching on no_proxy domains. The
  proxy_bypass implementation has been updated with CPython's fix from
  bpo-39057. (#7427)
- Requests no longer incorrectly strips duplicate leading slashes in
  URI paths. This should address user issues with specific presigned
  URLs. Note the full fix requires urllib3 2.7.0+. (#7315)