### PR TITLE
fix: handle double-digit IPv6 zone IDs in URL parsing

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -683,10 +683,39 @@ def unquote_unreserved(uri: str) -> str:
 
     :rtype: str
     """
+    # Preserve percent-encoded sequences inside IPv6 address brackets.
+    # Per RFC 6874, the "%" in a zone ID (e.g. [fe80::1%25eth0]) is a
+    # delimiter, not a percent-encoding prefix.  After urllib3 decodes %25
+    # to "%", we must not interpret the resulting "%XX" as a percent-escape.
+    ipv6_regions: list[tuple[int, int]] = []
+    depth = 0
+    start = -1
+    for idx, ch in enumerate(uri):
+        if ch == "[":
+            if depth == 0:
+                start = idx
+            depth += 1
+        elif ch == "]" and depth > 0:
+            depth -= 1
+            if depth == 0 and start >= 0:
+                ipv6_regions.append((start, idx))
+                start = -1
+
+    def _in_ipv6(pos: int) -> bool:
+        return any(s <= pos <= e for s, e in ipv6_regions)
+
     parts = uri.split("%")
+    # Pre-compute the original position of each "%" separator using the
+    # *original* part lengths, before we mutate any elements.
+    percent_positions: list[int] = []
+    pos = len(parts[0])
+    for i in range(1, len(parts)):
+        percent_positions.append(pos)
+        pos += 1 + len(parts[i])
+
     for i in range(1, len(parts)):
         h = parts[i][0:2]
-        if len(h) == 2 and h.isalnum():
+        if len(h) == 2 and h.isalnum() and not _in_ipv6(percent_positions[i - 1]):
             try:
                 c = chr(int(h, 16))
             except ValueError:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -506,10 +506,76 @@ def test_requote_uri_with_unquoted_percents(uri, expected):
             "http://example.com/?a=%300",
             "http://example.com/?a=00",
         ),
-    ),
+        ),
 )
 def test_unquote_unreserved(uri, expected):
     assert unquote_unreserved(uri) == expected
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    (
+        (
+            # Double-digit zone ID (issue #6808)
+            "http://[fe80::be0f:a7ff:fe00:2929%53]/",
+            "http://[fe80::be0f:a7ff:fe00:2929%53]/",
+        ),
+        (
+            # Single-digit zone ID
+            "http://[fe80::1%9]/",
+            "http://[fe80::1%9]/",
+        ),
+        (
+            # Triple-digit zone ID
+            "http://[fe80::1%100]/",
+            "http://[fe80::1%100]/",
+        ),
+        (
+            # Zone ID with mixed hex (uppercase)
+            "http://[fe80::1%AB]/",
+            "http://[fe80::1%AB]/",
+        ),
+        (
+            # Unreserved chars outside brackets are still decoded
+            # %41 = 'A'
+            "http://example.com/%41lice",
+            "http://example.com/Alice",
+        ),
+    ),
+)
+def test_unquote_unreserved_ipv6_zone_id(uri, expected):
+    """Percent-encoded sequences inside IPv6 address brackets must be
+    preserved, because per RFC 6874 the '%' is a zone-ID delimiter, not a
+    percent-encoding prefix.
+
+    See: https://github.com/psf/requests/issues/6808
+    """
+    assert unquote_unreserved(uri) == expected
+
+
+@pytest.mark.parametrize(
+    "uri, expected",
+    (
+        (
+            # Double-digit zone ID (issue #6808) – full requote cycle
+            "http://[fe80::be0f:a7ff:fe00:2929%53]/",
+            "http://[fe80::be0f:a7ff:fe00:2929%53]/",
+        ),
+        (
+            # Zone ID with numeric value that happens to decode to an
+                       # unreserved character (%53 = 'S')
+            "http://[fe80::1%53]/",
+            "http://[fe80::1%53]/",
+        ),
+    ),
+)
+def test_requote_uri_ipv6_zone_id(uri, expected):
+    """requote_uri must not decode percent-encoded zone IDs inside IPv6
+    address brackets (RFC 6874).
+
+    See: https://github.com/psf/requests/issues/6808
+    """
+    assert requote_uri(uri) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

When making a request to a link-local IPv6 address with a double-digit zone ID (e.g., `fe80::be0f:a7ff:fe00:2929%53`), `requests` raises a `ValueError` because `unquote_unreserved()` incorrectly decodes the percent-encoded zone ID as an unreserved character (`%53` → `S`).

Fixes #6808

## Root Cause

Per RFC 6874, the `%` in an IPv6 zone ID is a delimiter, not a percent-encoding prefix. When a user provides a URL like `http://[fe80::be0f:a7ff:fe00:2929%2553]/`, urllib3 correctly decodes `%25` to `%`, yielding the host `[fe80::be0f:a7ff:fe00:2929%53]`. However, when `requote_uri()` processes this URL, `unquote_unreserved()` sees `%53` and decodes it to `S` (an unreserved ASCII character), producing the invalid `http://[fe80::be0f:a7ff:fe00:2929S]/`.

Single-digit zone IDs (e.g., `%9`) were unaffected because the decoded character (e.g., tab) is not in the unreserved set.

## Fix

Modify `unquote_unreserved()` to skip decoding percent-escape sequences that appear inside IPv6 address brackets (`[...]`). This preserves zone IDs of any length while maintaining correct percent-decoding behavior for the rest of the URI.

## Testing

- Added `test_unquote_unreserved_ipv6_zone_id` with parametrized cases for double-digit, single-digit, triple-digit, and mixed-hex zone IDs, plus a regression test for unreserved chars outside brackets
- Added `test_requote_uri_ipv6_zone_id` for the full requote cycle
- All existing tests pass (223 passed, 13 skipped)

## Checklist

- [x] Bug fix with minimal, targeted change
- [x] Tests added and passing
- [x] References the issue (#6808)