### PR TITLE
Fix incorrect Content-Length with io.StringIO body

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -166,6 +166,15 @@ def super_len(o: Any) -> int:
         # of latin-1 (iso-8859-1) like http.client.
         o = o.encode("utf-8")
 
+    if not is_urllib3_1 and isinstance(o, io.StringIO):
+        # StringIO seek/tell counts characters, not bytes.  Since urllib3 2.x
+        # encodes StringIO content as UTF-8 when sending, Content-Length must
+        # reflect the UTF-8 byte count, not the character count.
+        current_position = o.tell()
+        remaining = o.read()
+        o.seek(current_position)
+        return len(remaining.encode("utf-8"))
+
     if hasattr(o, "__len__"):
         total_length = len(o)
 


### PR DESCRIPTION
## Summary
- Fixes #6917
- Adds an early-return branch in `super_len()` for `io.StringIO` that reads the content, encodes to UTF-8, and measures byte length
- Previously, `super_len` used `seek`/`tell` for StringIO, which returns character count — wrong for multi-byte UTF-8 characters (e.g., "💩" is 1 char but 4 bytes)
- This mirrors the existing fix for bare `str` from #6586

## Example
```python
data = io.StringIO("💩")
# Before: Content-Length: 1 (character count)
# After:  Content-Length: 4 (UTF-8 byte count)
```

## Test plan
- [x] All 16 existing `TestSuperLen` tests pass
- [x] Verified correct byte counts for ASCII, emoji, mixed strings, and partially-read streams
- [x] Stream position is preserved after measurement

🤖 Generated with [Claude Code](https://claude.com/claude-code)