### PR TITLE
Update lock-issues.yml to latest dependencies

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'psf'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
             issue-lock-inactive-days: 90
             pr-lock-inactive-days: 90


### PR DESCRIPTION
GitHub has been rolling out longer tokens and it seems like we finally got them recently. The lock issues action is failing because it has unnecessary validation on the token length that's been removed in 6.0.2 (see dessant/lock-threads#55).