### PR TITLE
Fix #7564: raise FileNotFoundError for missing TLS material

### DIFF
--- a/src/requests/adapters.py
+++ b/src/requests/adapters.py
@@ -8,6 +8,7 @@ and maintain connections.
 
 from __future__ import annotations
 
+import errno
 import os.path
 import socket  # noqa: F401
 import typing
@@ -329,9 +330,10 @@ class HTTPAdapter(BaseAdapter):
                 cert_loc = DEFAULT_CA_BUNDLE_PATH
 
             if not cert_loc or not os.path.exists(cert_loc):
-                raise OSError(
-                    f"Could not find a suitable TLS CA certificate bundle, "
-                    f"invalid path: {cert_loc}"
+                raise FileNotFoundError(
+                    errno.ENOENT,
+                    "Could not find a suitable TLS CA certificate bundle, invalid path",
+                    cert_loc
                 )
 
             conn.cert_reqs = "CERT_REQUIRED"
@@ -353,13 +355,16 @@ class HTTPAdapter(BaseAdapter):
                 conn.cert_file = cert
                 conn.key_file = None
             if conn.cert_file and not os.path.exists(conn.cert_file):
-                raise OSError(
-                    f"Could not find the TLS certificate file, "
-                    f"invalid path: {conn.cert_file}"
+                raise FileNotFoundError(
+                    errno.ENOENT,
+                    "Could not find the TLS certificate file, invalid path",
+                    conn.cert_file
                 )
             if conn.key_file and not os.path.exists(conn.key_file):
-                raise OSError(
-                    f"Could not find the TLS key file, invalid path: {conn.key_file}"
+                raise FileNotFoundError(
+                    errno.ENOENT,
+                    "Could not find the TLS key file, invalid path",
+                    conn.key_file
                 )
 
     def build_response(self, req: PreparedRequest, resp: Any) -> Response:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -972,7 +972,7 @@ class TestRequests:
             requests.get(httpbin_secure(), verify=INVALID_PATH)
         assert (
             str(e.value)
-            == f"Could not find a suitable TLS CA certificate bundle, invalid path: {INVALID_PATH}"
+            == f"[Errno 2] Could not find a suitable TLS CA certificate bundle, invalid path: '{INVALID_PATH}'"
         )
 
     def test_invalid_ssl_certificate_files(self, httpbin_secure):
@@ -981,13 +981,13 @@ class TestRequests:
             requests.get(httpbin_secure(), cert=INVALID_PATH)
         assert (
             str(e.value)
-            == f"Could not find the TLS certificate file, invalid path: {INVALID_PATH}"
+            == f"[Errno 2] Could not find the TLS certificate file, invalid path: '{INVALID_PATH}'"
         )
 
         with pytest.raises(IOError) as e:
             requests.get(httpbin_secure(), cert=(".", INVALID_PATH))
         assert str(e.value) == (
-            f"Could not find the TLS key file, invalid path: {INVALID_PATH}"
+            f"[Errno 2] Could not find the TLS key file, invalid path: '{INVALID_PATH}'"
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #7564 by replacing generic OSError with FileNotFoundError for missing TLS materials (certificates and CA bundles).