### PR TITLE
fix: preserve explicit Cookie headers on same-origin redirects

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -258,7 +258,8 @@ class SessionRedirectMixin:
                 prepared_request.body = None
 
             headers = prepared_request.headers
-            headers.pop("Cookie", None)
+            if "Cookie" in headers and self.should_strip_auth(resp.request.url, url):
+                headers.pop("Cookie", None)
 
             # Extract any cookies sent on the response to the cookiejar
             # in the new request. Because we've mutated our copied prepared

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -414,6 +414,25 @@ class TestRequests:
         assert "foo" in r.request.headers["Cookie"]
         assert "foo" in r.history[0].request.headers["Cookie"]
 
+    def test_cookie_header_is_retained_on_same_host_redirect(self, httpbin):
+        r = requests.get(httpbin("redirect/1"), headers={"Cookie": "foo=bar"})
+
+        assert r.history[0].request.headers["Cookie"] == "foo=bar"
+        assert r.request.headers["Cookie"] == "foo=bar"
+
+    def test_cookie_header_is_stripped_on_cross_origin_redirect(
+        self, httpbin, httpbin_secure, httpbin_ca_bundle
+    ):
+        r = requests.get(
+            httpbin("redirect-to"),
+            params={"url": httpbin_secure("get")},
+            headers={"Cookie": "foo=bar"},
+            verify=httpbin_ca_bundle,
+        )
+
+        assert r.history[0].request.headers["Cookie"] == "foo=bar"
+        assert "Cookie" not in r.request.headers
+
     def test_request_cookie_overrides_session_cookie(self, httpbin):
         s = requests.session()
         s.cookies["foo"] = "bar"


### PR DESCRIPTION
## Summary

Preserve an explicit `Cookie` header across same-origin redirects, while still stripping it when a redirect crosses origins or changes scheme/port in the same way Requests already decides whether to strip `Authorization`.

## Why

`Session.resolve_redirects()` was dropping `Cookie` unconditionally. That made a request like `requests.get(..., headers={"Cookie": ...})` behave differently from the rest of Requests' redirect handling and from the session cookie path.

## What changed

- `src/requests/sessions.py`
  - Only remove the `Cookie` header on redirects when `should_strip_auth()` says the redirect crosses origins or otherwise should not retain credentials.
- `tests/test_requests.py`
  - Added coverage for same-host redirects preserving an explicit `Cookie` header.
  - Added coverage for cross-origin redirects stripping the explicit `Cookie` header.

## Validation

- `python -m pytest tests/test_requests.py -k "cookie_persists_via_api or cookie_header_is_retained_on_same_host_redirect or cookie_header_is_stripped_on_cross_origin_redirect or auth_is_retained_for_redirect_on_host or should_strip_auth"`
- `python -m pytest tests/test_requests.py` was also run; it has two unrelated environment-specific failures in this container (`test_errors[http://doesnotexist.google.com-ConnectionError]` and `test_different_connection_pool_for_tls_settings_verify_bundle_unexpired_cert`).
