### PR TITLE
fix: decode bytes username/password to str in HTTPDigestAuth (#6102)

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -139,6 +139,11 @@ class HTTPDigestAuth(AuthBase):
     def __init__(self, username: bytes, password: bytes) -> None: ...
 
     def __init__(self, username: bytes | str, password: bytes | str) -> None:
+        # Decode bytes to str for proper header formatting
+        if isinstance(username, bytes):
+            username = username.decode("utf-8")
+        if isinstance(password, bytes):
+            password = password.decode("utf-8")
         self.username = username
         self.password = password
         # Keep state in per-thread local storage


### PR DESCRIPTION
## Problem

When `username` or `password` are passed as `bytes` to `HTTPDigestAuth` (e.g. `'Ondřej'.encode('utf-8')`), the f-string in `build_digest_header` outputs the bytes repr (`b'Ond\xc5\x99ej'`) instead of the decoded string.

This causes the Digest header to contain incorrect username:
```
Digest username="b'Ond\xc5\x99ej'", ...
```

## Solution

Decode `bytes` to `str` in `__init__` so that `username` and `password` are always strings when used in header formatting.

## Changes

- `src/requests/auth.py`: Added bytes-to-str decoding in `HTTPDigestAuth.__init__`

## Testing

- Verified bytes input is properly decoded: `HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko')` → `username='Ondřej'`
- Verified str input still works: `HTTPDigestAuth('Ondřej', 'heslíčko')` → `username='Ondřej'`
- Existing tests pass (35 passed, 16 fixture errors unrelated to this change)

Fixes #6102

Signed-off-by: 1795771535y-cell <1795771535y-cell@users.noreply.github.com>