### PR TITLE
docs: update concurrent requests recommendations

### DIFF
--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -35,12 +35,21 @@ requested by users within the community.
 .. _Requests-Toolbelt: https://toolbelt.readthedocs.io/en/latest/index.html
 
 
-Requests-Threads
-----------------
+Concurrent Requests
+-------------------
 
-`Requests-Threads`_ is a Requests session that returns the amazing Twisted's awaitable Deferreds instead of Response objects. This allows the use of ``async``/``await`` keyword usage on Python 3, or Twisted's style of programming, if desired.
+Requests itself performs blocking I/O. For concurrent or async-style
+workflows, use a third-party package built for that model. `gevent-requests`_
+provides a gevent-based API for making multiple Requests calls concurrently.
+It uses green threads rather than native ``asyncio`` coroutines.
 
-.. _Requests-Threads: https://github.com/requests/requests-threads
+Other projects in this space include `grequests`_ and `requests-futures`_.
+Check each project's current maintenance status and Python compatibility
+before adopting it.
+
+.. _gevent-requests: https://pypi.org/project/gevent-requests/
+.. _grequests: https://github.com/spyoungtech/grequests
+.. _requests-futures: https://github.com/ross/requests-futures
 
 Requests-OAuthlib
 -----------------

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1065,11 +1065,12 @@ you require more granularity, the streaming features of the library (see
 :ref:`streaming-requests`) allow you to retrieve smaller quantities of the
 response at a time. However, these calls will still block.
 
-If you are concerned about the use of blocking IO, there are lots of projects
-out there that combine Requests with one of Python's asynchronicity frameworks.
-Some excellent examples are `requests-threads`_, `grequests`_, `requests-futures`_, and `httpx`_.
+If you are concerned about the use of blocking IO, there are third-party
+projects that combine Requests with concurrency frameworks, and projects that
+provide async HTTP client APIs. Some examples are `gevent-requests`_,
+`grequests`_, `requests-futures`_, and `httpx`_.
 
-.. _`requests-threads`: https://github.com/requests/requests-threads
+.. _`gevent-requests`: https://pypi.org/project/gevent-requests/
 .. _`grequests`: https://github.com/spyoungtech/grequests
 .. _`requests-futures`: https://github.com/ross/requests-futures
 .. _`httpx`: https://github.com/encode/httpx


### PR DESCRIPTION
## Summary
- Replaces the outdated Requests-Threads recommendation with a broader concurrent Requests section.
- Points readers to gevent-requests, grequests, and requests-futures, while clarifying that these are not native asyncio support in Requests itself.
- Updates the advanced blocking/non-blocking docs to stop pointing at requests-threads.

Fixes #6582

## Verification
- `python -m sphinx -b html docs docs\_build\html`
- `python -m compileall docs -q`

Note: `python -m sphinx -b html docs docs\_build\html -W` is currently blocked by pre-existing warnings from `HISTORY.md` and `language = None`, unrelated to this change.