### PR TITLE
Inline pre-commit linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     cooldown:
       default-days: 7
     groups:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,6 @@ jobs:
       with:
         python-version: "3.x"
     - name: Run pre-commit
-      uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
+      run: |
+        python -m pip install pre-commit==4.6.0
+        pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
This PR moves us off of https://github.com/pre-commit/action to running pre-commit directly. This should avoid the transitive dependency pinning issues from #7536.

I've also reduced our pin update frequency for `pre-commit` to minor versions since we're getting weekly dependabot updates that aren't necessary. This matches our existing constraints for other ecosystems.