### PR TITLE
Document pickling custom adapters

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -993,6 +993,18 @@ The mount call registers a specific instance of a Transport Adapter to a
 prefix. Once mounted, any HTTP request made using that session whose URL starts
 with the given prefix will use the given Transport Adapter.
 
+If a custom adapter stores additional instance attributes that must survive
+pickling, extend the inherited ``__attrs__`` list with their names. Requests
+uses this list when serializing :class:`HTTPAdapter
+<requests.adapters.HTTPAdapter>` instances, so subclass-only state omitted
+from it will not be restored after unpickling::
+
+    class MyAdapter(HTTPAdapter):
+        __attrs__ = HTTPAdapter.__attrs__ + ['my_option']
+
+Use the same pattern for custom :class:`Session <requests.Session>`
+subclasses that add pickle-relevant state.
+
 .. note:: The adapter will be chosen based on a longest prefix match. Be mindful
    prefixes such as ``http://localhost`` will also match ``http://localhost.other.com``
    or ``http://localhost@other.com``. It's recommended to terminate full hostnames with a ``/``.


### PR DESCRIPTION
## Summary
- document how custom transport adapters should extend `__attrs__` when they store pickle-relevant state
- add a small example and note that the same pattern applies to custom `Session` subclasses

## Why
Issue #6255 points out that custom adapter attributes omitted from `__attrs__` are not restored after pickling. The advanced usage guide already explains how to build custom adapters, so documenting the serialization contract there helps prevent examples that appear to work until adapters are copied or pickled by downstream frameworks.

## Validation
- Not run locally
- Relying on static review of the documentation diff and the repository's remote CI.