### PR TITLE
Remove method cookies set to None

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -26,6 +26,7 @@ from .cookies import (
     cookiejar_from_dict,
     extract_cookies_to_jar,
     merge_cookies,
+    remove_cookie_by_name,
 )
 from .exceptions import (
     ChunkedEncodingError,
@@ -522,6 +523,7 @@ class Session(SessionRedirectMixin):
         method = cast(str, request.method)
 
         cookies = request.cookies or {}
+        method_cookie_mapping = cookies if isinstance(cookies, Mapping) else None
 
         # Bootstrap CookieJar.
         if not isinstance(cookies, cookielib.CookieJar):
@@ -531,6 +533,10 @@ class Session(SessionRedirectMixin):
         merged_cookies = merge_cookies(
             merge_cookies(RequestsCookieJar(), self.cookies), cookies
         )
+        if method_cookie_mapping is not None:
+            for cookie_name, cookie_value in method_cookie_mapping.items():
+                if cookie_value is None:
+                    remove_cookie_by_name(merged_cookies, cookie_name)
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -422,6 +422,23 @@ class TestRequests:
         # Session cookie should not be modified
         assert s.cookies["foo"] == "bar"
 
+    def test_request_cookie_none_removes_session_cookie(self):
+        s = requests.session()
+        s.cookies.update({"from-my": "browser", "keep": "yes"})
+        req = requests.Request(
+            "GET",
+            "https://example.com/",
+            cookies={"another": "cookie", "from-my": None},
+        )
+
+        prep = s.prepare_request(req)
+
+        cookie_header = prep.headers["Cookie"]
+        assert "from-my" not in cookie_header
+        assert "keep=yes" in cookie_header
+        assert "another=cookie" in cookie_header
+        assert s.cookies["from-my"] == "browser"
+
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()
         s.get(httpbin("cookies"), cookies={"foo": "baz"})


### PR DESCRIPTION
Summary
- Treat method-level cookie mappings with value None as removals after session cookies are merged.
- Leave the session cookie jar unchanged while omitting those cookies from the prepared request.
- Add regression coverage for the malformed Cookie header reported in #2716.

Closes #2716

Tests
- `.venv\Scripts\python.exe -m pytest tests/test_requests.py -q -k request_cookie_none_removes_session_cookie`
- `.venv\Scripts\python.exe -m pytest tests/test_requests.py -q -k cookie`
- `.venv\Scripts\python.exe -m ruff check src/requests/sessions.py tests/test_requests.py`
- `git diff --check`

I also ran `.venv\Scripts\python.exe -m pytest tests/test_requests.py -q`; it reached 337 passed, 1 skipped, and 1 xpassed, with 3 local environment failures from proxy/TLS certificate setup.