### PR TITLE
fix(auth): decode bytes username/password in HTTPDigestAuth to fix non-latin credentials

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -218,7 +218,17 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        # Normalise username/password: bytes are decoded to str so they are
+        # represented correctly in both the hash input and the header value.
+        # Passing bytes was a common workaround for non-latin-1 characters
+        # (see https://github.com/psf/requests/issues/6102).
+        _username = (
+            self.username.decode("utf-8") if isinstance(self.username, bytes) else self.username
+        )
+        _password = (
+            self.password.decode("utf-8") if isinstance(self.password, bytes) else self.password
+        )
+        A1 = f"{_username}:{realm}:{_password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -251,7 +261,7 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX should the partial digests be encoded too?
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{_username}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
## Problem

`HTTPDigestAuth` silently produces a malformed `Authorization` header when the username or password contains non-latin-1 characters.

A common workaround is to pass credentials as UTF-8 encoded bytes — but this makes things worse, because Python's f-string interpolation renders the `bytes` object with its `b'...'` repr instead of the actual string:

```python
# Attempt 1 — str with non-latin-1 char
HTTPDigestAuth('Ondřej', 'heslíčko')
# → UnicodeEncodeError or silent corruption in hash

# Attempt 2 — bytes workaround (suggested in #5089)
HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko'.encode('utf-8'))
# → Authorization: Digest username="b'Ond\xc5\x99ej'", ...  ❌
#                                   ^^^^^ bytes repr, not the username
```

**Root cause:** `build_digest_header` uses `self.username` and `self.password` directly in f-strings (lines 221 and 254) without normalising bytes to str first. When the value is `bytes`, the f-string produces `b'...'`.

## Fix

Decode bytes credentials to UTF-8 strings at the top of `build_digest_header`, before they are used in the hash computation (`A1`) or the header value:

```python
_username = (
    self.username.decode("utf-8") if isinstance(self.username, bytes) else self.username
)
_password = (
    self.password.decode("utf-8") if isinstance(self.password, bytes) else self.password
)
A1 = f"{_username}:{realm}:{_password}"   # correct hash input
...
f'username="{_username}", ...'             # correct header value
```

This makes both the hash computation and the emitted header correct for non-latin-1 credentials, whether the caller passes `str` or `bytes`.

## Verification

```python
import requests

auth = requests.auth.HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko'.encode('utf-8'))
# header before fix: username="b'Ond\xc5\x99ej'"
# header after fix:  username="Ondřej"
```

Closes #6102