### PR TITLE
refactor: use list() instead of list comprehension

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -802,7 +802,7 @@ class Session(SessionRedirectMixin):
         if allow_redirects:
             # Redirect resolving generator.
             gen = self.resolve_redirects(r, request, **kwargs)
-            history = [resp for resp in gen]
+            history = list(gen)
         else:
             history = []
 


### PR DESCRIPTION
## Summary

Replace the list comprehension used to consume a generator with `list(gen)`.

This change preserves the existing behavior while using the idiomatic way to materialize a generator into a list. No functional changes are intended.