### PR TITLE
Move Request.headers back to Mapping

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -109,7 +109,7 @@ if TYPE_CHECKING:
         bytes | str | Iterable[bytes | str] | SupportsRead[bytes | str] | None
     )
 
-    HeadersType: TypeAlias = MutableMapping[str, str | bytes] | None
+    HeadersType: TypeAlias = Mapping[str, str | bytes] | None
 
     CookiesType: TypeAlias = RequestsCookieJar | Mapping[str, str]
 

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -83,7 +83,6 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
     from http.cookiejar import CookieJar
 
     from typing_extensions import Self
@@ -311,7 +310,7 @@ class Request(RequestHooksMixin):
 
     method: str | None
     url: _t.UriType | None
-    headers: MutableMapping[str, str | bytes]
+    headers: Mapping[str, str | bytes]
     files: _t.FilesType
     data: _t.DataType
     json: _t.JsonType


### PR DESCRIPTION
This PR partially reverts #7431, moving it back to `Mapping` instead of `MutableMapping`. While we typically expect the input to be mutable, dicts inferred to be `dict[str, str]` at creation are incompatible with `MutableMapping[str, str | bytes]` even though they may later have a `bytes` value added.

This typing decision is a tradeoff of supporting `update()` calls on `Request.headers` and requiring all users to type their input as `dict[str, str | bytes]`. The latter is significantly more invasive and common for current codebases.