### PR TITLE
Response.content retains and re-raises errors from a broken stream

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,9 @@ Release History
 dev
 ---
 
-- \[Short description of non-trivial change.\]
+- Accessing `Response.content` again after it raised an error (e.g.
+  `ChunkedEncodingError` from an incomplete chunked read) now re-raises
+  that error instead of silently returning empty content. (#4965)
 
 
 2.34.2 (2026-05-14)

--- a/src/requests/models.py
+++ b/src/requests/models.py
@@ -736,6 +736,7 @@ class Response:
 
     _content: bytes | Literal[False] | None
     _content_consumed: bool
+    _content_error: BaseException | None
     _next: PreparedRequest | None
     status_code: int
     headers: CaseInsensitiveDict[str]
@@ -765,6 +766,7 @@ class Response:
     def __init__(self) -> None:
         self._content = False
         self._content_consumed = False
+        self._content_error = None
         self._next = None
 
         #: Integer Code of responded HTTP Status, e.g. 404 or 200.
@@ -1035,6 +1037,13 @@ class Response:
     def content(self) -> bytes:
         """Content of the response, in bytes."""
 
+        if self._content_error is not None:
+            # A previous attempt to read the content raised an error.
+            # The underlying stream is now in an unknown/exhausted
+            # state, so silently returning empty content here would be
+            # misleading. Re-raise the original error instead.
+            raise self._content_error
+
         if self._content is False:
             # Read the contents.
             if self._content_consumed:
@@ -1043,7 +1052,14 @@ class Response:
             if self.status_code == 0 or self.raw is None:
                 self._content = None
             else:
-                self._content = b"".join(self.iter_content(CONTENT_CHUNK_SIZE)) or b""
+                try:
+                    self._content = (
+                        b"".join(self.iter_content(CONTENT_CHUNK_SIZE)) or b""
+                    )
+                except BaseException as e:
+                    self._content_consumed = True
+                    self._content_error = e
+                    raise
 
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2248,6 +2248,47 @@ class TestRequests:
         resp.close()
         assert resp.raw.closed
 
+    def test_response_content_retains_error(self):
+        """Accessing .content a second time after a streaming error must
+        re-raise, not silently return empty content.
+
+        Regression test for
+        https://github.com/psf/requests/issues/4965
+        """
+        from urllib3.exceptions import ProtocolError
+
+        class FakeRaw:
+            """Simulates urllib3's HTTPResponse.stream() failing partway
+            through, e.g. due to an incomplete chunked response. A
+            second call to .stream() simulates the now-dead connection
+            simply yielding no further data, without raising again --
+            this is what happens with a real urllib3 connection, and is
+            what caused .content to silently return b'' previously."""
+
+            def __init__(self):
+                self._called = False
+
+            def stream(self, chunk_size, decode_content=True):
+                if not self._called:
+                    self._called = True
+                    yield b"partial data"
+                    raise ProtocolError(
+                        "Connection broken: incomplete chunked read"
+                    )
+                return
+                yield  # pragma: no cover - makes this a generator function
+
+        r = requests.Response()
+        r.status_code = 200
+        r.raw = FakeRaw()
+
+        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+            r.content
+
+        # Previously, this silently returned b"" instead of raising.
+        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+            r.content
+
     def test_empty_stream_with_auth_does_not_set_content_length_header(self, httpbin):
         """Ensure that a byte stream with size 0 will not set both a Content-Length
         and Transfer-Encoding header.


### PR DESCRIPTION
Fixes #4965.

Previously, if reading `response.content` raised an exception (e.g. `ChunkedEncodingError` from an incomplete chunked response), the exception propagated on the first access, but `_content` stayed at its initial sentinel value (`False`) and `_content_consumed` stayed `False`. A second access to `.content` would then attempt to re-read the underlying stream. Since the connection is often already dead after the first failure, this second attempt silently "succeeded" with no data, so `.content` returned `b''` instead of raising -- masking the original error entirely, as described in the issue.

**Fix**: add a `_content_error` attribute that stores the exception raised while reading content. If set, `.content` re-raises it on every subsequent access instead of attempting (and silently succeeding at) reading an already-broken stream again.

**Verification**: added a regression test using a stateful fake `raw` object that faithfully reproduces the real urllib3 behavior being worked around -- raises once on the first `.stream()` call, then yields no further data (no error) on a second call, simulating a dead connection. I confirmed the test fails without the fix (second access returns `b''` instead of raising) and passes with it.

Ran the existing non-network-dependent test suite; results are identical to a clean checkout of `main` aside from the one new passing test (pre-existing `httpbin` fixture and network-dependent failures/errors in this sandbox are present on a clean `main` checkout too, unrelated to this change).