### PR TITLE
Handle invalid CaseInsensitiveDict comparisons

### DIFF
--- a/src/requests/structures.py
+++ b/src/requests/structures.py
@@ -79,7 +79,10 @@ class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Mapping):
-            other_dict: CaseInsensitiveDict[Any] = CaseInsensitiveDict(other)  # type: ignore[reportUnknownArgumentType]
+            try:
+                other_dict: CaseInsensitiveDict[Any] = CaseInsensitiveDict(other)  # type: ignore[reportUnknownArgumentType]
+            except (AttributeError, TypeError):
+                return False
         else:
             return NotImplemented
         # Compare insensitively

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -45,6 +45,7 @@ class TestCaseInsensitiveDict:
             ({"AccePT": "application/json"}, True),
             ({}, False),
             (None, False),
+            ({1: "application/json"}, False),
         ),
     )
     def test_instance_equality(self, other, result):


### PR DESCRIPTION
Comparing a CaseInsensitiveDict with a mapping that contains non-string keys can currently raise while normalizing the other mapping.

This treats invalid mapping-like comparison inputs as not equal and adds a focused regression case.

Verification:
- uv run --with-requirements requirements-dev.txt python -m pytest tests/test_structures.py -q