### PR TITLE
fix: check callable before tuple in prepare_auth

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -678,11 +678,12 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             auth = url_auth if any(url_auth) else None
 
         if auth:
-            if isinstance(auth, tuple) and len(auth) == 2:  # type: ignore[arg-type]  # pyright widens tuple from Callable in AuthType
+            if callable(auth):
+                auth_handler = cast("Callable[..., PreparedRequest]", auth)
+            elif isinstance(auth, tuple) and len(auth) == 2:  # type: ignore[arg-type]  # pyright widens tuple from Callable in AuthType
                 # special-case basic HTTP auth
                 auth_handler = HTTPBasicAuth(*auth)  # type: ignore[arg-type]  # pyright widens tuple from Callable in AuthType
             else:
-                # TODO: can be fixed by flipping the conditionals
                 auth_handler = cast("Callable[..., PreparedRequest]", auth)
 
             # Allow auth to make its changes.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2124,6 +2124,34 @@ class TestRequests:
         assert isinstance(s, builtin_str)
         assert s == auth_str
 
+    def test_callable_namedtuple_auth_uses_call_not_tuple_branch(self):
+        """A callable that is also a 2-tuple subclass (e.g. namedtuple) must
+        have its __call__ invoked, not be silently downgraded to HTTPBasicAuth.
+
+        Regression: prepare_auth previously checked isinstance(auth, tuple)
+        before callable(auth), so any AuthBase subclass that also inherited
+        from a 2-field namedtuple would have its __call__ bypassed and its
+        fields extracted as Basic Auth credentials instead.
+        """
+        from collections import namedtuple
+        from requests.auth import AuthBase
+
+        _Base = namedtuple("_TokenAuth", ["token", "scheme"])
+
+        class TokenAuth(_Base, AuthBase):
+            def __call__(self, r):
+                r.headers["Authorization"] = f"{self.scheme} {self.token}"
+                return r
+
+        auth = TokenAuth(token="my-secret", scheme="Bearer")
+        assert isinstance(auth, tuple)  # confirm the ambiguous case
+        assert callable(auth)
+
+        p = requests.Request("GET", "http://example.com", auth=auth).prepare()
+
+        assert p.headers["Authorization"] == "Bearer my-secret"
+        assert not p.headers["Authorization"].startswith("Basic")
+
     def test_requests_history_is_saved(self, httpbin):
         r = requests.get(httpbin("redirect/5"))
         total = r.history[-1].history


### PR DESCRIPTION
## Summary

`prepare_auth` currently checks `isinstance(auth, tuple)` before `callable(auth)`. Any auth object that is both a 2-element tuple subclass **and** callable — for example an `AuthBase` subclass that also inherits from a 2-field `namedtuple` — silently takes the tuple branch. Its `__call__` is never invoked; instead its fields are extracted and passed to `HTTPBasicAuth`, bypassing the custom handler entirely.

This PR closes the existing TODO:

```python
# TODO: can be fixed by flipping the conditionals
```

## What changes

**`src/requests/models.py`** — flip the conditional order:

```python
# Before
if isinstance(auth, tuple) and len(auth) == 2:
    auth_handler = HTTPBasicAuth(*auth)
else:
    # TODO: can be fixed by flipping the conditionals
    auth_handler = cast(...)

# After
if callable(auth):
    auth_handler = cast(...)
elif isinstance(auth, tuple) and len(auth) == 2:
    auth_handler = HTTPBasicAuth(*auth)
else:
    auth_handler = cast(...)
```

**`tests/test_requests.py`** — regression test: a callable namedtuple auth handler must use `__call__`, not be downgraded to `HTTPBasicAuth`.

## Why this is safe

Plain `(username, password)` tuples are unaffected: a bare `tuple` is **not callable**, so it still reaches the `isinstance` branch. `HTTPBasicAuth` is itself callable, but it is not a bare tuple, so it routes through `callable` correctly as before.

## Proof of bug

Reproduced against requests 2.32.5:

```python
from collections import namedtuple
from requests.auth import AuthBase
from requests import PreparedRequest, structures

_Base = namedtuple("TokenAuth", ["token", "scheme"])

class TokenAuth(_Base, AuthBase):
    def __call__(self, r):
        r.headers["Authorization"] = f"{self.scheme} {self.token}"
        return r

auth = TokenAuth(token="my-secret", scheme="Bearer")
req = PreparedRequest()
req.prepare_url("https://api.example.com", {})
req.headers = structures.CaseInsensitiveDict()
req.prepare_auth(auth)

print(req.headers["Authorization"])
# Output:  Basic bXktc2VjcmV0OkJlYXJlcg==
# Decoded: my-secret:Bearer
# Expected: Bearer my-secret
```

The custom `__call__` was never invoked. The bearer token was silently encoded as a BasicAuth username.

This was found via Z3 formal verification of an `ordering` contract on `prepare_auth` (callable check must precede tuple check).