### PR TITLE
docs: clarify tuple-based timeouts in advanced usage

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1135,3 +1135,4 @@ coffee.
 
 .. _`wall clock`: https://wiki.php.net/rfc/max_execution_wall_time
 .. _`connect()`: https://linux.die.net/man/2/connect
+`n.. note:: When using a tuple for timeouts, it is structured as (connect_timeout, read_timeout).


### PR DESCRIPTION
Hello! While reviewing advanced usage for timeouts, I noticed the distinction between connection and read timeouts in a tuple could be slightly more explicit to avoid ReadTimeout confusion. This fast doc patch adds a brief clarification block. Happy to adjust wording!