### PR TITLE
Fix mypy false positives for json= parameter

### DIFF
--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -9,7 +9,7 @@ by external code.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -137,14 +137,21 @@ if TYPE_CHECKING:
     HooksType: TypeAlias = dict[str, list[HookType]] | None
     VerifyType: TypeAlias = bool | str
     CertType: TypeAlias = str | tuple[str, str] | None
+    # JsonType uses Any for container values to avoid mypy false positives when
+    # users assign a dict/list to a variable before passing it as json=.
+    # Mypy cannot properly narrow recursive type aliases for intermediate
+    # variables (e.g. dict[str, str] is not accepted as Mapping[str, JsonType]
+    # even though it is structurally valid). Using Any in the value position
+    # preserves useful top-level type information while staying compatible with
+    # all major type checkers (mypy, pyright, ty). See issue #7443.
     JsonType: TypeAlias = (
         None
         | bool
         | int
         | float
         | str
-        | Sequence["JsonType"]
-        | Mapping[str, "JsonType"]
+        | list[Any]
+        | dict[str, Any]
     )
 
     # TypedDicts for Unpack kwargs (PEP 692)


### PR DESCRIPTION
## Summary
- Fixes #7443
- Replaces recursive `Sequence["JsonType"]` / `Mapping[str, "JsonType"]` with `list[Any]` / `dict[str, Any]` in the `JsonType` alias
- mypy cannot prove that `dict[str, str]` satisfies `Mapping[str, JsonType]` when `JsonType` is a recursive union — pyright and ty handle this fine, but mypy (the most popular checker) emits false positives when users assign JSON dicts to intermediate variables

## Rationale
The new definition still prevents obviously wrong types (bytes, file handles, etc.) from being passed as `json=`, while accepting any `dict[str, ...]` or `list[...]` — mirroring what `json.dumps()` accepts at runtime. This matches the pragmatic approach discussed in the issue thread.

## Test plan
- [x] Verify the reproduction case from the issue no longer triggers mypy errors
- [x] Confirm pyright and ty continue to pass
- [ ] Existing test suite passes (no runtime behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)