### PR TITLE
fix(sessions): session.verify=False not overridden by REQUESTS_CA_BUNDLE env var

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -852,7 +852,10 @@ class Session(SessionRedirectMixin):
 
             # Look for requests environment configuration
             # and be compatible with cURL.
-            if verify is True or verify is None:
+            # Do not override an explicit session-level verify=False — the
+            # user has intentionally disabled SSL verification and the env
+            # CA bundle must not silently re-enable it (#3829).
+            if (verify is True or verify is None) and self.verify is not False:
                 verify = (
                     os.environ.get("REQUESTS_CA_BUNDLE")
                     or os.environ.get("CURL_CA_BUNDLE")


### PR DESCRIPTION
Fixes #3829.

## Summary

When `session.verify = False`, calling `session.get(url)` still performed SSL certificate verification if `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` was set in the environment. The env CA bundle silently overrode the explicit opt-out.

## Root cause

`merge_environment_settings` receives `verify=None` (the parameter default) when the caller did not pass an explicit per-request `verify`. The guard:

```python
if verify is True or verify is None:
    verify = os.environ.get("REQUESTS_CA_BUNDLE") or ...
```

fires, replacing `None` with the CA bundle path. The later `merge_setting(ca_path, session.verify=False)` then returns the CA bundle path because `merge_setting` only defers to the session value when the request value is `None`.

## Fix

Add `and self.verify is not False` so the env CA bundle is never applied when the session has explicitly disabled verification:

```python
if (verify is True or verify is None) and self.verify is not False:
    verify = os.environ.get("REQUESTS_CA_BUNDLE") or ...
```

Per-request `verify=False` was already handled correctly (it arrives as `False`, bypassing the condition). This fix closes the session-level gap.

## Behaviour

| Before | After |
|--------|-------|
| `session.verify=False` + `REQUESTS_CA_BUNDLE=/path/to/ca` → verifies with CA | `session.verify=False` + `REQUESTS_CA_BUNDLE=/path/to/ca` → skips verification ✓ |
| `session.verify=True` + `REQUESTS_CA_BUNDLE=/path/to/ca` → verifies with CA | unchanged ✓ |
| `session.verify='/path'` + `REQUESTS_CA_BUNDLE=...` → verifies with `/path` | unchanged ✓ |
| per-request `verify=False` + env CA | unchanged (already worked) ✓ |