### PR TITLE
fix: Strange behavior when setting cookie value to None in the method-level p

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -594,9 +594,11 @@ def cookiejar_from_dict(
 
     if cookie_dict is not None:
         names_from_jar = [cookie.name for cookie in cookiejar]
-        for name in cookie_dict:
-            if overwrite or (name not in names_from_jar):
-                cookiejar.set_cookie(create_cookie(name, cookie_dict[name]))
+        for name, value in cookie_dict.items():
+            if value is None:
+                remove_cookie_by_name(cookiejar, name)
+            elif overwrite or (name not in names_from_jar):
+                cookiejar.set_cookie(create_cookie(name, value))
 
     return cookiejar
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -29,7 +29,7 @@ from requests.compat import (
     is_urllib3_1,
     urlparse,
 )
-from requests.cookies import cookiejar_from_dict, morsel_to_cookie
+from requests.cookies import cookiejar_from_dict, merge_cookies, morsel_to_cookie
 from requests.exceptions import (
     ChunkedEncodingError,
     ConnectionError,
@@ -421,6 +421,21 @@ class TestRequests:
         assert r.json()["cookies"]["foo"] == "baz"
         # Session cookie should not be modified
         assert s.cookies["foo"] == "bar"
+
+    def test_request_cookie_none_unsets_session_cookie(self):
+        s = requests.session()
+        s.cookies.update({"from-my": "browser"})
+        merged = merge_cookies(
+            merge_cookies(requests.cookies.RequestsCookieJar(), s.cookies),
+            {"another": "cookie", "from-my": None},
+        )
+        prep = PreparedRequest()
+        prep.prepare(
+            method="GET",
+            url="http://httpbin.org/cookies",
+            cookies=merged,
+        )
+        assert prep.headers["Cookie"] == "another=cookie"
 
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()


### PR DESCRIPTION
Fixes #2716

Tests:
 in 59.84s
127.0.0.1 - - [16/Jun/2026 16:38:55] "POST /post HTTP/1.1" 200 291
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 222
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 203
127.0.0.1 - - [16/Jun/2026 16:38:56] "HEAD /get HTTP/1.1" 200 0
127.0.0.1 - - [16/Jun/2026 16:38:56] "POST /post HTTP/1.1" 200 388
127.0.0.1 - - [16/Jun/2026 16:38:56] "POST /post HTTP/1.1" 200 231823
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET / HTTP/1.1" 200 9509
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 170
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 222
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 222
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 259
127.0.0.1 - - [16/Jun/2026 16:38:56] "GET /get HTTP/1.1" 200 222

OK