### PR TITLE
fix: requests.exceptions.ReadTimeout is not raised when response is chunked

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -62,6 +62,7 @@ from .exceptions import (
     InvalidJSONError,
     InvalidURL,
     MissingSchema,
+    ReadTimeout,
     StreamConsumedError,
 )
 from .exceptions import JSONDecodeError as RequestsJSONDecodeError
@@ -942,7 +943,7 @@ class Response:
                 except DecodeError as e:
                     raise ContentDecodingError(e)
                 except ReadTimeoutError as e:
-                    raise ConnectionError(e)
+                    raise ReadTimeout(e)
                 except SSLError as e:
                     raise RequestsSSLError(e)
             else:

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 import pytest
 
@@ -57,6 +58,29 @@ def test_chunked_encoding_error():
         url = f"http://{host}:{port}/"
         with pytest.raises(requests.exceptions.ChunkedEncodingError):
             requests.get(url)
+        close_server.set()  # release server block
+
+
+def test_chunked_read_timeout():
+    """ReadTimeout is raised when a chunked response stalls."""
+
+    def slow_chunked_response_handler(sock):
+        consume_socket_content(sock, timeout=0.5)
+        sock.send(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"\r\n"
+        )
+        time.sleep(5)
+
+    close_server = threading.Event()
+    server = Server(slow_chunked_response_handler)
+
+    with server as (host, port):
+        url = f"http://{host}:{port}/"
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            requests.get(url, timeout=0.5)
         close_server.set()  # release server block
 
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1529,7 +1529,7 @@ class TestRequests:
         (
             (urllib3.exceptions.ProtocolError, tuple(), ChunkedEncodingError),
             (urllib3.exceptions.DecodeError, tuple(), ContentDecodingError),
-            (urllib3.exceptions.ReadTimeoutError, (None, "", ""), ConnectionError),
+            (urllib3.exceptions.ReadTimeoutError, (None, "", ""), ReadTimeout),
             (urllib3.exceptions.SSLError, tuple(), RequestsSSLError),
         ),
     )


### PR DESCRIPTION
Fixes #2392

Tests:
0.0.1 - - [16/Jun/2026 17:12:16] "GET /response-headers?Set-Cookie=foo%3Ddeleted%3B+expires%3DThu%2C+01-Jan-1970+00%3A00%3A01+GMT HTTP/1.1" 200 125
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /get HTTP/1.1" 200 203
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /user-agent HTTP/1.1" 200 55
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /basic-auth/user/pass HTTP/1.1" 401 0
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /digest-auth/auth/user/pass/SHA-512 HTTP/1.1" 401 0
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /status/404 HTTP/1.1" 404 0
127.0.0.1 - - [16/Jun/2026 17:12:17] "GET /get HTTP/1.1" 200 222
127.0.0.1 - - [16/Jun/2026 17:12:18] "GET /get HTTP/1.1" 200 222
127.0.0.1 - - [16/Jun/2026 17:12:48] "GET /status/200 HTTP/1.1" 200 0
127.0.0.1 - - [16/Jun/2026 17:12:48] "GET /bytes/20 HTTP/1.1" 500 59

OK