### PR TITLE
fix: honor ports in IPv4 no_proxy entries

### DIFF
--- a/src/requests/utils.py
+++ b/src/requests/utils.py
@@ -837,11 +837,15 @@ def should_bypass_proxies(url: str, no_proxy: str | None) -> bool:
         no_proxy_hosts = (host for host in no_proxy.replace(" ", "").split(",") if host)
 
         if is_ipv4_address(hostname):
+            host_with_port = hostname
+            if parsed.port:
+                host_with_port += f":{parsed.port}"
+
             for proxy_ip in no_proxy_hosts:
                 if is_valid_cidr(proxy_ip):
                     if address_in_network(hostname, proxy_ip):
                         return True
-                elif hostname == proxy_ip:
+                elif hostname == proxy_ip or host_with_port == proxy_ip:
                     # If no_proxy ip was defined in plain IP notation instead of cidr notation &
                     # matches the IP of the index
                     return True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -845,6 +845,17 @@ def test_should_bypass_proxies_no_proxy(url, expected, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "url, no_proxy, expected",
+    (
+        ("http://192.168.0.1:5000/", "192.168.0.1:5000", True),
+        ("http://192.168.0.1:5001/", "192.168.0.1:5000", False),
+    ),
+)
+def test_should_bypass_proxies_ipv4_port(url, no_proxy, expected):
+    assert should_bypass_proxies(url, no_proxy=no_proxy) == expected
+
+
+@pytest.mark.parametrize(
     "url, expected",
     (
         ("http://localhost/", True),


### PR DESCRIPTION
## Summary

- Honor `host:port` entries for IPv4 addresses in `no_proxy`.
- Preserve existing matching for plain IPv4 addresses and CIDR ranges.
- Add regression tests for matching and non-matching ports.

## Problem

`should_bypass_proxies` already matches `hostname:port` entries for domain names, but the IPv4 branch only compares the hostname. As a result, an entry such as `192.168.0.1:5000` does not bypass the proxy for `http://192.168.0.1:5000/`.

This can send requests to a local or internal IPv4 endpoint through a proxy even when the user explicitly excluded that host and port in `NO_PROXY` or `no_proxy`.

## Changes

- Build the request's IPv4 `hostname:port` value when a port is present.
- Match both the plain IPv4 address and the address with its port.
- Add tests showing that the configured port bypasses the proxy while a different port does not.

## Testing

- `python -m pytest tests/test_utils.py -q`
- Result: `230 passed, 1 skipped`
