### PR TITLE
return list of headers from MockResponse.getheaders

### DIFF
--- a/src/requests/cookies.py
+++ b/src/requests/cookies.py
@@ -129,7 +129,7 @@ class MockResponse:
         return self._headers
 
     def getheaders(self, name: str) -> Any:
-        self._headers.getheaders(name)
+        return self._headers.getheaders(name)
 
 
 def extract_cookies_to_jar(


### PR DESCRIPTION
http.client.HTTPResponse.getheaders() returns the list of values for the given header name, but MockResponse.getheaders() dropped the return value of the wrapped HTTPMessage.getheaders() call, so the method always returned None. Any code calling MockResponse.getheaders(name) expecting a list got None and would crash on the next access.

This brings MockResponse's behavior in line with the http.client contract it is mimicking for the cookie code path.