### PR TITLE
skip malformed link params instead of breaking out of the loop

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -987,10 +987,14 @@ def parse_header_links(value: str) -> list[dict[str, str]]:
         link: dict[str, str] = {"url": url.strip("<> '\"")}
 
         for param in params.split(";"):
-            try:
-                key, value = param.split("=")
-            except ValueError:
-                break
+            if "=" not in param:
+                # Skip malformed params (e.g. trailing ';') but keep parsing
+                # the rest of the link parameters. The previous implementation
+                # used `break` here, which silently dropped every parameter
+                # that came after a malformed one — a server that emits a
+                # stray `;` between valid params would lose all of them.
+                continue
+            key, value = param.split("=", 1)
 
             link[key.strip(replace_chars)] = value.strip(replace_chars)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -697,6 +697,19 @@ def test_parse_header_links(value, expected):
     assert parse_header_links(value) == expected
 
 
+def test_parse_header_links_param_without_equals_does_not_drop_later_params():
+    """A param without '=' should only skip itself, not drop later params.
+
+    Regression test: parse_header_links used to `break` on a malformed
+    parameter, which silently dropped every valid parameter that came
+    after it. Servers sometimes emit a stray ';' or attribute name without
+    a value (e.g. '<url>; rel=next; flag; title=hi'), and the caller
+    still wants `title` to come through.
+    """
+    result = parse_header_links('</page1>; rel="next"; flag; title=hi')
+    assert result == [{"url": "/page1", "rel": "next", "title": "hi"}]
+
+
 @pytest.mark.parametrize(
     "value, expected",
     (


### PR DESCRIPTION
parse_header_links used `break` when a link param had no `=` (e.g. a trailing `;` or a stray attribute name), which silently dropped every valid parameter that came after the malformed one. For a header like `</page1>; rel="next"; flag; title=hi` the caller lost `title` even though it was perfectly parseable. Switched to `continue` so a malformed param only skips itself, and switched `split("=")` to `split("=", 1)` so a value that legitimately contains `=` is preserved as a single value rather than raising.

Added a regression test in tests/test_utils.py covering the dropped-params case.