### PR TITLE
Constrain Response.reason to str

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -741,7 +741,7 @@ class Response:
     url: str
     encoding: str | None
     history: list[Response]
-    reason: str | None
+    reason: str
     cookies: RequestsCookieJar
     elapsed: datetime.timedelta
     request: PreparedRequest
@@ -790,7 +790,7 @@ class Response:
         self.history = []
 
         #: Textual reason of responded HTTP Status, e.g. "Not Found" or "OK".
-        self.reason = None
+        self.reason = None  # type: ignore[assignment]
 
         #: A CookieJar of Cookies the server sent back.
         self.cookies = cookiejar_from_dict({})


### PR DESCRIPTION
Similar to how we moved `status_code` to `int` to avoid needing to do `None` checks before doing `status_code<400` comparisons, we'll do the same ignore for `reason`.

While `reason` is explicitly optional, in practice, urllib3 will always supply an empty str (`''`) when it's not present in the status line. This is an ergonomics change where the types may not represent all possible values, but a Response initialized by Requests will always populate the field. Anyone instantiating Responses manually will need to take considerations for their construction.