### PR TITLE
[codex] Fix Link header parsing for equals signs

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -988,7 +988,7 @@ def parse_header_links(value: str) -> list[dict[str, str]]:
 
         for param in params.split(";"):
             try:
-                key, value = param.split("=")
+                key, value = param.split("=", 1)
             except ValueError:
                 break
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -690,6 +690,17 @@ def test_iter_slices(value, length):
                 {"url": "http://.../back.jpeg"},
             ],
         ),
+        (
+            '<https://example.com/?cursor=a=b>; rel="next"; title="A=B"; type="text/html"',
+            [
+                {
+                    "url": "https://example.com/?cursor=a=b",
+                    "rel": "next",
+                    "title": "A=B",
+                    "type": "text/html",
+                }
+            ],
+        ),
         ("", []),
     ),
 )


### PR DESCRIPTION
## Summary
- Update Link header parameter parsing so values containing equals signs are preserved instead of being dropped.

## Validation
- pytest tests/test_utils.py and full pytest passed; ruff passed.

## Notes
- Opened as a draft PR for maintainer review.
