### PR TITLE
parse_header_links: preserve parameter values containing '=' characters

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -988,7 +988,7 @@ def parse_header_links(value: str) -> list[dict[str, str]]:
 
         for param in params.split(";"):
             try:
-                key, value = param.split("=")
+                key, value = param.split("=", 1)
             except ValueError:
                 break
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -690,6 +690,10 @@ def test_iter_slices(value, length):
                 {"url": "http://.../back.jpeg"},
             ],
         ),
+        (
+            '<http:/.../front.jpeg>; title=Hello=World',
+            [{"url": "http:/.../front.jpeg", "title": "Hello=World"}],
+        ),
         ("", []),
     ),
 )


### PR DESCRIPTION
## Summary

`parse_header_links` silently dropped any Link-header parameter whose value contained `=`. A server sending

    Link: <http://example.com/page>; title=Hello=World

produced `{'url': 'http://example.com/page'}` — the `title` parameter was lost because `param.split("=")` raised `ValueError: too many values to unpack (expected 2)` and the loop `break`ed out, skipping every subsequent parameter too.

## Fix

Use `param.split("=", 1)` so only the first `=` is treated as the separator. The exact same pattern already lives a few lines above for the URL/params split (`val.split(";", 1)`).

## Test

Added a parametrized case to `test_parse_header_links` for `<http:/.../front.jpeg>; title=Hello=World` returning the expected `title: "Hello=World"`.

All 217 existing utils tests still pass.