### PR TITLE
Fix escaped quotes being stripped from cookie values

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -380,12 +380,6 @@ class RequestsCookieJar(CookieJar, MutableMapping[str, str | None]):  # type: ig
         remove_cookie_by_name(self, name)
 
     def set_cookie(self, cookie: Cookie, *args: Any, **kwargs: Any) -> None:
-        if (
-            (value := cookie.value) is not None
-            and value.startswith('"')
-            and value.endswith('"')
-        ):
-            cookie.value = value.replace('\\"', "")
         return super().set_cookie(cookie, *args, **kwargs)
 
     def update(  # type: ignore[override]


### PR DESCRIPTION
## Summary
- Fixes #6890
- Removes the broken `replace('\"', "")` logic in `RequestsCookieJar.set_cookie()` that stripped all escaped quotes from cookie values
- The code was intended to clean up quoted cookie values but instead corrupted legitimate data (e.g., `"159\"687"` became `"159687"`)

## Root cause
```python
# Before (cookies.py lines 349-356):
if (
    hasattr(cookie.value, "startswith")
    and cookie.value.startswith('"')
    and cookie.value.endswith('"')
):
    cookie.value = cookie.value.replace('\\"', "")  # BUG: destroys escaped quotes
```

The underlying `http.cookiejar.CookieJar` handles cookie values correctly without this mangling. While RFC 6265 says cookie values shouldn't contain escaped characters, many real-world servers use them, and clients should preserve values verbatim.

## Test plan
- [x] `"159\"687"` round-trips correctly through `set_cookie`
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)