### PR TITLE
`requests.help` static typing improvements

### DIFF
--- a/src/requests/help.py
+++ b/src/requests/help.py
@@ -4,32 +4,39 @@ import json
 import platform
 import ssl
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import idna
 import urllib3
 
 from . import __version__ as requests_version
 
-try:
-    import charset_normalizer
-except ImportError:
-    charset_normalizer = None
-
-try:
+if TYPE_CHECKING:
     import chardet
-except ImportError:
-    chardet = None
-
-try:
-    from urllib3.contrib import pyopenssl
-except ImportError:
-    pyopenssl = None
-    OpenSSL = None
-    cryptography = None
-else:
+    import charset_normalizer
     import cryptography
     import OpenSSL
+    from urllib3.contrib import pyopenssl
+else:
+    try:
+        import charset_normalizer
+    except ImportError:
+        charset_normalizer = None
+
+    try:
+        import chardet
+    except ImportError:
+        chardet = None
+
+    try:
+        from urllib3.contrib import pyopenssl
+    except ImportError:
+        pyopenssl = None
+        OpenSSL = None
+        cryptography = None
+    else:
+        import cryptography
+        import OpenSSL
 
 
 def _implementation():
@@ -79,7 +86,7 @@ def info() -> dict[str, Any]:
 
     implementation_info = _implementation()
     urllib3_info = {"version": urllib3.__version__}
-    charset_normalizer_info = {"version": None}
+    charset_normalizer_info: dict[str, str | None] = {"version": None}
     chardet_info: dict[str, str | None] = {"version": None}
     if charset_normalizer:
         charset_normalizer_info = {"version": charset_normalizer.__version__}
@@ -123,7 +130,7 @@ def info() -> dict[str, Any]:
     }
 
 
-def main():
+def main() -> None:
     """Pretty-print the bug information as JSON."""
     print(json.dumps(info(), sort_keys=True, indent=2))
 


### PR DESCRIPTION
Static type-checkers aren't very good at dealing with `try/except` blocks. Mypy, for example, reported 5 type errors in `help.py` because of this.

By moving these optional imports into an `if TYPE_CHECKING` block, static type-checkers will know how to deal with them. Even if these imports aren't found (because they're not installed), they'll be treated as `Any`, which won't lead to any typing issues (according to the [gradual guarantee](https://typing.python.org/en/latest/spec/concepts.html#the-gradual-guarantee)).

This also fixed another mypy error (related to mypy's greedy dict value type inference) by adding an inline annotation. 

The final score is -6 mypy errors (0 left in `help.py`), and +1.02% type coverage (according to `pyrefly report`) for a grand total of 99.30% type coverage (roughly speaking that's the number of things that *are* typed / the number of things that *can* be typed).