### PR TITLE
docs: clarify Session.request verify default

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -606,8 +606,9 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
-            ``False``, requests will accept any TLS certificate presented by
+            to a CA bundle to use. When left as ``None`` (the default), the value of
+            :attr:`Session.verify` is used, which itself defaults to ``True``. When
+            set to ``False``, requests will accept any TLS certificate presented by
             the server, and will ignore hostname mismatches and/or expired
             certificates, which will make your application vulnerable to
             man-in-the-middle (MitM) attacks. Setting verify to ``False``


### PR DESCRIPTION
Clarifies the documented default for the Session.request verify parameter. Documentation-only change.