### PR TITLE
docs: improve hook documentation comment

### DIFF
--- a/src/requests/hooks.py
+++ b/src/requests/hooks.py
@@ -26,7 +26,8 @@ def default_hooks() -> dict[str, list[_t.HookType]]:
     return {event: [] for event in HOOKS}
 
 
-# TODO: response is the only one
+# NOTE: Currently, "response" is the only available hook.
+# Additional hooks may be added in future versions.
 
 
 def dispatch_hook(


### PR DESCRIPTION
## Summary

Replaces the vague TODO comment in hooks.py with a clearer NOTE that explains the current state of available hooks.

## Changes

- Changed "# TODO: response is the only one" to a more descriptive comment explaining that "response" is currently the only available hook

This makes the code more maintainable and clearer for new contributors.