### PR TITLE
Fix request cookies set to None

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -111,7 +111,7 @@ if TYPE_CHECKING:
 
     HeadersType: TypeAlias = Mapping[str, str | bytes] | None
 
-    CookiesType: TypeAlias = RequestsCookieJar | Mapping[str, str]
+    CookiesType: TypeAlias = RequestsCookieJar | Mapping[str, str | None]
 
     # Building blocks for FilesType
     _FileName: TypeAlias = str | None

--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import calendar
 import copy
 import time
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
 from http.cookiejar import Cookie, CookieJar, CookiePolicy
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
@@ -562,7 +562,7 @@ _CookieJarT = TypeVar("_CookieJarT", bound=CookieJar)
 
 @overload
 def cookiejar_from_dict(
-    cookie_dict: dict[str, str] | None,
+    cookie_dict: Mapping[str, str | None] | None,
     cookiejar: None = None,
     overwrite: bool = True,
 ) -> RequestsCookieJar: ...
@@ -570,14 +570,14 @@ def cookiejar_from_dict(
 
 @overload
 def cookiejar_from_dict(
-    cookie_dict: dict[str, str] | None,
+    cookie_dict: Mapping[str, str | None] | None,
     cookiejar: _CookieJarT,
     overwrite: bool = True,
 ) -> _CookieJarT: ...
 
 
 def cookiejar_from_dict(
-    cookie_dict: dict[str, str] | None,
+    cookie_dict: Mapping[str, str | None] | None,
     cookiejar: CookieJar | None = None,
     overwrite: bool = True,
 ) -> CookieJar:
@@ -594,15 +594,17 @@ def cookiejar_from_dict(
 
     if cookie_dict is not None:
         names_from_jar = [cookie.name for cookie in cookiejar]
-        for name in cookie_dict:
-            if overwrite or (name not in names_from_jar):
-                cookiejar.set_cookie(create_cookie(name, cookie_dict[name]))
+        for name, value in cookie_dict.items():
+            if value is None:
+                remove_cookie_by_name(cookiejar, name)
+            elif overwrite or (name not in names_from_jar):
+                cookiejar.set_cookie(create_cookie(name, value))
 
     return cookiejar
 
 
 def merge_cookies(
-    cookiejar: CookieJar, cookies: dict[str, str] | CookieJar | None
+    cookiejar: CookieJar, cookies: Mapping[str, str | None] | CookieJar | None
 ) -> CookieJar:
     """Add cookies to cookiejar and returns a merged CookieJar.
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -523,14 +523,14 @@ class Session(SessionRedirectMixin):
 
         cookies = request.cookies or {}
 
-        # Bootstrap CookieJar.
-        if not isinstance(cookies, cookielib.CookieJar):
-            cookies = cookiejar_from_dict(cookies)
-
         # Merge with session cookies
-        merged_cookies = merge_cookies(
-            merge_cookies(RequestsCookieJar(), self.cookies), cookies
-        )
+        merged_cookies = merge_cookies(RequestsCookieJar(), self.cookies)
+        if isinstance(cookies, cookielib.CookieJar):
+            merged_cookies = merge_cookies(merged_cookies, cookies)
+        else:
+            merged_cookies = cookiejar_from_dict(
+                cookies, cookiejar=merged_cookies, overwrite=True
+            )
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -422,6 +422,18 @@ class TestRequests:
         # Session cookie should not be modified
         assert s.cookies["foo"] == "bar"
 
+    def test_request_cookie_none_removes_session_cookie(self):
+        s = requests.session()
+        s.cookies["foo"] = "bar"
+        req = requests.Request(
+            "GET", "http://example.com/", cookies={"foo": None, "baz": "qux"}
+        )
+
+        prepared = s.prepare_request(req)
+
+        assert prepared.headers["Cookie"] == "baz=qux"
+        assert s.cookies["foo"] == "bar"
+
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()
         s.get(httpbin("cookies"), cookies={"foo": "baz"})


### PR DESCRIPTION
Fixes #2716.

Method-level cookies with `None` values are meant to remove matching session cookies for that request. They were being converted into Cookie objects before the session merge, which could produce headers like `foo; baz=qux`. This keeps dict cookie handling at the merge point so `None` can remove the inherited cookie while normal request-level cookie overrides still work.

Tests run:
- `python -m pytest tests/test_requests.py::TestRequests::test_request_cookie_none_removes_session_cookie -q`
- `python -m pytest tests/test_requests.py::TestRequests::test_request_cookie_none_removes_session_cookie tests/test_requests.py::TestRequests::test_request_cookie_overrides_session_cookie tests/test_requests.py::TestRequests::test_request_cookies_not_persisted tests/test_requests.py::TestRequests::test_param_cookiejar_works tests/test_requests.py::TestRequests::test_generic_cookiejar_works -q`
- `python -m pytest tests/test_requests.py -k cookie -q`
- `python -m ruff check src/requests/_types.py src/requests/cookies.py src/requests/sessions.py tests/test_requests.py`
- `python -m ruff format --check src/requests/_types.py src/requests/cookies.py src/requests/sessions.py tests/test_requests.py`
- `python -m pyright src/requests/`
- `git diff --check`