### PR TITLE
Add more URLs to project metadata (Changelog, Issues, Sponsor)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,11 @@ classifiers = [
 ]
 
 [project.urls]
+Changelog = "https://requests.readthedocs.io/en/latest/community/updates/#release-history"
 Documentation = "https://requests.readthedocs.io"
+Issues = "https://github.com/psf/requests/issues"
 Source = "https://github.com/psf/requests"
+Sponsor = "https://www.python.org/psf/sponsorship/"
 
 [project.optional-dependencies]
 security = []


### PR DESCRIPTION
It would be nice if the PyPI page for `requests` listed the links for the changelog, the issues page, and the sponsoring page. This is useful not only for humans browsing PyPI, but for automated tools using the PyPI API like this:

    curl https://pypi.org/pypi/requests/json | jq '.info.project_urls'

These URLs will be given special icons on the PyPI.org website. See https://docs.pypi.org/project_metadata/

I'm writing a tool that automatically compiles a description of changes when upgrading dependencies, based on the changelogs of the dependencies. It looks at the project's metadata to find the URL of the changelog. This pull request adds the missing metadata that would be helpful for such a tool.