### PR TITLE
[Fix] response.content losing read errors on second access (#4965)

### DIFF
--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -765,6 +765,7 @@ class Response:
     def __init__(self) -> None:
         self._content = False
         self._content_consumed = False
+        self._content_error: Exception | None = None
         self._next = None
 
         #: Integer Code of responded HTTP Status, e.g. 404 or 200.
@@ -1035,6 +1036,9 @@ class Response:
     def content(self) -> bytes:
         """Content of the response, in bytes."""
 
+        if self._content_error is not None:
+            raise self._content_error
+
         if self._content is False:
             # Read the contents.
             if self._content_consumed:
@@ -1043,7 +1047,14 @@ class Response:
             if self.status_code == 0 or self.raw is None:
                 self._content = None
             else:
-                self._content = b"".join(self.iter_content(CONTENT_CHUNK_SIZE)) or b""
+                try:
+                    self._content = (
+                        b"".join(self.iter_content(CONTENT_CHUNK_SIZE)) or b""
+                    )
+                except Exception as e:
+                    self._content_error = e
+                    self._content_consumed = True
+                    raise
 
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -426,3 +426,24 @@ def test_json_decode_compatibility_for_alt_utf_encodings():
     assert isinstance(excinfo.value, requests.exceptions.RequestException)
     assert isinstance(excinfo.value, JSONDecodeError)
     assert r.text not in str(excinfo.value)
+
+
+def test_response_content_retains_error():
+    """Accessing response.content twice should re-raise the same error
+    instead of returning empty bytes. Regression test for #4965."""
+
+    class FaultyRaw:
+        def stream(self, chunk_size, decode_content=True):
+            yield b"some data"
+            raise requests.exceptions.ChunkedEncodingError("incomplete chunked read")
+
+    response = requests.Response()
+    response.status_code = 200
+    response.raw = FaultyRaw()
+
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        response.content
+
+    # Second access must re-raise, not return empty bytes
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        response.content


### PR DESCRIPTION
## Problem

Accessing `response.content` twice after a stream read error returns empty bytes on the second access instead of re-raising the error.

**Reproduction:**
```python
response = requests.post("http://connreset.biz/get/incomplete/chunked", stream=True)
try:
    response.content  # raises ChunkedEncodingError
except Exception:
    pass
content = response.content  # BUG: returns b"" instead of re-raising
```

**Root cause:** In the `content` property, when `b"".join(self.iter_content(...))` raises mid-stream, both `_content` stays `False` and `_content_consumed` stays `False` (the generator's `_content_consumed = True` line at the end of `generate()` is never reached because the generator dies mid-iteration). On second access, the content property re-enters the `if self._content is False` branch, `_content_consumed` is still `False`, so it tries reading from the already-exhausted stream and silently gets empty bytes.

## Fix

Cache the exception in a new `_content_error` attribute. On any subsequent access, re-raise the cached error immediately.

**Changes:**
- `src/requests/models.py`: Added `_content_error` attribute to `__init__`, wrap content read in try/except to cache errors, check for cached error at the top of `content` property.
- `tests/test_lowlevel.py`: Added `test_response_content_retains_error` regression test using a mock raw stream that raises `ChunkedEncodingError` mid-read.

Fixes #4965
