### PR TITLE
fix: restore urlparse path params in digest auth uri (#6990)

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -214,7 +214,11 @@ class HTTPDigestAuth(AuthBase):
         entdig = None
         p_parsed = urlparse(url)
         #: path is request-uri defined in RFC 2616 which should not be empty
-        path = p_parsed.path or "/"
+        path = p_parsed.path
+        if p_parsed.params:
+            path += f";{p_parsed.params}"
+        if not path:
+            path = "/"
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -780,6 +780,31 @@ class TestRequests:
             s.get(url, auth=auth)
             assert s.cookies["fake"] == "fake_value"
 
+    def test_DIGEST_AUTH_URI_WITH_SEMICOLONS_IN_PATH(self):
+        """Verify uri directive in digest auth header includes full path with semicolons.
+
+        Regression test for https://github.com/psf/requests/issues/6990
+        urlparse() discards semicolon-delimited path params; the uri field
+        must contain the full path per RFC 7616 §3.4.
+        """
+        for authtype in self.digest_auth_algo:
+            auth = HTTPDigestAuth("user", "pass")
+            # Set up thread-local challenge state to call build_digest_header directly
+            auth.init_per_thread_state()
+            auth._thread_local.last_nonce = ""  # ensure nonce_count increments
+            auth._thread_local.chal = {
+                "realm": "test",
+                "qop": "auth",
+                "nonce": "test-nonce",
+                "algorithm": authtype,
+                "opaque": "test-opaque",
+            }
+            url_with_semicolon = "http://httpbin.org/digest-auth/auth/user/pass/" + authtype + "/path;param1;param2?query=1"
+            header = auth.build_digest_header("GET", url_with_semicolon)
+            assert 'uri="/path;param1;param2?query=1"' in header, (
+                f"uri field should include full path with semicolons, got: {header}"
+            )
+
     def test_DIGEST_STREAM(self, httpbin):
         for authtype in self.digest_auth_algo:
             auth = HTTPDigestAuth("user", "pass")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -799,9 +799,16 @@ class TestRequests:
                 "algorithm": authtype,
                 "opaque": "test-opaque",
             }
-            url_with_semicolon = "http://httpbin.org/digest-auth/auth/user/pass/" + authtype + "/path;param1;param2?query=1"
+            url_with_semicolon = (
+                "http://httpbin.org/digest-auth/auth/user/pass/"
+                + authtype
+                + "/path;param1;param2?query=1"
+            )
             header = auth.build_digest_header("GET", url_with_semicolon)
-            assert 'uri="/path;param1;param2?query=1"' in header, (
+            expected_uri = (
+                f"/digest-auth/auth/user/pass/{authtype}/path;param1;param2?query=1"
+            )
+            assert f'uri="{expected_uri}"' in header, (
                 f"uri field should include full path with semicolons, got: {header}"
             )
 


### PR DESCRIPTION
## Problem

`urlparse()` from `urllib.parse` treats semicolons as path parameter delimiters per RFC 1808. For a URL like:

```
/ws/2/collection/xxx/releases/aaa;bbb?fmt=json
```

`urlparse()` returns:
- `.path = "/ws/2/collection/xxx/releases/aaa"`
- `.params = "bbb"`

The digest auth `build_digest_header()` method used only `p_parsed.path`, discarding the semicolon-delimited params. This caused the `uri` field in the `Authorization` header to be incorrect, leading to 401 authentication failures.

## Fix

Restore `p_parsed.params` to the path by appending `;{params}` when present, before appending the query string. This ensures the `uri` field in the digest auth header matches the full request URI as required by RFC 7616 §3.4.

## Changes

- **src/requests/auth.py**: Append `urlparse().params` (prefixed with `;`) to the path when present
- **tests/test_requests.py**: Add regression test verifying semicolons are preserved in the uri directive