### PR TITLE
Fix digest auth uri field dropping semicolons in URL path

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -17,7 +17,7 @@ from base64 import b64encode
 from typing import TYPE_CHECKING, Any, Final, cast, overload
 
 from ._internal_utils import to_native_string
-from .compat import basestring, str, urlparse
+from .compat import basestring, str, urlparse, urlsplit
 from .cookies import extract_cookies_to_jar
 from .utils import parse_dict_header
 
@@ -212,8 +212,11 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX not implemented yet
         entdig = None
-        p_parsed = urlparse(url)
+        p_parsed = urlsplit(url)
         #: path is request-uri defined in RFC 2616 which should not be empty
+        #: urlsplit is used instead of urlparse so that semicolons in the path
+        #: are not incorrectly treated as path-parameter delimiters (RFC 1808),
+        #: which would strip them into .params and corrupt the digest uri field.
         path = p_parsed.path or "/"
         if p_parsed.query:
             path += f"?{p_parsed.query}"


### PR DESCRIPTION
## Summary
- Fixes #6990
- Replaces `urlparse` with `urlsplit` in `HTTPDigestAuth.build_digest_header()`
- `urlparse` treats `;` as a path-parameter delimiter (RFC 1808), stripping everything after the first semicolon into `.params` — this corrupts the digest `uri` field. `urlsplit` preserves the full path including semicolons.

## Example
URL: `/releases/uuid1;uuid2?fmt=json`
- **Before:** `uri="/releases/uuid1?fmt=json"` (uuid2 lost)
- **After:** `uri="/releases/uuid1;uuid2?fmt=json"` (correct)

## Test plan
- [x] Verified the reproduction case from the issue produces the correct `uri` field
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)