### PR TITLE
Improve static typing of 3rd party imports 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ test = [
 typecheck = [
     "pyright",
     "typing_extensions",
+    "chardet",
+    "cryptography",
+    "PyOpenSSL",
 ]
 
 [tool.setuptools]

--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -52,7 +52,7 @@ except ImportError:
     charset_normalizer_version = None
 
 try:
-    from chardet import __version__ as chardet_version  # type: ignore[import-not-found]
+    from chardet import __version__ as chardet_version
 except ImportError:
     chardet_version = None
 
@@ -112,7 +112,7 @@ def _check_cryptography(cryptography_version: str) -> None:
 try:
     check_compatibility(
         urllib3.__version__,  # type: ignore[reportPrivateImportUsage]
-        chardet_version,  # type: ignore[reportUnknownArgumentType]
+        chardet_version,
         charset_normalizer_version,
     )
 except (AssertionError, ValueError):
@@ -138,11 +138,11 @@ try:
         pyopenssl.inject_into_urllib3()
 
         # Check cryptography version
-        from cryptography import (  # type: ignore[reportMissingImports]
-            __version__ as cryptography_version,  # type: ignore[reportUnknownVariableType]
+        from cryptography import (
+            __version__ as cryptography_version,
         )
 
-        _check_cryptography(cryptography_version)  # type: ignore[reportUnknownArgumentType]
+        _check_cryptography(cryptography_version)
 except ImportError:
     pass
 

--- a/src/requests/compat.py
+++ b/src/requests/compat.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import importlib
 import sys
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 # -------
 # urllib3
@@ -46,7 +47,10 @@ def _resolve_char_detection() -> ModuleType | None:
     return chardet
 
 
-chardet = _resolve_char_detection()
+if TYPE_CHECKING:
+    import chardet
+else:
+    chardet = _resolve_char_detection()
 
 # -------
 # Pythons

--- a/src/requests/help.py
+++ b/src/requests/help.py
@@ -1,7 +1,5 @@
 """Module containing bug report helper(s)."""
 
-# pyright: reportUnknownMemberType=false
-
 import json
 import platform
 import ssl
@@ -19,7 +17,7 @@ except ImportError:
     charset_normalizer = None
 
 try:
-    import chardet  # type: ignore[import-not-found]
+    import chardet
 except ImportError:
     chardet = None
 
@@ -30,8 +28,8 @@ except ImportError:
     OpenSSL = None
     cryptography = None
 else:
-    import cryptography  # type: ignore[import-not-found]
-    import OpenSSL  # type: ignore[import-not-found]
+    import cryptography
+    import OpenSSL
 
 
 def _implementation():
@@ -51,7 +49,7 @@ def _implementation():
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
         pypy = sys.pypy_version_info  # type: ignore[attr-defined]
-        implementation_version = f"{pypy.major}.{pypy.minor}.{pypy.micro}"
+        implementation_version = f"{pypy.major}.{pypy.minor}.{pypy.micro}"  # pyright: ignore[reportUnknownMemberType]
         if sys.pypy_version_info.releaselevel != "final":  # type: ignore[attr-defined]
             implementation_version = "".join(
                 [implementation_version, sys.pypy_version_info.releaselevel]  # type: ignore[attr-defined]

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -238,7 +238,7 @@ class RequestEncodingMixin:
                 fdata = fp
             elif isinstance(fp, _SupportsRead):  # type: ignore[reportUnnecessaryIsInstance]  # defensive check for untyped callers
                 fdata = fp.read()
-            elif fp is None:  # type: ignore[reportUnnecessaryComparison]  # defensive check for untyped callers
+            elif fp is None:  # defensive check for untyped callers
                 continue
             else:
                 fdata = fp
@@ -1010,7 +1010,7 @@ class Response:
         ):
             if pending is not None:
                 # TODO: remove cast after iter_lines rewrite
-                chunk = cast("str | bytes", pending + chunk)  # type: ignore[operator]
+                chunk = cast("str | bytes", pending + chunk)
 
             if delimiter:
                 lines = chunk.split(delimiter)  # type: ignore[arg-type]


### PR DESCRIPTION
This adds `chardet`, `cryptography`, and `PyOpenSSL` to the `typecheck` dependency group. This way, Pyright is able to resolve these imports, removing the need for a bunch of `# type: ignore` comments. 

I verified that mypy (2.1.0) doesn't report any new errors.

And in case anyone is wondering: I didn't use any AI for this (I'm pretty sure I'm a human).