### PR TITLE
Fix link to AI Policy in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before opening any issues or proposing any pull requests, please read
 our [Contributor's Guide](https://requests.readthedocs.io/en/latest/dev/contributing/)
-as well as our [AI Policy](./.github/AI_POLICY.md).
+as well as our [AI Policy](/.github/AI_POLICY.md).
 
 To get the greatest chance of helpful responses, please also observe the
 following additional notes.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before opening any issues or proposing any pull requests, please read
 our [Contributor's Guide](https://requests.readthedocs.io/en/latest/dev/contributing/)
-as well as our [AI Policy](./AI_POLICY.md).
+as well as our [AI Policy](./.github/AI_POLICY.md).
 
 To get the greatest chance of helpful responses, please also observe the
 following additional notes.


### PR DESCRIPTION
The AI Policy is not accessible with a relative link inside .github folder, this PR fixes it.