### PR TITLE
Parse standard cookie Expires dates from Morsel

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -9,7 +9,6 @@ requests.utils imports from here, so be careful with imports.
 
 from __future__ import annotations
 
-import calendar
 import copy
 import time
 from collections.abc import Iterator, MutableMapping
@@ -538,8 +537,9 @@ def morsel_to_cookie(morsel: Morsel[Any]) -> Cookie:
         except ValueError:
             raise TypeError(f"max-age: {morsel['max-age']} must be integer")
     elif morsel["expires"]:
-        time_template = "%a, %d-%b-%Y %H:%M:%S GMT"
-        expires = calendar.timegm(time.strptime(morsel["expires"], time_template))
+        expires = cookielib.http2time(morsel["expires"])
+        if expires is None:
+            raise ValueError(f"expires: {morsel['expires']} must be a valid HTTP date")
     return create_cookie(
         comment=morsel["comment"],
         comment_url=bool(morsel["comment"]),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -10,6 +10,7 @@ import re
 import tempfile
 import threading
 import warnings
+from http.cookies import SimpleCookie
 from unittest import mock
 
 import pytest
@@ -2489,6 +2490,31 @@ class TestMorselToCookieExpires:
         morsel["expires"] = "Thu, 01-Jan-1970 00:00:01 GMT"
         cookie = morsel_to_cookie(morsel)
         assert cookie.expires == 1
+
+    def test_expires_valid_http_date(self):
+        """Test case where expires uses the common HTTP-date format."""
+
+        morsel = Morsel()
+        morsel["expires"] = "Wed, 21 Oct 2015 07:28:00 GMT"
+        cookie = morsel_to_cookie(morsel)
+        assert cookie.expires == 1445412480
+
+    def test_cookie_jar_update_accepts_http_date(self):
+        """Test RequestsCookieJar.update accepts HTTP-date Morsel expires."""
+
+        cookies = SimpleCookie()
+        cookies.load(
+            "auth_session=null; path=/; "
+            "expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+            "httponly; samesite=strict"
+        )
+
+        jar = requests.cookies.RequestsCookieJar()
+        jar.update(cookies)
+
+        cookie = next(iter(jar))
+        assert cookie.name == "auth_session"
+        assert cookie.expires == 0
 
     @pytest.mark.parametrize(
         "value, exception",


### PR DESCRIPTION
## Summary
- parse Morsel expires values with http.cookiejar.http2time instead of a single fixed strptime template
- keep invalid expires values rejected when the stdlib parser cannot parse them
- add regression coverage for RequestsCookieJar.update(SimpleCookie(...)) with a standard HTTP-date Expires value

Fixes #6004

## Testing
- python -c "import sys, pytest; sys.path.insert(0, 'src'); raise SystemExit(pytest.main(['tests/test_requests.py::TestMorselToCookieExpires', '-q']))"
- python -m ruff check src/requests/cookies.py tests/test_requests.py
- git diff --check