### PR TITLE
Add type annotation for `Request.hooks`

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -308,6 +308,7 @@ class Request(RequestHooksMixin):
       <PreparedRequest [GET]>
     """
 
+    hooks: dict[str, list[_t.HookType]]
     method: str | None
     url: _t.UriType | None
     headers: Mapping[str, str | bytes]


### PR DESCRIPTION
The typestats dashboard (https://jorenham.github.io/typestats/dashboard/report/#requests)  showed that this instance attribute wasn't typed yet. And I thought it would be nice if we could get the type coverage % of `requests` to 100%, because it's currently (`requests==2.34.2`) at 97.9% (so close!).