### PR TITLE
fix: decode bytes credentials in HTTPDigestAuth to prevent b'...' repr in hashes

### DIFF
--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -218,7 +218,9 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        _username = self.username.decode("utf-8") if isinstance(self.username, bytes) else self.username
+        _password = self.password.decode("utf-8") if isinstance(self.password, bytes) else self.password
+        A1 = f"{_username}:{realm}:{_password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -251,7 +253,7 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX should the partial digests be encoded too?
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{_username}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:


### PR DESCRIPTION
## Summary

- `HTTPDigestAuth` stores `username` and `password` as `bytes | str`, but `build_digest_header` interpolated them directly into f-strings
- For bytes credentials, Python's f-string produces `b'username'` (with the `b` prefix and quotes) instead of the raw string value
- This causes two bugs: (1) the A1 hash is computed over the wrong string, producing an incorrect digest; (2) the `Authorization` header contains `username="b'user'"` instead of `username="user"`, which servers reject

## Changes

- Decode bytes username/password to UTF-8 strings before constructing `A1` and the `Authorization` header base string
- Both the hash computation (`A1 = f"{_username}:{realm}:{_password}"`) and the header value (`username="{_username}"`) are fixed
- Matches the convention already used in `prepare_url` and elsewhere in the codebase

## Test plan

- [ ] Create `HTTPDigestAuth(b"user", b"pass")` and confirm the Authorization header contains `username="user"` not `username="b'user'"`
- [ ] Verify `HTTPDigestAuth("user", "pass")` (str credentials) still works identically
- [ ] Run existing digest auth tests: `pytest tests/test_auth.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)