### PR TITLE
Fix JsonType to accept Mapping[str, Any] instead of recursive Mapping[str, "JsonType"]

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -144,7 +144,7 @@ if TYPE_CHECKING:
         | float
         | str
         | Sequence["JsonType"]
-        | Mapping[str, "JsonType"]
+        | Mapping[str, Any]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)


### PR DESCRIPTION
Fixes #7443

## Problem
The recursive `JsonType` definition used `Mapping[str, "JsonType"]`, which causes mypy to reject valid dict subtypes like `dict[str, object]` or `dict[str, Collection[str]]` due to mypy's invariance handling of recursive Mapping types.

## Reproduction
```python
def fn(d: dict[str, str]) -> None:
    j = {"foo": d, "bar": "hi"}
    requests.post("https://example.com", json=j)  # mypy error
```

## Fix
Replaced the recursive `Mapping[str, "JsonType"]` with `Mapping[str, Any]`. This matches how Python's `json.dumps` actually accepts any serializable value. `Any` is the standard pattern used by CPython's `json` module stubs for the same purpose.

## Testing
- 407 relevant tests pass (all pre-existing failures are network-dependent)
- No new mypy errors introduced
- `pyright` and `ty` continue to work correctly
