### PR TITLE
Modernization: Add technical debt report

### DIFF
--- a/b47457b5-2b85-4192-a564-f9cf593cfaea_DEBT_REPORT.md
+++ b/b47457b5-2b85-4192-a564-f9cf593cfaea_DEBT_REPORT.md
@@ -1,0 +1,10 @@
+# Debt Report: b47457b5-2b85-4192-a564-f9cf593cfaea
+
+## /tmp/repos/b47457b5-2b85-4192-a564-f9cf593cfaea/src/requests/utils.py
+- **Complexity/Debt Observations**: This is a large module (1100+ lines) containing a wide variety of unrelated utility functions ranging from proxy configuration, cookie management, to URL handling and content encoding detection. The code uses broad type annotations (many `Any`) and some sections have high complexity.
+- **Suggested Refactors**: 
+    - Break this file down into smaller, domain-specific modules (e.g., `requests.proxies`, `requests.cookies`, `requests.headers`, `requests.encoding`).
+    - Improve type safety by replacing `Any` with more specific types or TypeVars.
+    - Standardize the error handling approach across utility functions.
+    - Decouple proxy bypass logic from the general utility module.
+- **Verification Status**: Verified with existing tests in `tests/test_utils.py` which passed.


### PR DESCRIPTION
This PR adds a technical debt report document for the `requests` repository. The utility module (`src/requests/utils.py`) was reviewed for technical debt. No logic changes were made, and existing tests in `tests/test_utils.py` were confirmed to pass. Future refactors are suggested in the added report.