### PR TITLE
Preserve username-only URL auth

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -1075,13 +1075,10 @@ def get_auth_from_url(url: str) -> tuple[str, str]:
     """
     parsed = urlparse(url)
 
-    try:
-        # except handles parsed.username/password being None
-        auth = (unquote(parsed.username), unquote(parsed.password))  # type: ignore[arg-type]
-    except (AttributeError, TypeError):
-        auth = ("", "")
+    username = parsed.username or ""
+    password = parsed.password or ""
 
-    return auth
+    return (unquote(username), unquote(password))
 
 
 def check_header_validity(header: tuple[str | bytes, str | bytes]) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -463,6 +463,14 @@ ENCODED_PASSWORD = compat.quote(PASSWORD, "")
             ("user%user", "pass"),
         ),
         (
+            "http://user@complex.url.com/path?query=yes",
+            ("user", ""),
+        ),
+        (
+            "http://user%25user@complex.url.com/path?query=yes",
+            ("user%user", ""),
+        ),
+        (
             "http://user:pass%23pass@complex.url.com/path?query=yes",
             ("user", "pass#pass"),
         ),


### PR DESCRIPTION
## Summary

get_auth_from_url() now keeps a URL username when the URL has no password component instead of dropping the username.

## Why

A username-only URL authority still carries authentication information. Returning an empty auth tuple loses that information and differs from the behavior for URLs that include both username and password.

## Tests

- python -m pytest tests/test_utils.py::test_get_auth_from_url tests/test_utils.py::test_prepend_scheme_if_needed tests/test_utils.py::test_urldefragauth -q
- git diff --check origin/main..HEAD

## AI-assisted

Codex helped prepare this focused change. I reviewed the diff and ran the tests above before submitting.