### PR TITLE
Fix case-insensitive JSON content type encoding

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -586,7 +586,7 @@ def get_encoding_from_headers(headers: CaseInsensitiveDict[str]) -> str | None:
     if "text" in content_type:
         return "ISO-8859-1"
 
-    if "application/json" in content_type:
+    if "application/json" in content_type.lower():
         # Assume UTF-8 based on RFC 4627: https://www.ietf.org/rfc/rfc4627.txt since the charset was unset
         return "utf-8"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -644,6 +644,7 @@ def test__parse_content_type_header(value, expected):
             CaseInsensitiveDict({"content-type": "application/json; charset=utf-8"}),
             "utf-8",
         ),
+        (CaseInsensitiveDict({"content-type": "Application/JSON"}), "utf-8"),
         (CaseInsensitiveDict({"content-type": "text/plain"}), "ISO-8859-1"),
         (
             CaseInsensitiveDict({"content-type": "text/html; charset"}),


### PR DESCRIPTION
## Summary

Recognize the `application/json` media type case-insensitively when choosing the default response encoding.

`Application/JSON` is a valid spelling of the media type, but previously did not receive the same UTF-8 fallback as lowercase `application/json` when no charset was provided.

## Test plan

- Added a regression case for `Application/JSON`.
- `pytest tests/test_utils.py -q` → 217 passed, 13 skipped.

Explicit `charset` values continue to take precedence.