### PR TITLE
Align Session.get parameters with requests.get

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -652,16 +652,23 @@ class Session(SessionRedirectMixin):
 
         return resp
 
-    def get(self, url: _t.UriType, **kwargs: Unpack[_t.GetKwargs]) -> Response:
+    def get(
+        self,
+        url: _t.UriType,
+        params: _t.ParamsType = None,
+        **kwargs: Unpack[_t.GetKwargs],
+    ) -> Response:
         r"""Sends a GET request. Returns :class:`Response` object.
 
         :param url: URL for the new :class:`Request` object.
+        :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype: requests.Response
         """
 
         kwargs.setdefault("allow_redirects", True)
-        return self.request("GET", url, **kwargs)
+        return self.request("GET", url, params=params, **kwargs)
 
     def options(self, url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:
         r"""Sends a OPTIONS request. Returns :class:`Response` object.


### PR DESCRIPTION
This PR makes our `params` support explicit on Session.get() to match what's already in `requests.get()`.