### PR TITLE
Support for QUERY http method

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before opening any issues or proposing any pull requests, please read
 our [Contributor's Guide](https://requests.readthedocs.io/en/latest/dev/contributing/)
-as well as our [AI Policy](./AI_POLICY.md).
+as well as our [AI Policy](./.github/AI_POLICY.md).
 
 To get the greatest chance of helpful responses, please also observe the
 following additional notes.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,7 +13,7 @@ important right here and provide links to the canonical documentation.
 Main Interface
 --------------
 
-All of Requests' functionality can be accessed by these 7 methods.
+All of Requests' functionality can be accessed by these 8 methods.
 They all return an instance of the :class:`Response <Response>` object.
 
 .. autofunction:: request
@@ -24,6 +24,7 @@ They all return an instance of the :class:`Response <Response>` object.
 .. autofunction:: put
 .. autofunction:: patch
 .. autofunction:: delete
+.. autofunction:: query
 
 Exceptions
 ----------

--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -168,7 +168,7 @@ from .__version__ import (
     __url__,
     __version__,
 )
-from .api import delete, get, head, options, patch, post, put, request
+from .api import delete, get, head, options, patch, post, put, query, request
 from .exceptions import (
     ConnectionError,
     ConnectTimeout,
@@ -211,6 +211,7 @@ __all__ = (
     "request",
     "session",
     "utils",
+    "query"
 )
 
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -186,3 +186,6 @@ if TYPE_CHECKING:
 
         params: ParamsType
         json: JsonType
+
+    class QueryKwargs(BaseRequestKwargs, total=False):
+        params: ParamsType

--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -26,7 +26,7 @@ def request(
 ) -> Response:
     """Constructs and sends a :class:`Request <Request>`.
 
-    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, ``DELETE`` or ``QUERY``.
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
         in the query string for the :class:`Request`.
@@ -178,3 +178,18 @@ def delete(url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:
     """
 
     return request("delete", url, **kwargs)
+
+
+def query(url: _t.UriType, data: _t.DataType = None, json: _t.JsonType = None, **kwargs: Unpack[_t.QueryKwargs]) -> Response:
+    r"""Sends a QUERY request.
+
+    :param url: URL for the new :class:`Request` object.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the :class:`Request`.
+    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
+    :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
+    """
+
+    return request("query", url, data=data, json=json, **kwargs)

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -250,7 +250,7 @@ class SessionRedirectMixin:
             if resp.status_code not in (
                 codes.temporary_redirect,
                 codes.permanent_redirect,
-            ):
+            ) and prepared_request.method != "QUERY": #
                 # https://github.com/psf/requests/issues/3490
                 purged_headers = ("Content-Length", "Content-Type", "Transfer-Encoding")
                 for header in purged_headers:
@@ -375,13 +375,16 @@ class SessionRedirectMixin:
         """
         method = prepared_request.method
 
-        # https://tools.ietf.org/html/rfc7231#section-6.4.4
+        # see https://tools.ietf.org/html/rfc7231#section-6.4.4
+        # also see: https://datatracker.ietf.org/doc/html/rfc10008#name-redirection
+
+        # "303: See Other" should always be turned into GET:
         if response.status_code == codes.see_other and method != "HEAD":
             method = "GET"
 
         # Do what the browsers do, despite standards...
-        # First, turn 302s into GETs.
-        if response.status_code == codes.found and method != "HEAD":
+        # First, turn 302s into GETs (Except HEAD and QUERY).
+        if response.status_code == codes.found and method not in ["HEAD", "QUERY"]:
             method = "GET"
 
         # Second, if a POST is responded to with a 301, turn it into a GET.
@@ -748,6 +751,25 @@ class Session(SessionRedirectMixin):
         """
 
         return self.request("DELETE", url, **kwargs)
+
+    def query(
+        self,
+        url: _t.UriType,
+        data: _t.DataType = None,
+        json: _t.JsonType = None,
+        **kwargs: Unpack[_t.QueryKwargs],
+    ) -> Response:
+        r"""Sends a QUERY request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
+
+        return self.request("QUERY", url, data=data, json=json, **kwargs)
 
     def send(self, request: PreparedRequest, **kwargs: Any) -> Response:
         """Send a given PreparedRequest.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ import threading
 import pytest
 
 from requests.compat import urljoin
+from tests.monkeypatch_httpbin import allow_query_method
+
+
+def pytest_configure(config):
+    from httpbin import app
+    allow_query_method(app)
 
 
 def prepare_url(value):

--- a/tests/monkeypatch_httpbin.py
+++ b/tests/monkeypatch_httpbin.py
@@ -1,0 +1,24 @@
+from flask import Flask
+
+"""Local patches for pytest-httpbin's bundled Flask application to test QUERY method."""
+
+QUERY_ENDPOINTS_IN_TEST = {
+    "view_anything",
+    "redirect_n_times",
+    "redirect_to"
+}
+
+
+def allow_query_method(app: Flask, endpoints: set[str] = QUERY_ENDPOINTS_IN_TEST):
+    """Allow QUERY on selected httpbin endpoints.
+
+    httpbin registers Flask routes at import time, so patching ``app.route``
+    later will not affect existing rules. The registered URL rules are mutable,
+    though, and pytest-httpbin serves this same app object.
+    """
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint in endpoints:
+            if rule.methods is None:
+                rule.methods = {"QUERY"}
+            else:
+                rule.methods.add("QUERY")

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -88,11 +88,13 @@ class TestRequests:
         requests.session
         requests.session().get
         requests.session().head
+        requests.session().query
         requests.get
         requests.head
         requests.put
         requests.patch
         requests.post
+        requests.query
         # Not really an entry point, but people rely on it.
         from requests.packages.urllib3.poolmanager import PoolManager  # noqa:F401
 
@@ -126,17 +128,18 @@ class TestRequests:
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert "Content-Length" not in req.headers
 
-    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS"))
+    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS", "QUERY"))
     def test_no_body_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert req.headers["Content-Length"] == "0"
 
-    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS"))
+    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS", "QUERY"))
     def test_empty_content_length(self, httpbin, method):
         req = requests.Request(method, httpbin(method.lower()), data="").prepare()
         assert req.headers["Content-Length"] == "0"
 
-    def test_override_content_length(self, httpbin):
+    @pytest.mark.parametrize("method", ("POST", "PUT", "PATCH", "OPTIONS", "QUERY"))
+    def test_override_content_length(self, httpbin, method):
         headers = {"Content-Length": "not zero"}
         r = requests.Request("POST", httpbin("post"), headers=headers).prepare()
         assert "Content-Length" in r.headers
@@ -184,6 +187,12 @@ class TestRequests:
     def test_binary_put(self):
         request = requests.Request(
             "PUT", "http://example.com", data="ööö".encode()
+        ).prepare()
+        assert isinstance(request.body, bytes)
+
+    def test_binary_query(self):
+        request = requests.Request(
+            "QUERY", "http://example.com", data="ööö".encode()
         ).prepare()
         assert isinstance(request.body, bytes)
 
@@ -319,20 +328,10 @@ class TestRequests:
 
     def test_header_and_body_removal_on_redirect(self, httpbin):
         purged_headers = ("Content-Length", "Content-Type")
-        ses = requests.Session()
-        req = requests.Request("POST", httpbin("post"), data={"test": "data"})
-        prep = ses.prepare_request(req)
-        resp = ses.send(prep)
-
-        # Mimic a redirect response
-        resp.status_code = 302
-        resp.headers["location"] = "get"
-
-        # Run request through resolve_redirects
-        next_resp = next(ses.resolve_redirects(resp, prep))
-        assert next_resp.request.body is None
+        resp = requests.post(httpbin("redirect-to?url=post&status_code=302"), data={"test": "data"})
+        assert resp.request.body is None
         for header in purged_headers:
-            assert header not in next_resp.request.headers
+            assert header not in resp.request.headers
 
     def test_transfer_enc_removal_on_redirect(self, httpbin):
         purged_headers = ("Transfer-Encoding", "Content-Type")
@@ -2326,6 +2325,59 @@ class TestRequests:
         assert r.history[1].status_code == 200
         assert not r.history[1].is_redirect
         assert r.url == urls_test[2]
+
+    def test_http_307_allow_redirect_query(self, httpbin):
+        r = requests.query(
+            httpbin("redirect-to"),
+            data="test",
+            params={"url": "anything", "status_code": 307}
+        )
+        assert r.status_code == 200
+        assert r.request.method == "QUERY"
+        assert r.history[0].status_code == 307
+        assert r.history[0].is_redirect
+        assert r.json()["data"] == "test"
+
+    def test_http_308_allow_redirect_query(self, httpbin):
+        r = requests.query(
+            httpbin("redirect-to"),
+            data="test",
+            params={"url": "anything", "status_code": 307}
+        )
+        assert r.status_code == 200
+        assert r.request.method == "QUERY"
+        assert r.history[0].status_code == 307
+        assert r.history[0].is_redirect
+        assert r.json()["data"] == "test"
+    
+
+    @pytest.mark.parametrize("status_code", [301, 302, 307, 308])
+    def test_header_and_body_not_removed_on_redirect_query(self, httpbin, status_code):
+        """
+        As per RFC-10008 Section 2.5 Redirection, redirects keep headers and body (except 303).
+        See: https://datatracker.ietf.org/doc/html/rfc10008#name-redirection
+        """
+        required_headers = ("Content-Length", "Content-Type")
+        r = requests.query(httpbin(f"redirect-to?url=anything/&status_code={status_code}"), data={"test": "data"})
+
+        assert r.request.body == "test=data"
+        assert r.request.method == "QUERY"
+        for header in required_headers:
+            assert header in r.request.headers
+
+    def test_header_and_body_removed_on_303_query(self, httpbin):
+        """
+        As per RFC-10008 Section 2.5 Redirection, 303 redirects turns into GET requests. 
+        See: https://datatracker.ietf.org/doc/html/rfc10008#name-redirection
+        """
+        purged_headers = ("Content-Length", "Content-Type")
+        r = requests.query(httpbin(f"redirect-to?url=anything&status_code={303}"), data={"test": "data"})
+
+        assert r.request.body is None
+        assert r.request.method == "GET"
+        assert r.request.url == httpbin("anything")
+        for header in purged_headers:
+            assert header not in r.request.headers
 
 
 class TestCaseInsensitiveDict:


### PR DESCRIPTION
This PR adds the QUERY http method to the API as defined in [RFC10008](https://datatracker.ietf.org/doc/html/rfc10008).
Albeit we can use `Session.request` method to send arbitrary HTTP verbs, in the case of QUERY, [the redirection rules](https://datatracker.ietf.org/doc/html/rfc10008#name-redirection) are slightly different: 
- 303s follow "Location" header with GET (no change here)
- 301 and 302s do not drop body, and not get turned into GETs

This PR adds the QUERY method, handle the redirection rules and adds tests related to it. During test, httpbin had to be monkeypatched to accept QUERY method on some paths.  Also includes a minor fix to the "AI policy" link in the "Contribution Guidelines".

Relates to issue #7574. I have been bitten by the lack of QUERY method and having to POST a body for complex retrieval operations a bunch of times, so this has been a welcoming change for me, unfortunately adoption is slow.
