### PR TITLE
Fix model class runtime type hints

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -181,3 +181,22 @@ if TYPE_CHECKING:
 
         params: ParamsType
         json: JsonType
+else:
+    UriType: TypeAlias = str | bytes
+    ParamsType: TypeAlias = Any
+    KVDataType: TypeAlias = Any
+    RawDataType: TypeAlias = Any
+    StreamDataType: TypeAlias = SupportsRead[str | bytes]
+    EncodableDataType: TypeAlias = Any
+    DataType: TypeAlias = Any
+    BodyType: TypeAlias = Any
+    HeadersType: TypeAlias = Mapping[str, str | bytes] | None
+    CookiesType: TypeAlias = Any
+    FilesType: TypeAlias = Any
+    AuthType: TypeAlias = Any
+    TimeoutType: TypeAlias = float | tuple[float | None, float | None] | None
+    ProxiesType: TypeAlias = MutableMapping[str, str]
+    HooksType: TypeAlias = dict[str, list[HookType]] | None
+    VerifyType: TypeAlias = bool | str
+    CertType: TypeAlias = str | tuple[str, str] | None
+    JsonType: TypeAlias = Any

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -14,6 +14,7 @@ import datetime
 # such as in Embedded Python. See https://github.com/psf/requests/issues/3578.
 import encodings.idna  # noqa: F401  # type: ignore[reportUnusedImport]
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping
+from http.cookiejar import CookieJar
 from io import UnsupportedOperation
 from typing import (
     TYPE_CHECKING,
@@ -35,6 +36,7 @@ from urllib3.fields import RequestField
 from urllib3.filepost import encode_multipart_formdata
 from urllib3.util import parse_url
 
+from . import _types as _t
 from ._internal_utils import to_native_string, unicode_is_ascii
 from ._types import SupportsRead as _SupportsRead
 from .auth import HTTPBasicAuth
@@ -50,6 +52,7 @@ from .compat import (
 )
 from .compat import json as complexjson
 from .cookies import (
+    RequestsCookieJar,
     _copy_cookie_jar,  # type: ignore[reportPrivateUsage]
     cookiejar_from_dict,
     get_cookie_header,
@@ -83,13 +86,11 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from http.cookiejar import CookieJar
-
     from typing_extensions import Self
 
-    from . import _types as _t
     from .adapters import HTTPAdapter
-    from .cookies import RequestsCookieJar
+else:
+    HTTPAdapter = Any
 
 #: The set of HTTP status codes that indicate an automatically
 #: processable redirect.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -9,6 +9,7 @@ import pickle
 import re
 import tempfile
 import threading
+import typing
 import warnings
 from unittest import mock
 
@@ -79,6 +80,21 @@ try:
     HAS_PYOPENSSL = True
 except AttributeError:
     HAS_PYOPENSSL = False
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "expected_hint"),
+    (
+        (requests.Request, "cookies"),
+        (requests.PreparedRequest, "_cookies"),
+        (requests.Response, "cookies"),
+    ),
+)
+def test_model_class_type_hints_resolve(
+    model_cls: type[object], expected_hint: str
+) -> None:
+    hints = typing.get_type_hints(model_cls)
+    assert expected_hint in hints
 
 
 class TestRequests:


### PR DESCRIPTION
## Summary

Fixes `typing.get_type_hints()` for the inline-typed model classes by making the annotation-only names resolvable at runtime.

This keeps the new annotations usable for `requests.Request`, `requests.PreparedRequest`, and `requests.Response` without importing adapters into `models.py` at runtime.

Fixes #7456

## Test plan

- `PYTHONPATH=src python3 -m pytest -q tests/test_requests.py::test_model_class_type_hints_resolve`
- `uv run --group test pytest -q tests/test_requests.py`
- `uv run --group typecheck pyright src/requests`
- `ruff check src/requests/_types.py src/requests/models.py tests/test_requests.py`
- `ruff format --check src/requests/_types.py src/requests/models.py tests/test_requests.py`
- `git diff --check HEAD~1..HEAD`
