### PR TITLE
Ignore None request cookies

### DIFF
--- a/src/requests/sessions.py
+++ b/src/requests/sessions.py
@@ -26,6 +26,7 @@ from .cookies import (
     cookiejar_from_dict,
     extract_cookies_to_jar,
     merge_cookies,
+    remove_cookie_by_name,
 )
 from .exceptions import (
     ChunkedEncodingError,
@@ -522,6 +523,11 @@ class Session(SessionRedirectMixin):
         method = cast(str, request.method)
 
         cookies = request.cookies or {}
+        cookies_to_remove = []
+        if isinstance(cookies, Mapping):
+            cookies_to_remove = [
+                name for name, value in cookies.items() if value is None
+            ]
 
         # Bootstrap CookieJar.
         if not isinstance(cookies, cookielib.CookieJar):
@@ -531,6 +537,8 @@ class Session(SessionRedirectMixin):
         merged_cookies = merge_cookies(
             merge_cookies(RequestsCookieJar(), self.cookies), cookies
         )
+        for cookie_name in cookies_to_remove:
+            remove_cookie_by_name(merged_cookies, cookie_name)
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -422,6 +422,18 @@ class TestRequests:
         # Session cookie should not be modified
         assert s.cookies["foo"] == "bar"
 
+    def test_request_cookie_none_removes_session_cookie(self):
+        s = requests.session()
+        s.cookies["foo"] = "bar"
+
+        req = requests.Request(
+            "GET", "http://example.com", cookies={"foo": None, "baz": "qux"}
+        )
+        prep = s.prepare_request(req)
+
+        assert prep.headers["Cookie"] == "baz=qux"
+        assert s.cookies["foo"] == "bar"
+
     def test_request_cookies_not_persisted(self, httpbin):
         s = requests.session()
         s.get(httpbin("cookies"), cookies={"foo": "baz"})


### PR DESCRIPTION
## Summary

- Treat method-level cookies set to `None` as per-request removals of matching session cookies.
- Prevent `None` cookie values from producing malformed Cookie headers such as `foo; baz=qux`.
- Add a regression test covering the session-cookie override behavior.

Closes #2716.

## Testing

- `.venv/bin/python -m pytest tests/test_requests.py::TestRequests::test_request_cookie_none_removes_session_cookie -q`
- `.venv/bin/python -m pytest tests/test_requests.py::TestRequests::test_request_cookie_overrides_session_cookie tests/test_requests.py::TestRequests::test_request_cookie_none_removes_session_cookie tests/test_requests.py::TestRequests::test_request_cookies_not_persisted -q`
- `.venv/bin/python -m compileall -q src/requests/sessions.py tests/test_requests.py`