### PR TITLE
fix: Inline annotations in 2.34.0 cause mypy error for Request js

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -139,7 +139,7 @@ if TYPE_CHECKING:
     VerifyType: TypeAlias = bool | str
     CertType: TypeAlias = str | tuple[str, str] | None
     JsonType: TypeAlias = (
-        None | bool | int | float | str | list["JsonType"] | dict[str, "JsonType"]
+        None | bool | int | float | str | list["JsonType"] | Mapping[str, "JsonType"]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -313,7 +313,7 @@ class Request(RequestHooksMixin):
     headers: CaseInsensitiveDict[str] | Mapping[str, str | bytes] | None
     files: _t.FilesType
     data: _t.DataType
-    json: _t.JsonType
+    json: _t.JsonType | None
     params: _t.ParamsType
     auth: _t.AuthType
     cookies: RequestsCookieJar | CookieJar | dict[str, str] | None


### PR DESCRIPTION
Automated fix for #7434

> Generated by Dark Factory
> Run ID: `20260513T002337`
> Triage score: 0.75

**Please review carefully before merging.**
