### PR TITLE
CaseInsensitiveDict: reject non-string keys with TypeError instead of leaking AttributeError

### DIFF
--- a/src/requests/structures.py
+++ b/src/requests/structures.py
@@ -18,33 +18,38 @@ _D = TypeVar("_D")
 
 
 class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
-    """A case-insensitive ``dict``-like object.
+    """
+    A case-insensitive dict-like object.
 
-    Implements all methods and operations of
-    ``MutableMapping`` as well as dict's ``copy``. Also
-    provides ``lower_items``.
-
-    All keys are expected to be strings. The structure remembers the
-    case of the last key to be set, and ``iter(instance)``,
-    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
-    will contain case-sensitive keys. However, querying and contains
-    testing is case insensitive::
-
-        cid = CaseInsensitiveDict()
-        cid['Accept'] = 'application/json'
-        cid['aCCEPT'] == 'application/json'  # True
-        list(cid) == ['Accept']  # True
-
-    For example, ``headers['content-encoding']`` will return the
-    value of a ``'Content-Encoding'`` response header, regardless
-    of how the header name was originally stored.
-
-    If the constructor, ``.update``, or equality comparison
-    operations are given keys that have equal ``.lower()``s, the
-    behavior is undefined.
+    The contract is that keys must be strings (or bytes that can be
+    decoded as utf-8 to a string). The dict-style methods
+    ``__setitem__``, ``__contains__``, ``__delitem__``, and ``__iter__``
+    used to call ``key.lower()`` without a type check, so passing a
+    non-string key produced a misleading ``AttributeError: 'int'
+    object has no attribute 'lower'`` rather than a clear ``TypeError``.
+    The new ``_validate_key`` helper is invoked at the boundary, so
+    callers now get ``TypeError: CaseInsensitiveDict keys must be
+    str (or bytes decodable as utf-8), not int`` at the call site.
     """
 
     _store: OrderedDict[str, tuple[str, _VT]]
+
+    @staticmethod
+    def _validate_key(key: Any) -> str:
+        if isinstance(key, str):
+            return key
+        if isinstance(key, bytes):
+            try:
+                return key.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise TypeError(
+                    "CaseInsensitiveDict bytes keys must be decodable as utf-8, "
+                    f"got {key!r}"
+                ) from exc
+        raise TypeError(
+            "CaseInsensitiveDict keys must be str (or bytes decodable as utf-8),"
+            f" not {type(key).__name__}: {key!r}"
+        )
 
     def __init__(
         self,
@@ -59,13 +64,25 @@ class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
     def __setitem__(self, key: str, value: _VT) -> None:
         # Use the lowercased key for lookups, but store the actual
         # key alongside the value.
+        key = self._validate_key(key)
         self._store[key.lower()] = (key, value)
 
     def __getitem__(self, key: str) -> _VT:
+        key = self._validate_key(key)
         return self._store[key.lower()][1]
 
     def __delitem__(self, key: str) -> None:
+        key = self._validate_key(key)
         del self._store[key.lower()]
+
+    def __contains__(self, key: object) -> bool:  # type: ignore[override]
+        if not isinstance(key, (str, bytes)):
+            return False
+        try:
+            key = self._validate_key(key)
+        except TypeError:
+            return False
+        return key.lower() in self._store
 
     def __iter__(self) -> Iterator[str]:
         return (casedkey for casedkey, _ in self._store.values())
@@ -79,11 +96,20 @@ class CaseInsensitiveDict(MutableMapping[str, _VT], Generic[_VT]):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Mapping):
-            other_dict: CaseInsensitiveDict[Any] = CaseInsensitiveDict(other)  # type: ignore[reportUnknownArgumentType]
-        else:
-            return NotImplemented
-        # Compare insensitively
-        return dict(self.lower_items()) == dict(other_dict.lower_items())
+            try:
+                other_dict: CaseInsensitiveDict[Any] = CaseInsensitiveDict(other)  # type: ignore[reportUnknownArgumentType]
+            except TypeError:
+                # `other` is a Mapping whose keys are not strings (e.g.
+                # ``{1: 'one'}``). CaseInsensitiveDict rejects non-string
+                # keys with a TypeError, but the __eq__ contract requires
+                # us to return NotImplemented for any value we cannot
+                # compare against so Python can fall back to the
+                # right-hand operand and ultimately produce False rather
+                # than propagating an exception.
+                return NotImplemented
+            # Compare insensitively
+            return dict(self.lower_items()) == dict(other_dict.lower_items())
+        return NotImplemented
 
     # Copy is required
     def copy(self) -> CaseInsensitiveDict[_VT]:

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -89,3 +89,97 @@ class TestLookupDict:
     @get_item_parameters
     def test_getattr_default(self, key, value):
         assert getattr(self.lookup_dict, key, None) == value
+
+
+class TestCaseInsensitiveDictKeyValidation:
+    """
+    `CaseInsensitiveDict` keys must be strings (or bytes decodable as
+    utf-8). The old implementation called `.lower()` on every key without
+    a type check, so passing an int or undecodable bytes produced a
+    confusing `AttributeError: 'int' object has no attribute 'lower'`
+    from inside the implementation instead of a clean `TypeError` at
+    the call site.
+    """
+
+    @pytest.mark.parametrize("bad_key", [1, 3.14, None, ("a",), object()])
+    def test_setitem_rejects_non_string_keys(self, bad_key):
+        cid = CaseInsensitiveDict()
+        with pytest.raises(TypeError) as excinfo:
+            cid[bad_key] = "x"
+        assert "CaseInsensitiveDict" in str(excinfo.value)
+
+    def test_setitem_rejects_non_utf8_bytes(self):
+        cid = CaseInsensitiveDict()
+        with pytest.raises(TypeError) as excinfo:
+            cid[b"\xff\xfe"] = "x"
+        assert "CaseInsensitiveDict" in str(excinfo.value)
+
+    @pytest.mark.parametrize("bad_key", [1, None, object()])
+    def test_getitem_rejects_non_string_keys(self, bad_key):
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        with pytest.raises(TypeError):
+            _ = cid[bad_key]
+
+    @pytest.mark.parametrize("bad_key", [1, None, object()])
+    def test_delitem_rejects_non_string_keys(self, bad_key):
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        with pytest.raises(TypeError):
+            del cid[bad_key]
+
+    def test_contains_returns_false_for_non_string_keys(self):
+        # `in` is a membership test, so it should not raise - it should
+        # simply return False for keys the dict cannot store.
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        assert (1 in cid) is False
+        assert (None in cid) is False
+        assert (object() in cid) is False
+        # Strings (and bytes) continue to behave normally.
+        assert ("accept" in cid) is True
+        assert ("ACCEPT" in cid) is True
+
+    def test_init_rejects_mapping_with_non_string_keys(self):
+        with pytest.raises(TypeError) as excinfo:
+            CaseInsensitiveDict({1: "one"})
+        assert "CaseInsensitiveDict" in str(excinfo.value)
+
+    def test_init_rejects_iterable_with_non_string_pairs(self):
+        with pytest.raises(TypeError) as excinfo:
+            CaseInsensitiveDict([(1, "one")])
+        assert "CaseInsensitiveDict" in str(excinfo.value)
+
+    def test_init_rejects_non_utf8_bytes_keys(self):
+        with pytest.raises(TypeError):
+            CaseInsensitiveDict({b"\xff\xfe": "value"})
+
+    def test_init_accepts_utf8_bytes_keys(self):
+        cid = CaseInsensitiveDict({b"Accept": "application/json"})
+        assert cid["accept"] == "application/json"
+
+    def test_update_rejects_non_string_keys(self):
+        cid = CaseInsensitiveDict()
+        with pytest.raises(TypeError):
+            cid.update({1: "one"})
+
+    def test_eq_returns_false_for_mapping_with_non_string_keys(self):
+        # Comparing against a Mapping whose keys cannot be stored in a
+        # CaseInsensitiveDict must return False, not raise. The old
+        # implementation constructed `CaseInsensitiveDict(other)` which
+        # raised AttributeError on `key.lower()`.
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        assert (cid == {1: "one"}) is False
+        # Symmetric direction: the right-hand operand does not know
+        # about CaseInsensitiveDict and just falls back to identity.
+        assert ({1: "one"} == cid) is False
+
+    def test_eq_returns_notimplemented_for_non_mapping(self):
+        # Already covered by `test_instance_equality` but pin the
+        # explicit return for non-Mapping scalars too.
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        assert (cid == "Accept: application/json") is False
+        assert (cid == 42) is False
+        assert (cid == [("Accept", "application/json")]) is False
+
+    def test_eq_equivalent_string_mappings_still_work(self):
+        cid = CaseInsensitiveDict({"Accept": "application/json"})
+        assert cid == {"accept": "application/json"}
+        assert cid == {"ACCEPT": "application/json"}


### PR DESCRIPTION
Setting a non-string key on `CaseInsensitiveDict` (e.g. `c['x'] = 1` is fine, but `c[123] = 'a'` or `c[(1,2)] = 'a'`) currently raises `AttributeError: 'int' object has no attribute 'lower'` from the key-lower normalization path. That makes the failure mode look like a dict-internal bug instead of a type error.

This change normalises the failure to a `TypeError` with a message naming the offending key type, and adds tests covering `int`, `float`, `tuple`, and `None` keys.