### PR TITLE
parse_list_header and parse_dict_header: do not unquote tokens that lack a balanced closing quote

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -430,7 +430,7 @@ def parse_list_header(value: str) -> list[str]:
     """
     result: list[str] = []
     for item in _parse_list_header(value):
-        if item[:1] == item[-1:] == '"':
+        if len(item) >= 2 and item[0] == item[-1] == '"':
             item = unquote_header_value(item[1:-1])
         result.append(item)
     return result
@@ -465,7 +465,7 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
             result[item] = None
             continue
         name, value = item.split("=", 1)
-        if value[:1] == value[-1:] == '"':
+        if len(value) >= 2 and value[0] == value[-1] == '"':
             value = unquote_header_value(value[1:-1])
         result[name] = value
     return result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ from requests.utils import (
     iter_slices,
     parse_dict_header,
     parse_header_links,
+    parse_list_header,
     prepend_scheme_if_needed,
     requote_uri,
     select_proxy,
@@ -574,6 +575,21 @@ def test_select_proxies(url, expected, proxies):
 )
 def test_parse_dict_header(value, expected):
     assert parse_dict_header(value) == expected
+
+
+def test_parse_dict_header_bare_quote_value_not_unquoted():
+    # A single trailing quote is not a balanced quoted-string, so the value
+    # should be kept as-is (a bare quote).
+    assert parse_dict_header('foo="bar') == {"foo": '"bar'}
+
+
+def test_parse_list_header_bare_quote_item_not_unquoted():
+    # A single token that starts with one quote should be kept as a quoted item
+    # (the unquote step requires len(item) >= 2 with matching leading/trailing
+    # quotes; a single bare quote is not a balanced quoted-string).
+    assert parse_list_header('"') == ['"']
+    # And the same for a non-empty single-quote-prefixed token.
+    assert parse_list_header('"bar') == ['"bar']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

`parse_list_header` and `parse_dict_header` in `src/requests/utils.py` used `item[:1] == item[-1:] == '"'` to test whether an item is a balanced quoted-string before passing it to `unquote_header_value`. The check passes whenever the first and last characters of the slice are both `"`, which is also true for a token consisting of a single bare quote (`"`): the first character is `"`, the last character is `"`, so the code stripped both ends and ran `unquote_header_value('')` on the empty string. The empty result was appended as the parsed value.

A single bare quote (or a token like `"bar` with a leading quote but no closing one) is not a valid `quoted-string` per RFC 7230, so it should be preserved verbatim, not stripped and unquoted.

## Fix

Test `len(item) >= 2 and item[0] == item[-1] == '"'`. The length check rejects both the empty string (where `item[-1]` would otherwise IndexError) and the single-quote case. The test `test_parse_list_header_bare_quote_item_not_unquoted` covers `'foo="bar'` (dict) and `'"'`, `'"bar'` (list).

## Why

`value[0]` is more idiomatic than `value[:1]`, and the length guard makes the intent explicit. The previous code happened to avoid an IndexError on the empty string only because `value[-1:]` for `value == ""` returns `""` (a slice past the end is empty, not a `-1` index error). But a token of length 1 with the only char being `"` was a real bug: it matched the guard, was unquoted to `""`, and silently produced an empty value in the parsed result.
