### PR TITLE
fix(digest-auth): support non-latin characters in username and password

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -166,6 +166,19 @@ class HTTPDigestAuth(AuthBase):
         opaque = self._thread_local.chal.get("opaque")
         hash_utf8 = None
 
+        # Normalize username and password to strings. If they're passed as bytes
+        # (e.g., to support non-latin characters), decode them using UTF-8.
+        # Using bytes in f-strings or string formatting would produce incorrect
+        # output like ``b'...'`` in both the hash calculation and the header.
+        if isinstance(self.username, bytes):
+            username = self.username.decode("utf-8")
+        else:
+            username = self.username
+        if isinstance(self.password, bytes):
+            password = self.password.decode("utf-8")
+        else:
+            password = self.password
+
         if algorithm is None:
             _algorithm = "MD5"
         else:
@@ -218,7 +231,7 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -251,7 +264,7 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX should the partial digests be encoded too?
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{username}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
## Description

HTTPDigestAuth fails when username or password contain non-latin characters (e.g. `'Ondřej'`, `'Сергей_Ласточкин'`).

### Root Cause

In `build_digest_header()`, `self.username` and `self.password` are used directly in f-strings for both the hash calculation (A1) and the HTTP header value. When users pass `bytes` as a workaround for non-ASCII support:

```python
HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko')
```

The f-string interpolation produces `b'Ond\xc5\x99ej'` (the bytes repr) instead of the actual decoded string, resulting in incorrect hashes and malformed headers like:

```
Digest username="b'Ond\xc5\x99ej'"
```

### Fix

Normalize `username` and `password` to `str` at the start of `build_digest_header()` — if they're `bytes`, decode them using UTF-8. The normalized string variables are then used consistently for both the digest hash computation and the `Authorization` header.

Fixes #6102
