### PR TITLE
Fix mutability issues with headers input types

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -109,8 +109,7 @@ if TYPE_CHECKING:
         bytes | str | Iterable[bytes | str] | SupportsRead[bytes | str] | None
     )
 
-    HeadersType: TypeAlias = CaseInsensitiveDict[str] | Mapping[str, str | bytes]
-    HeadersUpdateType: TypeAlias = Mapping[str, str | bytes | None]
+    HeadersType: TypeAlias = MutableMapping[str, str | bytes] | None
 
     CookiesType: TypeAlias = RequestsCookieJar | Mapping[str, str]
 
@@ -145,7 +144,7 @@ if TYPE_CHECKING:
     # TypedDicts for Unpack kwargs (PEP 692)
 
     class BaseRequestKwargs(TypedDict, total=False):
-        headers: Mapping[str, str | bytes] | None
+        headers: HeadersType
         cookies: RequestsCookieJar | CookieJar | dict[str, str] | None
         files: FilesType
         auth: AuthType

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -83,6 +83,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
     from http.cookiejar import CookieJar
 
     from typing_extensions import Self
@@ -310,7 +311,7 @@ class Request(RequestHooksMixin):
 
     method: str | None
     url: _t.UriType | None
-    headers: CaseInsensitiveDict[str] | Mapping[str, str | bytes] | None
+    headers: MutableMapping[str, str | bytes]
     files: _t.FilesType
     data: _t.DataType
     json: _t.JsonType
@@ -322,7 +323,7 @@ class Request(RequestHooksMixin):
         self,
         method: str | None = None,
         url: _t.UriType | None = None,
-        headers: Mapping[str, str | bytes] | None = None,
+        headers: _t.HeadersType = None,
         files: _t.FilesType = None,
         data: _t.DataType = None,
         params: _t.ParamsType = None,

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -560,7 +560,7 @@ class Session(SessionRedirectMixin):
         url: _t.UriType,
         params: _t.ParamsType = None,
         data: _t.DataType = None,
-        headers: Mapping[str, str | bytes] | None = None,
+        headers: _t.HeadersType = None,
         cookies: RequestsCookieJar | CookieJar | dict[str, str] | None = None,
         files: _t.FilesType = None,
         auth: _t.AuthType = None,


### PR DESCRIPTION
We already got a helpful email, lack of header mutability in the typing contract is creating friction for some code bases. I think we'd started to go down this route but it got lost in the cleanup. I'm going to stage this as a known issue for a 2.34.1 but we'll likely wait a day or two before cutting another release to see what other feedback we missed.