### PR TITLE
fix: broaden JsonType to accept Sequence[Any] and Mapping[str, Any]

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -143,8 +143,8 @@ if TYPE_CHECKING:
         | int
         | float
         | str
-        | Sequence["JsonType"]
-        | Mapping[str, "JsonType"]
+        | Sequence[Any]
+        | Mapping[str, Any]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)


### PR DESCRIPTION
## Problem

The `JsonType` alias in `_types.py` uses a recursive definition:

```python
JsonType: TypeAlias = (
    None | bool | int | float | str
    | Sequence["JsonType"]
    | Mapping[str, "JsonType"]
)
```

This causes mypy to reject valid JSON arguments. For example:

```python
def fn(d: dict[str, str]) -> None:
    j = {"foo": d, "bar": "hi"}
    requests.post("https://example.com", json=j)  # error
```

mypy reports:
```
Argument "json" to "post" has incompatible type "dict[str, Collection[str]]"; expected "JsonType"
Argument "json" to "post" has incompatible type "dict[str, object]"; expected "JsonType"
```

The root cause is that mypy cannot resolve the recursive constraint — `Collection[str]` is not `Sequence[JsonType]` (wrong abstract base), and mypy's structural check on the recursive union fails for non-literal types passed via variables.

## Fix

Replace the recursive inner types with `Any`:

```python
JsonType: TypeAlias = (
    None | bool | int | float | str
    | Sequence[Any]
    | Mapping[str, Any]
)
```

This preserves the top-level shape check (the argument must be a primitive, sequence, or str-keyed mapping) while accepting any values inside — which matches what `json.dumps()` actually accepts at runtime.

## Verification

Ran mypy 2.1.0 against the exact reproduction case from the issue — no errors with the fix applied.

Fixes #7443