### PR TITLE
Fix RequestsCookieJar popitem

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,8 @@ Release History
 dev
 ---
 
-- \[Short description of non-trivial change.\]
+- Fixed `RequestsCookieJar.popitem()` so it removes and returns a cookie pair
+  instead of always raising `KeyError`. (#6190)
 
 
 2.34.2 (2026-05-14)

--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -299,6 +299,16 @@ class RequestsCookieJar(CookieJar, MutableMapping[str, str | None]):  # type: ig
         """
         return list(self.iteritems())
 
+    def popitem(self) -> tuple[str, str | None]:
+        """Dict-like popitem() that removes and returns a cookie pair."""
+        for cookie in iter(self):
+            name = cookie.name
+            value = cookie.value
+            self.clear(cookie.domain, cookie.path, cookie.name)
+            return name, value
+
+        raise KeyError("dictionary is empty")
+
     def list_domains(self) -> list[str]:
         """Utility method to list all the domains in the jar."""
         domains: list[str] = []

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1374,6 +1374,13 @@ class TestRequests:
         # make sure one can use items multiple times
         assert list(items) == list(items)
 
+    def test_cookie_popitem_removes_and_returns_cookie_pair(self):
+        jar = requests.cookies.RequestsCookieJar()
+        jar.set("some_cookie", "some_value", domain="test.com", path="/")
+
+        assert jar.popitem() == ("some_cookie", "some_value")
+        assert not jar
+
     def test_cookie_duplicate_names_different_domains(self):
         key = "some_cookie"
         value = "some_value"


### PR DESCRIPTION
Fixes #6190

`RequestsCookieJar` inherits `MutableMapping.popitem()`, but its iterator yields `Cookie` objects rather than mapping keys. That makes the inherited implementation look up a `Cookie` object as a key and raise `KeyError` even when the jar contains cookies.

This adds an explicit `popitem()` implementation that removes one cookie from its domain/path/name and returns its `(name, value)` pair.

Tests run:

- `uv run --group test pytest tests/test_requests.py::TestRequests::test_cookie_popitem_removes_and_returns_cookie_pair -q`
- `uv run --group test pytest tests/test_requests.py -q -k "cookie_as_dict or cookie_popitem or cookie_duplicate_names or cookie_policy_copy"`
- `uv run --group test pytest tests/test_requests.py -q -k "not TestTimeout"`
- `uv run --with ruff ruff check HISTORY.md src/requests/cookies.py tests/test_requests.py`
- `git diff --check`