### PR TITLE
docs: Clarify `verify` parameter defaults and behavior

### DIFF
--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -50,7 +50,8 @@ def request(
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``.
+            to a CA bundle to use. Defaults to ``True``. Passing a boolean value will also
+            ignore any custom CA bundle set globally.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
     :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
     :return: :class:`Response <Response>` object

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -606,7 +606,9 @@ class Session(SessionRedirectMixin):
             content. Defaults to ``False``.
         :param verify: (optional) Either a boolean, in which case it controls whether we verify
             the server's TLS certificate, or a string, in which case it must be a path
-            to a CA bundle to use. Defaults to ``True``. When set to
+            to a CA bundle to use. Defaults to ``None``, in which case the value from
+            ``self.verify`` is used. Passing a boolean value will also reset the CA bundle
+            to the default. When set to
             ``False``, requests will accept any TLS certificate presented by
             the server, and will ignore hostname mismatches and/or expired
             certificates, which will make your application vulnerable to


### PR DESCRIPTION
Fixes psf/requests#7399

This updates the docstrings in `requests.request` and `requests.Session.request` to accurately reflect the default parameter value (`None` in `Session.request()`) and clarifies that passing a boolean overrides custom CA bundle logic.