### PR TITLE
docs: add tuple timeout example to Quickstart

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -549,6 +549,21 @@ to hang indefinitely::
     not time out.
 
 
+
+If no timeout is specified explicitly, requests do not time out.
+
+.. note::
+
+   A timeout can also be specified as a tuple ``(connect_timeout, read_timeout)``
+   to set separate limits for establishing the connection and waiting for the
+   server to send data.
+
+   For example::
+
+      >>> requests.get('https://github.com/', timeout=(3.05, 27))
+
+
+
 Errors and Exceptions
 ---------------------
 


### PR DESCRIPTION
## Summary

Adds a short note to the Quickstart documentation showing that the `timeout` parameter also accepts a `(connect_timeout, read_timeout)` tuple.

## Motivation

Many users begin with the Quickstart guide. Including this example makes the tuple form of `timeout` easier to discover without needing to read the Advanced documentation.