### PR TITLE
Update JsonType containers to read-based collections

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -9,7 +9,7 @@ by external code.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -139,7 +139,13 @@ if TYPE_CHECKING:
     VerifyType: TypeAlias = bool | str
     CertType: TypeAlias = str | tuple[str, str] | None
     JsonType: TypeAlias = (
-        None | bool | int | float | str | list["JsonType"] | Mapping[str, "JsonType"]
+        None
+        | bool
+        | int
+        | float
+        | str
+        | Sequence["JsonType"]
+        | Mapping[str, "JsonType"]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)

--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -139,7 +139,7 @@ if TYPE_CHECKING:
     VerifyType: TypeAlias = bool | str
     CertType: TypeAlias = str | tuple[str, str] | None
     JsonType: TypeAlias = (
-        None | bool | int | float | str | list["JsonType"] | dict[str, "JsonType"]
+        None | bool | int | float | str | list["JsonType"] | Mapping[str, "JsonType"]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)


### PR DESCRIPTION
The current definition for `JsonType` is constrained to `dict` for map-like objects but that introduces issues when input is explicitly typed.

The type checker is able to infer typing correctly with:

```python
payload = {"test": "test"}
r = requests.post(url, json=payload)
```

but not
```python
payload: dict[str, str] = {"test": "test"}
r = requests.post(url, json=payload)
```

This is due to the varied Value typing on `JsonType` and the mutability of `dict`. Changing it to `Mapping` which only exposes read interfacea allows us to check covariant value types. This works because the `json` input is never touched. It's taken from input and passed directly to `json.dumps` resulting in bytes. There's no access point in the pipeline to modify it later.

We're going to start with this expansion of the type to see if it works broadly. The goal is to avoid `Any` for JsonType if at all possible.