### PR TITLE
Decode bytes credentials in HTTPDigestAuth as UTF-8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,9 @@ dev
 ---
 
 - \[Short description of non-trivial change.\]
+- `HTTPDigestAuth` now accepts `bytes` credentials, decoding them as UTF-8,
+  so non-latin usernames and passwords produce a correct `Authorization`
+  header instead of the bytes repr. (#6102)
 
 
 2.34.2 (2026-05-14)

--- a/src/requests/auth.py
+++ b/src/requests/auth.py
@@ -166,6 +166,16 @@ class HTTPDigestAuth(AuthBase):
         opaque = self._thread_local.chal.get("opaque")
         hash_utf8 = None
 
+        # Accept bytes credentials by decoding them as UTF-8. Embedding bytes
+        # directly in the header via an f-string would render their repr
+        # (e.g. ``username="b'Ond\xc5\x99ej'"``) and hash the wrong value.
+        username = self.username
+        password = self.password
+        if isinstance(username, bytes):
+            username = username.decode("utf-8")
+        if isinstance(password, bytes):
+            password = password.decode("utf-8")
+
         if algorithm is None:
             _algorithm = "MD5"
         else:
@@ -218,7 +228,7 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += f"?{p_parsed.query}"
 
-        A1 = f"{self.username}:{realm}:{self.password}"
+        A1 = f"{username}:{realm}:{password}"
         A2 = f"{method}:{path}"
 
         HA1 = hash_utf8(A1)
@@ -251,7 +261,7 @@ class HTTPDigestAuth(AuthBase):
 
         # XXX should the partial digests be encoded too?
         base = (
-            f'username="{self.username}", realm="{realm}", nonce="{nonce}", '
+            f'username="{username}", realm="{realm}", nonce="{nonce}", '
             f'uri="{path}", response="{respdig}"'
         )
         if opaque:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -745,6 +745,28 @@ class TestRequests:
             os.environ["NETRC"] = old_netrc
             os.unlink(netrc_file)
 
+    def test_DIGEST_AUTH_ACCEPTS_BYTES_CREDENTIALS(self):
+        """Bytes credentials are decoded as UTF-8 for the digest header.
+
+        Regression test for #6102: passing bytes (as older advice suggested
+        for non-latin credentials) rendered the bytes repr into the header,
+        e.g. ``username="b'Ond\\xc5\\x99ej'"``.
+        """
+        challenge = {"realm": "test", "nonce": "abc123", "qop": "auth"}
+
+        str_auth = HTTPDigestAuth("Ondřej", "heslíčko")
+        str_auth.init_per_thread_state()
+        str_auth._thread_local.chal = dict(challenge)
+        str_header = str_auth.build_digest_header("GET", "http://example.org/")
+
+        bytes_auth = HTTPDigestAuth("Ondřej".encode(), "heslíčko".encode())
+        bytes_auth.init_per_thread_state()
+        bytes_auth._thread_local.chal = dict(challenge)
+        bytes_header = bytes_auth.build_digest_header("GET", "http://example.org/")
+
+        assert 'username="Ondřej"' in str_header
+        assert 'username="Ondřej"' in bytes_header
+
     def test_DIGEST_HTTP_200_OK_GET(self, httpbin):
         for authtype in self.digest_auth_algo:
             auth = HTTPDigestAuth("user", "pass")


### PR DESCRIPTION
Closes #6102

## Problem

`HTTPDigestAuth` corrupts the `Authorization` header when credentials are passed as `bytes` (which older advice, e.g. in #5089, recommended for non-latin credentials):

```python
HTTPDigestAuth("Ondřej".encode("utf-8"), "heslíčko".encode("utf-8"))
# -> Digest username="b'Ond\xc5\x99ej'", ...
```

The bytes are interpolated into the header via an f-string, so their `repr` is rendered and the wrong value is hashed.

## Fix

Decode `bytes` username/password as UTF-8 at the top of `build_digest_header` before they are used in the header and the digest. `str` credentials keep working exactly as before; `bytes` now produce the correct `username="Ondřej"` and matching digest.

## Tests

Added `test_DIGEST_AUTH_ACCEPTS_BYTES_CREDENTIALS` (no network) asserting both `str` and `bytes` credentials render `username="Ondřej"`. Full digest suite passes (7 passed). Added a HISTORY.md entry.