### PR TITLE
fix: HTTPDigestAuth properly handles bytes credentials

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -159,6 +159,9 @@ class HTTPDigestAuth(AuthBase):
         :rtype: str
         """
 
+        username = self.username.decode("utf-8") if isinstance(self.username, bytes) else self.username
+        password = self.password.decode("utf-8") if isinstance(self.password, bytes) else self.password
+
         realm = self._thread_local.chal["realm"]
         nonce = self._thread_local.chal["nonce"]
         qop = self._thread_local.chal.get("qop")
@@ -218,7 +221,7 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -251,7 +254,7 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX should the partial digests be encoded too?
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{username}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
## Problem

When bytes are passed as username/password to `HTTPDigestAuth`, the digest header contains the bytes repr instead of the decoded string:

```python
HTTPDigestAuth('Ondřej'.encode('utf-8'), 'heslíčko')
# Creates: Digest username="b'Ond\\xc5\\x99ej'"  # WRONG
```

## Root Cause

In `build_digest_header`, `self.username` and `self.password` are used directly in f-strings. When they are bytes objects, Python's f-string calls `repr()` on them, producing the bytes representation instead of the decoded string.

## Fix

Decode bytes credentials to str using UTF-8 at the beginning of `build_digest_header` before using them in:
1. The A1 hash calculation (`username:realm:password`)
2. The Digest header output

## Testing

- Verified with non-latin UTF-8 credentials (Czech characters)
- All existing digest auth tests pass
- Both bytes and str credentials now produce correct headers

Fixes #6102
