### PR TITLE
docs: indent continuation line in Session.get :param params:

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -662,7 +662,7 @@ class Session(SessionRedirectMixin):
 
         :param url: URL for the new :class:`Request` object.
         :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the query string for the :class:`Request`.
+            in the query string for the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype: requests.Response
         """


### PR DESCRIPTION
Aims at fixing #7459