### PR TITLE
Add query method newly introduced in RFC 10008

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,6 +131,22 @@ API Changes
       r = requests.get('https://api.github.com/events')
       r.json()   # This *call* raises an exception if JSON decoding fails
 
+  Requests also supports the newer ``QUERY`` method for safe requests with a
+  body when you need to send more complex search parameters than fit well in a
+  URL.
+
+  ::
+
+     payload = {
+        "keywords": ["http", "query", "method"],
+        "filters": {
+           "dateFrom": "2024-01-01",
+           "dateTo": "2024-12-31",
+        },
+     }
+     r = requests.query('https://api.example.com/search', json=payload)
+     r.json()
+
 * The ``Session`` API has changed. Sessions objects no longer take parameters.
   ``Session`` is also now capitalized, but it can still be
   instantiated with a lowercase ``session`` for backwards compatibility.

--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -168,7 +168,7 @@ from .__version__ import (
     __url__,
     __version__,
 )
-from .api import delete, get, head, options, patch, post, put, request
+from .api import delete, get, head, options, patch, post, put, query, request
 from .exceptions import (
     ConnectionError,
     ConnectTimeout,
@@ -208,6 +208,7 @@ __all__ = (
     "patch",
     "post",
     "put",
+    "query",
     "request",
     "session",
     "utils",

--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -174,13 +174,6 @@ if TYPE_CHECKING:
         data: DataType
         json: JsonType
 
-    class QueryKwargs(BaseRequestKwargs, total=False):
-        """kwargs for query()."""
-
-        params: ParamsType
-        data: DataType
-        json: JsonType
-
     class GetKwargs(BaseRequestKwargs, total=False):
         data: DataType
         json: JsonType

--- a/src/requests/_types.py
+++ b/src/requests/_types.py
@@ -174,6 +174,13 @@ if TYPE_CHECKING:
         data: DataType
         json: JsonType
 
+    class QueryKwargs(BaseRequestKwargs, total=False):
+        """kwargs for query()."""
+
+        params: ParamsType
+        data: DataType
+        json: JsonType
+
     class GetKwargs(BaseRequestKwargs, total=False):
         data: DataType
         json: JsonType

--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -26,7 +26,7 @@ def request(
 ) -> Response:
     """Constructs and sends a :class:`Request <Request>`.
 
-    :param method: method for the new :class:`Request` object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param method: method for the new :class:`Request` object: ``GET``, ``QUERY``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
     :param url: URL for the new :class:`Request` object.
     :param params: (optional) Dictionary, list of tuples or bytes to send
         in the query string for the :class:`Request`.
@@ -45,7 +45,7 @@ def request(
         before giving up, as a float, or a :ref:`(connect timeout, read
         timeout) <timeouts>` tuple.
     :type timeout: float or tuple
-    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/QUERY/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
     :param verify: (optional) Either a boolean, in which case it controls whether we verify
@@ -85,6 +85,29 @@ def get(
     """
 
     return request("get", url, params=params, **kwargs)
+
+
+def query(
+    url: _t.UriType,
+    params: _t.ParamsType = None,
+    data: _t.DataType = None,
+    json: _t.JsonType = None,
+    **kwargs: Unpack[_t.QueryKwargs],
+) -> Response:
+    r"""Sends a QUERY request.
+
+    :param url: URL for the new :class:`Request` object.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the :class:`Request`.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the :class:`Request`.
+    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
+    :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
+    """
+
+    return request("query", url, params=params, data=data, json=json, **kwargs)
 
 
 def options(url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:

--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -89,25 +89,17 @@ def get(
 
 def query(
     url: _t.UriType,
-    params: _t.ParamsType = None,
-    data: _t.DataType = None,
-    json: _t.JsonType = None,
     **kwargs: Unpack[_t.RequestKwargs],
 ) -> Response:
     r"""Sends a QUERY request.
 
     :param url: URL for the new :class:`Request` object.
-    :param params: (optional) Dictionary, list of tuples or bytes to send
-        in the query string for the :class:`Request`.
-    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
-        object to send in the body of the :class:`Request`.
-    :param json: (optional) A JSON serializable Python object to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
     """
 
-    return request("query", url, params=params, data=data, json=json, **kwargs)
+    return request("query", url, **kwargs)
 
 
 def options(url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:

--- a/src/requests/api.py
+++ b/src/requests/api.py
@@ -92,7 +92,7 @@ def query(
     params: _t.ParamsType = None,
     data: _t.DataType = None,
     json: _t.JsonType = None,
-    **kwargs: Unpack[_t.QueryKwargs],
+    **kwargs: Unpack[_t.RequestKwargs],
 ) -> Response:
     r"""Sends a QUERY request.
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -676,7 +676,7 @@ class Session(SessionRedirectMixin):
         params: _t.ParamsType = None,
         data: _t.DataType = None,
         json: _t.JsonType = None,
-        **kwargs: Unpack[_t.QueryKwargs],
+        **kwargs: Unpack[_t.RequestKwargs],
     ) -> Response:
         r"""Sends a QUERY request. Returns :class:`Response` object.
 

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -673,25 +673,16 @@ class Session(SessionRedirectMixin):
     def query(
         self,
         url: _t.UriType,
-        params: _t.ParamsType = None,
-        data: _t.DataType = None,
-        json: _t.JsonType = None,
         **kwargs: Unpack[_t.RequestKwargs],
     ) -> Response:
         r"""Sends a QUERY request. Returns :class:`Response` object.
 
-        :param url: URL for the new :class:`Request` object.
-        :param params: (optional) Dictionary, list of tuples or bytes to send
-            in the query string for the :class:`Request`.
-        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
-            object to send in the body of the :class:`Request`.
-        :param json: (optional) json to send in the body of the :class:`Request`.
         :param \*\*kwargs: Optional arguments that ``request`` takes.
         :rtype: requests.Response
         """
 
         kwargs.setdefault("allow_redirects", True)
-        return self.request("QUERY", url, params=params, data=data, json=json, **kwargs)
+        return self.request("QUERY", url, **kwargs)
 
     def options(self, url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:
         r"""Sends a OPTIONS request. Returns :class:`Response` object.

--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -670,6 +670,29 @@ class Session(SessionRedirectMixin):
         kwargs.setdefault("allow_redirects", True)
         return self.request("GET", url, params=params, **kwargs)
 
+    def query(
+        self,
+        url: _t.UriType,
+        params: _t.ParamsType = None,
+        data: _t.DataType = None,
+        json: _t.JsonType = None,
+        **kwargs: Unpack[_t.QueryKwargs],
+    ) -> Response:
+        r"""Sends a QUERY request. Returns :class:`Response` object.
+
+        :param url: URL for the new :class:`Request` object.
+        :param params: (optional) Dictionary, list of tuples or bytes to send
+            in the query string for the :class:`Request`.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the :class:`Request`.
+        :param json: (optional) json to send in the body of the :class:`Request`.
+        :param \*\*kwargs: Optional arguments that ``request`` takes.
+        :rtype: requests.Response
+        """
+
+        kwargs.setdefault("allow_redirects", True)
+        return self.request("QUERY", url, params=params, data=data, json=json, **kwargs)
+
     def options(self, url: _t.UriType, **kwargs: Unpack[_t.RequestKwargs]) -> Response:
         r"""Sends a OPTIONS request. Returns :class:`Response` object.
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -87,14 +87,50 @@ class TestRequests:
     def test_entry_points(self):
         requests.session
         requests.session().get
+        requests.session().query
         requests.session().head
         requests.get
+        requests.query
         requests.head
         requests.put
         requests.patch
         requests.post
         # Not really an entry point, but people rely on it.
         from requests.packages.urllib3.poolmanager import PoolManager  # noqa:F401
+
+    def test_query_method_dispatch(self):
+        with mock.patch("requests.api.request", return_value=mock.Mock()) as request_mock:
+            requests.query(
+                "https://example.com/search",
+                params={"q": "requests"},
+                data={"filter": "recent"},
+            )
+
+        request_mock.assert_called_once_with(
+            "query",
+            "https://example.com/search",
+            params={"q": "requests"},
+            data={"filter": "recent"},
+            json=None,
+        )
+
+    def test_session_query_method_dispatch(self):
+        session = requests.Session()
+        with mock.patch.object(session, "request", return_value=mock.Mock()) as request_mock:
+            session.query(
+                "https://example.com/search",
+                params={"q": "requests"},
+                data={"filter": "recent"},
+            )
+
+        request_mock.assert_called_once_with(
+            "QUERY",
+            "https://example.com/search",
+            params={"q": "requests"},
+            data={"filter": "recent"},
+            json=None,
+            allow_redirects=True,
+        )
 
     @pytest.mark.parametrize(
         "exception, url",

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -111,7 +111,6 @@ class TestRequests:
             "https://example.com/search",
             params={"q": "requests"},
             data={"filter": "recent"},
-            json=None,
         )
 
     def test_session_query_method_dispatch(self):
@@ -128,7 +127,6 @@ class TestRequests:
             "https://example.com/search",
             params={"q": "requests"},
             data={"filter": "recent"},
-            json=None,
             allow_redirects=True,
         )
 


### PR DESCRIPTION
This pull request adds support for the HTTP `QUERY` method to the Requests library, making it possible to send safe requests with a body—useful for complex search parameters that don't fit well in a URL. The change includes updates to the public API, session methods, documentation, and tests to ensure full support for the new method.

**New QUERY method support:**

* Added a new `query` function to `requests.api`, allowing users to send `QUERY` requests in the same way as other HTTP verbs.
* Added a `Session.query` method to the `Session` class for sending `QUERY` requests with session handling.

**API and documentation updates:**

* Updated the main API exports and `__all__` to include the new `query` function, making it available as a top-level import [[1]](diffhunk://#diff-f40e17fa6f1d6fe1bfda012d628c2e0cafabff9c4c61493829f5339b5f169bf1L171-R171) [[2]](diffhunk://#diff-f40e17fa6f1d6fe1bfda012d628c2e0cafabff9c4c61493829f5339b5f169bf1R211).
* Updated docstrings and documentation (`api.rst`) to describe the `QUERY` method, its use cases, and its parameters [[1]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R134-R149) [[2]](diffhunk://#diff-37be5c9092fb8389471f3411bdf68f1bb6222d8480d15867579d3ae880f19968L29-R29) [[3]](diffhunk://#diff-37be5c9092fb8389471f3411bdf68f1bb6222d8480d15867579d3ae880f19968L48-R48).

**Testing:**

* Added tests to ensure that both `requests.query` and `Session.query` correctly dispatch to the underlying request machinery, and included them in entry point tests.